### PR TITLE
chore: add waitlist bypass header

### DIFF
--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -89,7 +89,10 @@ const waitlist: MiddlewareHandler<State> = async (req, ctx) => {
       url.pathname.startsWith("/badges/") ||
       url.pathname.startsWith("/login"));
   if (interactive) {
-    if (Deno.env.get("SKIP_WAITLIST") === "1") {
+    if (
+      Deno.env.get("SKIP_WAITLIST") === "1" ||
+      req.headers.has("x-jsr-bypass-waitlist")
+    ) {
       return await ctx.next();
     }
     let isWaitlisted = false;


### PR DESCRIPTION
This commit adds a header to bypass the waitlist with. This is useful for benchmarking purposes.