### PR TITLE
fix: allow clicking on search results again

### DIFF
--- a/frontend/islands/PackageSearch.tsx
+++ b/frontend/islands/PackageSearch.tsx
@@ -166,11 +166,11 @@ export function PackageSearch(
 
   const placeholder = `Search for packages (${macLike ? "⌘K" : "Ctrl+K"})`;
   return (
-    <div ref={ref}>
+    <div ref={ref} class="pointer-events-auto">
       <form
         action="/packages"
         method="GET"
-        class="flex w-full pointer-events-auto"
+        class="flex w-full"
         onSubmit={onSubmit}
       >
         <label htmlFor="package-search-input" class="sr-only">


### PR DESCRIPTION
The `pointer-events-auto` was one element too low in the tree.