### PR TITLE
cleanup: Change home page column ordering and version labels

### DIFF
--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -5,7 +5,6 @@ import { path } from "../utils/api.ts";
 import type { Package, PackageVersion, Stats } from "../utils/api_types.ts";
 import type { PanelEntry } from "../components/ListPanel.tsx";
 import { ListPanel } from "../components/ListPanel.tsx";
-import twas from "$twas";
 import { Head } from "$fresh/runtime.ts";
 import { ComponentChildren } from "preact";
 
@@ -23,14 +22,14 @@ export default function Home({ data }: PageProps<Data>) {
       </Head>
 
       <div class="grid grid-cols-1 gap-8 lg:grid-cols-3 md:gap-14">
-        <ListPanel title="New Packages">
-          {data.stats.newest.map(PackageToPanelEntry)}
+        <ListPanel title="Featured Packages">
+          {data.stats.featured.map(PackageToPanelEntry)}
         </ListPanel>
         <ListPanel title="Recent updates">
           {data.stats.updated.map(PackageVersionToPanelEntry)}
         </ListPanel>
-        <ListPanel title="Featured Packages">
-          {data.stats.featured.map(PackageToPanelEntryNoLabel)}
+        <ListPanel title="New Packages">
+          {data.stats.newest.map(PackageToPanelEntry)}
         </ListPanel>
       </div>
 
@@ -183,16 +182,6 @@ function BenefitText({ children }: { children: ComponentChildren }) {
 }
 
 function PackageToPanelEntry(
-  entry: Package,
-): PanelEntry {
-  return {
-    value: `@${entry.scope}/${entry.name}`,
-    href: `/@${entry.scope}/${entry.name}`,
-    label: twas(new Date(entry.createdAt)),
-  };
-}
-
-function PackageToPanelEntryNoLabel(
   entry: Package,
 ): PanelEntry {
   return {


### PR DESCRIPTION
Changes ordering of the columns on the home page:
- featured (no version)
- recent (version)
- new package (no version)


<img width="1359" alt="Screenshot 2024-02-28 at 15 46 41" src="https://github.com/jsr-io/jsr/assets/13602871/1576511e-430c-4b4f-bc49-e02f06a16150">
