### PR TITLE
fix: typo; Github --> GitHub

### DIFF
--- a/frontend/islands/GithubUserLink.tsx
+++ b/frontend/islands/GithubUserLink.tsx
@@ -21,5 +21,5 @@ export function GitHubUserLink({ user }: { user?: User }) {
 
   return login.value == ""
     ? <span>loading...</span>
-    : <a class="link" href={"https://github.com/" + login.value}>Github</a>;
+    : <a class="link" href={"https://github.com/" + login.value}>GitHub</a>;
 }


### PR DESCRIPTION
I stumbled across a typo for GitHub.

<img width="180" alt="Screenshot 2024-03-04 at 10 13 25" src="https://github.com/jsr-io/jsr/assets/13130705/eb851cb4-3b71-48f1-b82b-bece51f30a09">
