### PR TITLE
fix: improve package score page

### DIFF
--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -340,7 +340,7 @@ pub struct ApiPackageScore {
 }
 
 impl ApiPackageScore {
-  pub const MAX_SCORE: u32 = 18;
+  pub const MAX_SCORE: u32 = 17;
 
   pub fn score_percentage(&self) -> u32 {
     (self.total * 100) / Self::MAX_SCORE
@@ -363,7 +363,9 @@ impl From<(&PackageVersionMeta, &Package)> for ApiPackageScore {
       score += 1;
     }
 
-    score += (meta.percentage_documented_symbols * 5.0).floor() as u32;
+    // You only need to document 80% of your symbols to get all the points.
+    score += ((meta.percentage_documented_symbols + 0.2).min(1.0) * 5.0).floor()
+      as u32;
 
     if meta.all_fast_check {
       score += 5;

--- a/frontend/docs/toc.ts
+++ b/frontend/docs/toc.ts
@@ -24,6 +24,11 @@ export default [
     group: "Guide",
   },
   {
+    title: "Writing documentation",
+    id: "writing-docs",
+    group: "Guide",
+  },
+  {
     title: "Troubleshooting",
     id: "troubleshooting",
     group: "Guide",

--- a/frontend/docs/writing-docs.md
+++ b/frontend/docs/writing-docs.md
@@ -1,1 +1,163 @@
-TODO: writing docs
+---
+description: This guide explains how to write documentation for JSR packages.
+---
+
+Writing documentation is vital for the success of a package. JSR makes it very
+easy for package authors to have great documentation, because it generates
+documentation based on the JSDoc comments in the package source code.
+
+This generated documentation is displayed on the package page. This
+documentation will also be shown to users in their editor in form of completions
+and hover descriptions.
+
+There are two important pieces to documentation:
+
+- **symbol documentation**: this is the documentation for each individual
+  function, interface, constant, or class that a package exports
+- **module documentation**: this is the documentation for each exported module
+  of the package - it acts as an overview or summary for all symbols in the
+  module
+
+## Symbol documentation
+
+To add documentation for a symbol, add a JSDoc comment above the symbol:
+
+```diff
++ /** This function adds the two passed numbers together. */
+  export function add(a: number, b: number): number {
+    return a + b;
+  }
+```
+
+The comment can also be a multi-line comment:
+
+```diff
++ /**
++  * This function takes two numbers as input, and then adds these numbers using
++  * floating point math.
++  */
+  export function add(a: number, b: number): number {
+    return a + b;
+  }
+```
+
+For functions, documentation can be added to specific parameters or the return
+type:
+
+```diff
+  /**
+   * Search the database with the given query.
+   *
++  * @param query This is the query to search with. It should be less than 50 chars to ensure good performance.
++  * @param limit The number of items to return. If unspecified, defaults to 20.
++  * @returns The array of matched items.
+   */
+  export function search(query: string, limit: number = 20): string[];
+```
+
+For more complex symbols, it is often good to include an example demonstrating
+how to use the function:
+
+````diff
+  /**
+   * Search the database with the given query.
+   *
++  * ```ts
++  * search("Alan") // ["Alan Turing", "Alan Kay", ...]
++  * ```
+   */
+  export function search(query: string, limit: number = 20): string[];
+````
+
+Interfaces can also be annotated with JSDoc. Their properties and methods can
+also be annotated:
+
+```ts
+/** The options bag to pass to the {@link search} method. */
+export interface SearchOptions {
+  /** The maximum number of items to return from the search. Defaults to 50 if
+   * unspecified. */
+  limit?: number;
+  /** Skip the given number of items. This is helpful to implement pagination.
+   * Defaults to 0 (do not skip) if not specified. */
+  skip?: number;
+
+  /** The function to call if the {@link search} function needs to show warnings
+   * to the user. If not specified, warnings will be silently swallowed. */
+  reportWarning?(message: string): void;
+}
+```
+
+> As seen above, `{@link <ident>}` can be used to link between symbols in JSDoc.
+> These will become clickable links in the generated documentation.
+
+Classes can be similarly annotated to interfaces and functions:
+
+```ts
+/**
+ * A class to represent a person.
+ */
+export class Person {
+  /** The name of the person. */
+  name: string;
+  /** The age of the person. */
+  age: number;
+
+  /**
+   * Create a new person with the given name and age.
+   * @param name The name of the person.
+   * @param age The age of the person. Must be non-negative.
+   */
+  constructor(name: string, age: number) {
+    if (age < 0) {
+      throw new Error("Age cannot be negative");
+    }
+    this.name = name;
+    this.age = age;
+  }
+
+  /** Print a greeting to the console. */
+  greet() {
+    console.log(
+      `Hello, my name is ${this.name} and I am ${this.age} years old.`,
+    );
+  }
+}
+```
+
+## Module documentation
+
+Not just symbols can be documented. Modules can also be documented. This is
+useful to give an overview of the module and its exported symbols.
+
+To document a module, add a JSDoc comment at the top of the module file, and
+include the `@module` tag anywhere in the comment:
+
+```diff
++ /**
++  * This module contains functions to search the database.
++  * @module
++  */
+  
+  /** The options bag to pass to the {@link search} method. */
+  export interface SearchOptions {}
+  
+  /** Search the database with the given query. */
+  export function search(query: string, options?: SearchOptions): string[];
+```
+
+You can also include examples in module documentation:
+
+````diff
+  /**
+   * @module
+   *
+   * This module contains functions to search the database.
+   *
++  * ```ts
++  * import { search } from "@luca/search";
++  *
++  * search("Alan") // ["Alan Turing", "Alan Kay", ...]
++  * ```
+   */
+````

--- a/frontend/routes/docs/[...id].tsx
+++ b/frontend/routes/docs/[...id].tsx
@@ -49,7 +49,7 @@ export default function PackagePage({ data }: PageProps<Data, State>) {
                       class={`${
                         id === data.id
                           ? "px-4 text-cyan-700 border-l-4 border-cyan-400 bg-cyan-100"
-                          : "px-5 "
+                          : "pl-5 pr-4"
                       } py-1.5 block leading-5 hover:text-gray-600 hover:underline`}
                     >
                       {title}

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -1,4 +1,5 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
+import { ComponentChildren } from "preact";
 import { Handlers, PageProps, RouteConfig } from "$fresh/server.ts";
 import type {
   Package,
@@ -21,7 +22,7 @@ interface Data {
   member: ScopeMember | null;
 }
 
-export const MAX_SCORE = 18;
+export const MAX_SCORE = 17;
 
 export default function Score(
   { data, params, state }: PageProps<Data, State>,
@@ -78,47 +79,89 @@ export default function Score(
           </div>
         </div>
 
-        <ul class="flex flex-col gap-y-5 md:col-span-2 md:mr-auto">
+        <ul class="flex flex-col divide-jsr-cyan-100 divide-y-1 md:col-span-2 w-full">
           <ScoreItem
             value={data.score.hasReadme}
             scoreValue={2}
-            explanation="Has a readme or module doc"
-          />
+            title="Has a readme or module doc"
+          >
+            The package should have a README.md in the root of the repository or
+            a{" "}
+            <a class="link" href="/docs/writing-docs#module-documentation">
+              module doc
+            </a>{" "}
+            in the main entrypoint of the package.
+          </ScoreItem>
           <ScoreItem
             value={data.score.hasReadmeExamples}
             scoreValue={1}
-            explanation="Has examples in the readme or module doc"
-          />
+            title="Has examples in the readme or module doc"
+          >
+            The README or{" "}
+            <a class="link" href="/docs/writing-docs#module-documentation">
+              module doc
+            </a>{" "}
+            of the main entrypoint should have an example of how to use the
+            package, in the form of a code block.
+          </ScoreItem>
           <ScoreItem
             value={data.score.allEntrypointsDocs}
             scoreValue={1}
-            explanation="Has module docs in all entrypoints"
-          />
+            title="Has module docs in all entrypoints"
+          >
+            Every entrypoint of the package should have a{" "}
+            <a class="link" href="/docs/writing-docs#module-documentation">
+              module doc
+            </a>{" "}
+            summarizing what is defined in that module.
+          </ScoreItem>
           <ScoreItem
-            value={data.score.percentageDocumentedSymbols}
+            value={Math.min(1, data.score.percentageDocumentedSymbols + 0.2)}
             scoreValue={5}
-            explanation="Has docs in all symbols"
-          />
+            title="Has docs for most symbols"
+          >
+            At least 80% of the packages' symbols should have{" "}
+            <a class="link" href="/docs/writing-docs#symbol-documentation">
+              symbol documentation
+            </a>. Currently{" "}
+            {(data.score.percentageDocumentedSymbols * 100).toFixed(0)}% of
+            symbols are documented.
+          </ScoreItem>
           <ScoreItem
             value={data.score.allFastCheck}
             scoreValue={5}
-            explanation="All entrypoints are fast-check compatible"
-          />
+            title="No slow types are used"
+          >
+            This package uses no{" "}
+            <a class="link" href="/docs/about-slow-types">
+              slow types
+            </a>.
+          </ScoreItem>
           <ScoreItem
             value={data.score.hasDescription}
             scoreValue={1}
-            explanation="Has a description"
-          />
+            title="Has a description"
+          >
+            The package has a description set in the package settings to help
+            users find this package via search.
+          </ScoreItem>
           <ScoreItem
             value={data.score.atLeastOneRuntimeCompatible}
             scoreValue={1}
-            explanation="At least one runtime is marked as compatible"
-          />
+            title="At least one runtime is marked as compatible"
+          >
+            This package marks at least one runtime as "compatible" in the
+            package settings to aid users in understanding where they can use
+            this package.
+          </ScoreItem>
           <ScoreItem
             value={data.score.multipleRuntimesCompatible}
             scoreValue={1}
-            explanation="At least two runtimes are marked as compatible"
-          />
+            title="At least two runtimes are marked as compatible"
+          >
+            This package is compatible with more than one runtime, and is marked
+            as such in the package settings.
+          </ScoreItem>
         </ul>
       </div>
     </div>
@@ -126,7 +169,12 @@ export default function Score(
 }
 
 function ScoreItem(
-  props: { explanation: string; value: boolean | number; scoreValue: number },
+  props: {
+    title: string;
+    children: ComponentChildren;
+    value: boolean | number;
+    scoreValue: number;
+  },
 ) {
   let status: "complete" | "partial" | "missing";
   if (typeof props.value === "boolean") {
@@ -142,14 +190,17 @@ function ScoreItem(
   }
 
   return (
-    <li class="grid grid-cols-[auto_1fr_auto] gap-x-3 items-start border-b-1.5 border-jsr-cyan-100 pb-0.5">
+    <li class="grid grid-cols-[auto_1fr_auto] gap-x-3 py-1.5 items-start">
       {status === "complete"
         ? <Check class="size-6 stroke-green-500 stroke-2 -mt-px" />
         : (status === "partial"
           ? <ErrorIcon class="size-6 stroke-yellow-500 stroke-2 -mt-px" />
           : <Cross class="size-6 stroke-red-500 stroke-2 -mt-px" />)}
 
-      <p class="leading-tight">{props.explanation}</p>
+      <div class="max-w-xl pr-2">
+        <p class="leading-tight">{props.title}</p>
+        <p class="text-gray-500 text-sm">{props.children}</p>
+      </div>
 
       <div class="text-sm text-gray-400 pt-[0.2em]">
         {typeof props.value === "number"


### PR DESCRIPTION
Firstly, this fixes the algorithm to actually let you get to 100%.

Then it fixes the calculation for the symbol docs to only require 80% of symbols to be documented.

Then it adds descriptions to the scores + a docs page for writing documentation.

<img width="1439" alt="image" src="https://github.com/jsr-io/jsr/assets/7829205/74760a59-7b5f-4d50-b652-4b7029f87ea6">
