### PR TITLE
fix: don't hit API server for /api prefixed paths

### DIFF
--- a/terraform/https.tf
+++ b/terraform/https.tf
@@ -270,13 +270,16 @@ resource "google_compute_url_map" "frontend_https" {
       priority = 2
       service  = google_compute_backend_service.registry_api.self_link
       match_rules {
-        prefix_match = "/api"
+        prefix_match = "/api/"
       }
       match_rules {
-        prefix_match = "/login"
+        full_path_match = "/login"
       }
       match_rules {
-        prefix_match = "/logout"
+        full_path_match = "/login/callback"
+      }
+      match_rules {
+        full_path_match = "/logout"
       }
     }
   }

--- a/tools/server.ts
+++ b/tools/server.ts
@@ -58,8 +58,9 @@ async function handler(req: Request): Promise<Response> {
         return res;
       }
       if (
-        url.pathname.startsWith("/api") || url.pathname.startsWith("/login") ||
-        url.pathname.startsWith("/logout")
+        url.pathname.startsWith("/api/") || url.pathname === "/login" ||
+        url.pathname === "/login/callback" ||
+        url.pathname === "/logout"
       ) {
         const apiUrl = `${API_SERVER}${url.pathname}${url.search}`;
         const apiRes = await proxy(req, apiUrl);


### PR DESCRIPTION
Fixes #135