### PR TITLE
feat: add cache headers to API

### DIFF
--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -29,6 +29,7 @@ use self::scope::scope_router;
 use self::users::users_router;
 
 use crate::util;
+use crate::util::CacheDuration;
 
 pub fn api_router() -> Router<Body, ApiError> {
   Router::builder()
@@ -41,7 +42,10 @@ pub fn api_router() -> Router<Body, ApiError> {
     .scope("/authorizations", authorization_router())
     .scope("/publishing_tasks", publishing_task_router())
     .get("/packages", util::json(global_list_handler))
-    .get("/stats", util::json(global_stats_handler))
+    .get(
+      "/stats",
+      util::cache(CacheDuration::ONE_MINUTE, util::json(global_stats_handler)),
+    )
     .get(
       // todo: remove once CLI uses the new endpoint
       "/publish_status/:publishing_task_id",

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -60,6 +60,7 @@ use crate::util::decode_json;
 use crate::util::pagination;
 use crate::util::search;
 use crate::util::ApiResult;
+use crate::util::CacheDuration;
 use crate::util::RequestIdExt;
 use crate::util::VersionOrLatest;
 use crate::NpmUrl;
@@ -96,11 +97,14 @@ pub fn package_router() -> Router<Body, ApiError> {
     .get("/:package", util::json(get_handler))
     .patch("/:package", util::auth(util::json(update_handler)))
     .delete("/:package", util::auth(delete_handler))
-    .get("/:package/versions", util::json(list_versions_handler))
+    .get(
+      "/:package/versions",
+      util::cache(CacheDuration::ONE_MINUTE, util::json(list_versions_handler)),
+    )
     .get("/:package/dependents", util::json(list_dependents_handler))
     .get(
       "/:package/versions/:version",
-      util::json(get_version_handler),
+      util::cache(CacheDuration::ONE_MINUTE, util::json(get_version_handler)),
     )
     .post(
       "/:package/versions/:version",
@@ -116,15 +120,18 @@ pub fn package_router() -> Router<Body, ApiError> {
     )
     .get(
       "/:package/versions/:version/docs",
-      util::json(get_docs_handler),
+      util::cache(CacheDuration::ONE_MINUTE, util::json(get_docs_handler)),
     )
     .get(
       "/:package/versions/:version/docs/search",
-      util::json(get_docs_search_handler),
+      util::cache(
+        CacheDuration::ONE_MINUTE,
+        util::json(get_docs_search_handler),
+      ),
     )
     .get(
       "/:package/versions/:version/source",
-      util::json(get_source_handler),
+      util::cache(CacheDuration::ONE_MINUTE, util::json(get_source_handler)),
     )
     .get(
       "/:package/versions/:version/dependencies",

--- a/api/src/api/scope.rs
+++ b/api/src/api/scope.rs
@@ -34,14 +34,13 @@ pub fn scope_router() -> Router<Body, ApiError> {
     .scope("/:scope/packages", package_router())
     .post("/", util::auth(util::json(create_handler)))
     .get("/:scope", util::json(get_handler))
-    .patch("/:scope", util::json(update_handler))
+    .patch("/:scope", util::auth(util::json(update_handler)))
     .delete("/:scope", util::auth(delete_handler))
     .get("/:scope/members", util::json(list_members_handler))
     .post(
       "/:scope/members",
       util::auth(util::json(invite_member_handler)),
     )
-    .get("/:scope/members/:member", util::json(get_member_handler))
     .patch(
       "/:scope/members/:member",
       util::auth(util::json(update_member_handler)),

--- a/api/src/iam.rs
+++ b/api/src/iam.rs
@@ -24,6 +24,10 @@ pub struct IamHandler<'s> {
 }
 
 impl<'s> IamHandler<'s> {
+  pub fn is_anonymous(&self) -> bool {
+    matches!(self.principal, Principal::Anonymous)
+  }
+
   pub async fn check_scope_write_access(
     &self,
     scope: &ScopeName,

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -202,7 +202,9 @@ function PackageVersionToPanelEntry(
 
 export const handler: Handlers<Data, State> = {
   async GET(_req, ctx) {
-    const statsResp = await ctx.state.api.get<Stats>(path`/stats`);
+    const statsResp = await ctx.state.api.get<Stats>(path`/stats`, undefined, {
+      anonymous: true,
+    });
     if (!statsResp.ok) throw statsResp; // gracefully handle this
     return ctx.render({ stats: statsResp.data });
   },

--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -8,7 +8,7 @@ import { Params } from "./PackageNav.tsx";
 interface DocsProps {
   docs: Docs;
   params: Params;
-  selectedVersion?: PackageVersionWithUser;
+  selectedVersion: PackageVersionWithUser;
 }
 
 export function DocsView({ docs, params, selectedVersion }: DocsProps) {
@@ -26,7 +26,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
       )}
       <div class="ddoc" dangerouslySetInnerHTML={{ __html: docs.main }} />
 
-      {selectedVersion?.rekorLogId && (
+      {selectedVersion.rekorLogId && (
         <div class="mt-4 border border-gray-400 rounded-md py-1 px-2">
           <div className="items-center">
             <span className="text-sm text-gray-600 mr-1">
@@ -77,7 +77,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
         <LocalSymbolSearch
           scope={params.scope}
           pkg={params.package}
-          version={params.version}
+          version={selectedVersion.version}
         />
         <div
           class="ddoc w-full lg:flex-1 lg:min-h-0 lg:*:!h-full"

--- a/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
+++ b/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
@@ -14,7 +14,7 @@ import { api, path } from "../../../utils/api.ts";
 export interface LocalSymbolSearchProps {
   scope: string;
   pkg: string;
-  version?: string;
+  version: string;
 }
 
 interface SearchRecord {

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -48,6 +48,7 @@ export default function File({ data, params, state }: PageProps<Data, State>) {
       <DocsView
         docs={data.docs}
         params={params as unknown as Params}
+        selectedVersion={data.selectedVersion}
       />
     </div>
   );

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -52,6 +52,7 @@ export default function Symbol(
       <DocsView
         docs={data.docs}
         params={params as unknown as Params}
+        selectedVersion={data.selectedVersion}
       />
     </div>
   );

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -42,12 +42,12 @@ export default function PackagePage(
         latestVersion={data.package.latestVersion}
       />
 
-      {data.docs
+      {data.docs && data.selectedVersion
         ? (
           <DocsView
             docs={data.docs}
             params={params as unknown as Params}
-            selectedVersion={data.selectedVersion ?? undefined}
+            selectedVersion={data.selectedVersion}
           />
         )
         : (

--- a/frontend/routes/package/symbols.tsx
+++ b/frontend/routes/package/symbols.tsx
@@ -46,6 +46,7 @@ export default function Symbols(
       <DocsView
         docs={data.docs}
         params={params as unknown as Params}
+        selectedVersion={data.selectedVersion}
       />
     </div>
   );

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -10,6 +10,7 @@ export interface APIRequest<T> {
   query?: QueryParams;
   body?: T;
   signal?: AbortSignal;
+  anonymous?: boolean;
 }
 
 export type APIResponse<T> = APIResponseOK<T> | APIResponseError;
@@ -66,6 +67,7 @@ interface APIOptions {
 
 interface RequestOptions {
   signal?: AbortSignal;
+  anonymous?: boolean;
 }
 
 export class API {
@@ -92,7 +94,13 @@ export class API {
     query?: QueryParams,
     opts?: RequestOptions,
   ): Promise<APIResponse<RespT>> {
-    return this.request({ method: "GET", path, query, signal: opts?.signal });
+    return this.request({
+      method: "GET",
+      path,
+      query,
+      signal: opts?.signal,
+      anonymous: opts?.anonymous,
+    });
   }
 
   post<RespT = unknown, ReqT = unknown>(
@@ -107,6 +115,7 @@ export class API {
       query,
       body,
       signal: opts?.signal,
+      anonymous: opts?.anonymous,
     });
   }
 
@@ -122,6 +131,7 @@ export class API {
       query,
       body,
       signal: opts?.signal,
+      anonymous: opts?.anonymous,
     });
   }
 
@@ -135,6 +145,7 @@ export class API {
       path,
       query,
       signal: opts?.signal,
+      anonymous: opts?.anonymous,
     });
   }
 
@@ -149,7 +160,7 @@ export class API {
       url.searchParams.append(key, String(value));
     }
     const headers = new Headers();
-    if (this.#token) {
+    if (this.#token && !req.anonymous) {
       headers.append("Authorization", `Bearer ${this.#token}`);
     }
     if (req.body) {

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -45,7 +45,9 @@ resource "google_compute_backend_bucket" "modules" {
   enable_cdn       = true
   compression_mode = "AUTOMATIC"
   custom_response_headers = [
-    "Content-Security-Policy: default-src 'none'; script-src 'none'; style-src 'none'; img-src 'none'; font-src 'none'; connect-src 'none'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; sandbox; form-action 'none';"
+    "Content-Security-Policy: default-src 'none'; script-src 'none'; style-src 'none'; img-src 'none'; font-src 'none'; connect-src 'none'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; sandbox; form-action 'none';",
+    "x-jsr-cache-id: {cdn_cache_id}",
+    "x-jsr-cache-status: {cdn_cache_status}",
   ]
   cdn_policy {
     cache_mode         = "USE_ORIGIN_HEADERS"
@@ -69,8 +71,11 @@ resource "google_compute_backend_bucket" "npm" {
   enable_cdn       = true
   compression_mode = "AUTOMATIC"
   custom_response_headers = [
-    "Content-Security-Policy: default-src 'none'; script-src 'none'; style-src 'none'; img-src 'none'; font-src 'none'; connect-src 'none'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; sandbox; form-action 'none';"
+    "Content-Security-Policy: default-src 'none'; script-src 'none'; style-src 'none'; img-src 'none'; font-src 'none'; connect-src 'none'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; sandbox; form-action 'none';",
+    "x-jsr-cache-id: {cdn_cache_id}",
+    "x-jsr-cache-status: {cdn_cache_status}",
   ]
+
   cdn_policy {
     cache_mode         = "USE_ORIGIN_HEADERS"
     default_ttl        = 0        # no caching unless specified by the backend

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -48,7 +48,7 @@ resource "google_cloud_run_v2_service" "registry_api" {
 
     containers {
       image = var.api_image_id
-      args  = ["--cloud_trace", "--api", "--tasks=false", "--database_pool_size=3"]
+      args  = ["--cloud_trace", "--api", "--tasks=false", "--database_pool_size=4"]
 
       dynamic "env" {
         for_each = local.api_envs
@@ -121,8 +121,8 @@ resource "google_compute_backend_service" "registry_api" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
   custom_response_headers = [
-    "x-deno-cache-id: {cdn_cache_id}",
-    "x-deno-cache-status: {cdn_cache_status}",
+    "x-jsr-cache-id: {cdn_cache_id}",
+    "x-jsr-cache-status: {cdn_cache_status}",
   ]
 
   enable_cdn = true

--- a/terraform/cloud_run_frontend.tf
+++ b/terraform/cloud_run_frontend.tf
@@ -65,8 +65,8 @@ resource "google_compute_backend_service" "registry_frontend" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
   custom_response_headers = [
-    "x-deno-cache-id: {cdn_cache_id}",
-    "x-deno-cache-status: {cdn_cache_status}",
+    "x-jsr-cache-id: {cdn_cache_id}",
+    "x-jsr-cache-status: {cdn_cache_status}",
   ]
 
   enable_cdn = true


### PR DESCRIPTION
This also updates the frontend to fetch the /stats page without auth headers, even if the user is signed in.
