### PR TITLE
Fix horizontal overflow for code blocks and add scrollbar colors

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -49,6 +49,7 @@
 
   :root {
     scroll-behavior: smooth;
+    scrollbar-color: theme("colors.jsr-cyan.950") theme("colors.jsr-cyan.50");
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -185,7 +186,7 @@ body .ddoc .markdown h3 {
 
 body .ddoc .markdown h4 {
   @apply mt-6 -mx-6 px-6 md:mx-0 md:px-0 font-bold md:font-medium !important;
-} 
+}
 
 body .ddoc a {
   word-wrap: break-word;
@@ -204,11 +205,11 @@ body .ddoc .markdown a:not(.no_color) {
 }
 
 body .ddoc .usage {
-  @apply bg-jsr-cyan-50 border-jsr-cyan-100 -mx-6 md:mx-0 rounded-none md:rounded-lg md:border-1.5;
+  @apply bg-jsr-cyan-50 border-y-1.5 border-jsr-cyan-100 border-x-0 -mx-6 md:mx-0 rounded-none md:rounded-lg md:border-1.5;
 }
 
 body .ddoc .usage pre.highlight {
-  @apply bg-white border-jsr-cyan-200;
+  @apply bg-white border-jsr-cyan-200 -mx-4 md:mx-0 border-x-0 md:border-1.5;
 }
 
 body .ddoc .usage nav {


### PR DESCRIPTION
Some code blocks in package docs are slightly overflowing. This fixes that, and also adds a branded color to scrollbars on some browsers/systems (mostly so that items like these code blocks, which are supposed to go to the edge of the page, go visibly to the edge of the scrollbar instead).

<img width="499" alt="image" src="https://github.com/jsr-io/jsr/assets/22334764/b87d9b1c-7659-46db-a8da-f0aab8aa577e">
