### PR TITLE
feat: disable waitlist with env var

### DIFF
--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -89,8 +89,10 @@ const waitlist: MiddlewareHandler<State> = async (req, ctx) => {
       url.pathname.startsWith("/badges/") ||
       url.pathname.startsWith("/login"));
   if (interactive) {
+    if (Deno.env.get("SKIP_WAITLIST") === "1") {
+      return await ctx.next();
+    }
     let isWaitlisted = false;
-
     const token = ctx.state.api.token();
     if (token) {
       if (tokensForWaitlistAccepted.has(token)) {


### PR DESCRIPTION
You can now disable the waitlist and see how things work when you are not signed in by setting `SKIP_WAITLIST=1` env var.