### PR TITLE
fix: rendered view of meta.json file

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1111,7 +1111,13 @@ pub async fn get_source_handler(
   };
   let version = maybe_version.ok_or(ApiError::PackageVersionNotFound)?;
 
-  let file = if path == format!("{}_meta.json", version.version) {
+  let file = if path == "meta.json" {
+    let source_file_path = crate::gcs_paths::package_metadata(&scope, &package);
+    buckets
+      .modules_bucket
+      .download(source_file_path.into())
+      .await?
+  } else if path == format!("{}_meta.json", version.version) {
     let source_file_path =
       crate::gcs_paths::version_metadata(&scope, &package, &version.version);
     buckets

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -207,5 +207,6 @@ export const handler: Handlers<Data, State> = {
 };
 
 export const config: RouteConfig = {
-  routeOverride: "/@:scope/:package/:version((?:\\d+\\.\\d+\\.\\d+.*?)|meta\.json)/:path*",
+  routeOverride:
+    "/@:scope/:package/:version((?:\\d+\\.\\d+\\.\\d+.*?)|meta\.json)/:path*",
 };

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -170,6 +170,10 @@ export const handler: Handlers<Data, State> = {
       });
     }
     let sourcePath = "/" + (ctx.params.path ?? "");
+    if (ctx.params.version === "meta.json" && ctx.params.path === "") {
+      sourcePath = "meta.json";
+      ctx.params.version = "latest";
+    }
     if (ctx.params.version.endsWith("_meta.json") && ctx.params.path === "") {
       sourcePath = ctx.params.version;
       ctx.params.version = ctx.params.version.slice(0, -10);
@@ -203,5 +207,5 @@ export const handler: Handlers<Data, State> = {
 };
 
 export const config: RouteConfig = {
-  routeOverride: "/@:scope/:package/:version(\\d+\\.\\d+\\.\\d+.*?)/:path*",
+  routeOverride: "/@:scope/:package/:version((?:\\d+\\.\\d+\\.\\d+.*?)|meta\.json)/:path*",
 };


### PR DESCRIPTION
This page previously was a 404 for the HTML view, but a 200 when `curl`ing.

http://jsr.test/@std/expect/meta.json
