### PR TITLE
chore: update deno_graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.69.5"
+version = "0.69.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49d7cfd7eb14200f2d91b9ff3330b7bd86334060367d47248871c78374a2897"
+checksum = "a9d04f8bc8d8a40369e8549d15f6b315ffe025d0048fcd3c541f90647471f670"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -77,7 +77,7 @@ deno_semver = "0.5.2"
 flate2 = "1"
 thiserror = "1"
 async-tar = "0.4.2"
-deno_graph = "0.69.5"
+deno_graph = "0.69.6"
 deno_ast = "0.34.1"
 deno_doc = { version = "0.115.0", features = ["tree-sitter"] }
 comrak = { version = "0.20.0", default-features = false }


### PR DESCRIPTION
Best to just upgrade this. It has the dynamic import fix, but I don't think that fixes the registry in any way.