### PR TITLE
fix: sidenav grows too large with long names

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -73,7 +73,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
 
   return (
     <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-      <div class="col-span-1 top-0 md:pl-0 md:pr-2 max-h-screen py-4 box-border">
+      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 box-border">
         <LocalSymbolSearch
           scope={params.scope}
           pkg={params.package}


### PR DESCRIPTION
Long symbol names were causing the sidenav to grow in a way where it would cover most of the page. this switches to a grid layout so the sidenav takes up 25% and long symbol names truncate

<img width="1235" alt="Screenshot 2024-02-29 at 3 52 14 PM" src="https://github.com/jsr-io/jsr/assets/776987/b59bc1a8-a7ef-4b8b-ad15-0d6c5975ead2">

