### PR TITLE
fix: adjust mobile header styling 

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -73,7 +73,6 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
 
   return (
     <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-
       <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 box-border">
         <LocalSymbolSearch
           scope={params.scope}


### PR DESCRIPTION
<img width="1853" alt="Screenshot 2024-02-29 at 4 53 24 PM" src="https://github.com/jsr-io/jsr/assets/776987/8f7593d9-575c-464b-a261-e1f6718a0869">

adjusting header styling in ddoc to show more document hierarchy in mobile views