### PR TITLE
fix: npm package missing non-script files

### DIFF
--- a/api/.sqlx/query-c1bd11f511ea58aba2d5b9890215776c29603714cbd867c8c62069da27e2edff.json
+++ b/api/.sqlx/query-c1bd11f511ea58aba2d5b9890215776c29603714cbd867c8c62069da27e2edff.json
@@ -1,0 +1,91 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, status as \"status: PublishingTaskStatus\", error as \"error: PublishingTaskError\", user_id, package_scope as \"package_scope: ScopeName\", package_name as \"package_name: PackageName\", package_version as \"package_version: Version\", config_file as \"config_file: PackagePath\", created_at, updated_at\n      FROM publishing_tasks\n      WHERE package_scope = $1 AND package_name = $2 AND package_version = $3 AND status = 'success'\n      LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "status: PublishingTaskStatus",
+        "type_info": {
+          "Custom": {
+            "name": "task_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "processing",
+                "processed",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "error: PublishingTaskError",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "package_scope: ScopeName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "package_name: PackageName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "package_version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "config_file: PackagePath",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c1bd11f511ea58aba2d5b9890215776c29603714cbd867c8c62069da27e2edff"
+}

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -1453,6 +1453,27 @@ impl Database {
     .await
   }
 
+  #[instrument(name = "Database::get_publish_task_by_package", skip(self), err)]
+  pub async fn get_publish_task_by_package(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+  ) -> Result<Option<PublishingTask>> {
+    sqlx::query_as!(
+      PublishingTask,
+      r#"SELECT id, status as "status: PublishingTaskStatus", error as "error: PublishingTaskError", user_id, package_scope as "package_scope: ScopeName", package_name as "package_name: PackageName", package_version as "package_version: Version", config_file as "config_file: PackagePath", created_at, updated_at
+      FROM publishing_tasks
+      WHERE package_scope = $1 AND package_name = $2 AND package_version = $3 AND status = 'success'
+      LIMIT 1"#,
+      scope as _,
+      name as _,
+      version as _
+    )
+    .fetch_optional(&self.pool)
+    .await
+  }
+
   #[instrument(name = "Database::list_package_files", skip(self), err)]
   pub async fn list_package_files(
     &self,

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -25,7 +25,7 @@ pub use self::tarball::NpmTarballOptions;
 pub use self::types::NpmMappedJsrPackageName;
 use self::types::NpmVersionInfo;
 
-pub const NPM_TARBALL_REVISION: u32 = 5;
+pub const NPM_TARBALL_REVISION: u32 = 6;
 
 pub async fn generate_npm_version_manifest<'a>(
   db: &Database,

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -1,12 +1,10 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::collections::HashSet;
 
 use anyhow::Context;
 use base64::Engine;
 use deno_graph::ModuleGraph;
-use deno_graph::ModuleSpecifier;
 use deno_graph::ParsedSourceStore;
 use deno_semver::package::PackageReqReference;
 use indexmap::IndexMap;

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -150,13 +150,6 @@ pub async fn npm_tarball_build_handler(
       }
     }
 
-    // let files: HashMap<_> = db
-    //   .list_package_files(&job.scope, &job.name, &job.version)
-    //   .await?
-    //   .into_iter()
-    //   .map(|f| (f.path, f.))
-    //   .collect();
-
     let dependencies = dependencies
       .into_iter()
       .map(|dep| {

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -140,15 +140,12 @@ pub async fn npm_tarball_build_handler(
           path
         };
 
-        match header.entry_type() {
-          EntryType::Regular => {
-            let path = PackagePath::new(path.clone()).unwrap();
+        if header.entry_type() == EntryType::Regular {
+          let path = PackagePath::new(path.clone()).unwrap();
 
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).await?;
-            files.insert(path, bytes);
-          }
-          _ => {}
+          let mut bytes = Vec::new();
+          entry.read_to_end(&mut bytes).await?;
+          files.insert(path, bytes);
         }
       }
     }


### PR DESCRIPTION
This PR addresses the issue that npm tarballs only contain the files discovered by `deno_graph`, instead of all files that were part of the jsr package tarball. So we'll keep track of which files we already processed from the tarball and insert the remaining ones.