### PR TITLE
fix: add vary header to cached responses

### DIFF
--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -7,6 +7,7 @@ use hyper::Body;
 use hyper::Request;
 use hyper::Response;
 use hyper::StatusCode;
+use oauth2::http::HeaderValue;
 use routerify::prelude::RequestExt;
 use routerify_query::RequestQueryExt;
 use serde::de::DeserializeOwned;
@@ -133,6 +134,14 @@ where
     async move {
       let is_anonymous = req.iam().is_anonymous();
       let mut res = handler(req).await?;
+      match res.headers_mut().entry(header::VARY) {
+        header::Entry::Occupied(mut entry) => {
+          entry.append(HeaderValue::from_name(header::AUTHORIZATION));
+        }
+        header::Entry::Vacant(entry) => {
+          entry.insert(HeaderValue::from_name(header::AUTHORIZATION));
+        }
+      }
       if is_anonymous {
         res
           .headers_mut()


### PR DESCRIPTION
Previously when a public request cached the response, even signed in users would be served this response. Now the vary header ensures that only public users will receive the cached response.