### PR TITLE
fix: fix sticky nav on symbol navigation

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -73,7 +73,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
 
   return (
     <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 box-border">
+      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 lg:sticky lg:max-h-screen box-border">
         <LocalSymbolSearch
           scope={params.scope}
           pkg={params.package}


### PR DESCRIPTION
This functionality was accidentally removed when I converted the navigation to use a grid instead of flexbox. When scrolling the nav should stick so the search is still available at the top.

<img width="965" alt="Screenshot 2024-02-29 at 10 40 46 PM" src="https://github.com/jsr-io/jsr/assets/776987/40c67dc9-cf73-4e35-a35c-fe6a14b71838">
