### PR TITLE
chore: reserve apache scope for the ASF

### DIFF
--- a/api/src/reserved_scopes.json
+++ b/api/src/reserved_scopes.json
@@ -18,6 +18,7 @@
   "antd",
   "anymatch",
   "anypromise",
+  "apache",
   "apollo",
   "apple",
   "appwrite",


### PR DESCRIPTION
I'm one of The ASF Members. Perhaps I'd start a discussion in the foundation to register a foundation-wise scope and publish Apache projects to JSR.

This file seems to reserve some well-known names to avoid branding issues. I suggest to add "apache" on the list.