### PR TITLE
docs: correct include & exclude option

### DIFF
--- a/frontend/docs/publishing-packages.md
+++ b/frontend/docs/publishing-packages.md
@@ -258,9 +258,9 @@ equivalent to specifying a default entrypoint in the object form.
 }
 ```
 
-You can also use the `includes` and `excludes` options to include and exclude
-files during publishing. If using a `deno.json`, you can use `publish.includes`
-and `publish.excludes` to include and exclude files only for publishing, rather
+You can also use the `include` and `exclude` options to include and exclude
+files during publishing. If using a `deno.json`, you can use `publish.include`
+and `publish.exclude` to include and exclude files only for publishing, rather
 than for all Deno subcommands.
 [Learn more about ignoring files](#ignoring-files).
 


### PR DESCRIPTION
It's `include` and `exclude` instead of `includes` and `excludes`