### PR TITLE
fix: redirect scope members to package publish page if there are no versions

### DIFF
--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -32,13 +32,20 @@ export function PackageNav(
 
   return (
     <Nav>
-      <NavItem href={versionedBase} active={currentTab === "Index"}>
-        Overview
-      </NavItem>
-      <NavItem href={`${versionedBase}/doc`} active={currentTab === "Symbols"}>
-        Symbols
-      </NavItem>
-      {latestVersion && (
+      {((canEdit && versionCount > 0) || !canEdit) && (
+        <NavItem href={versionedBase} active={currentTab === "Index"}>
+          Overview
+        </NavItem>
+      )}
+      {versionCount > 0 && (
+        <NavItem
+          href={`${versionedBase}/doc`}
+          active={currentTab === "Symbols"}
+        >
+          Symbols
+        </NavItem>
+      )}
+      {versionCount > 0 && latestVersion && (
         <NavItem
           href={`${base}/${params.version || latestVersion}`}
           active={currentTab === "Files"}

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -83,6 +83,15 @@ export const handler: Handlers<Data, State> = {
       docs,
     } = res;
 
+    if (scopeMember && pkg.latestVersion === null) {
+      return new Response(null, {
+        status: 303,
+        headers: {
+          Location: `/@${pkg.scope}/${pkg.name}/publish`,
+        },
+      });
+    }
+
     return ctx.render({
       package: pkg,
       selectedVersion,


### PR DESCRIPTION
Also disabled "Overview" and "Symbols" tabs if there are no versions published.

Closes https://github.com/jsr-io/jsr/issues/25