### PR TITLE
fix: respect img height in docs

### DIFF
--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -25,7 +25,8 @@
     "@orama/orama": "npm:@orama/orama@^2",
     "@oramacloud/client": "npm:@oramacloud/client@^1",
     "tailwindcss": "npm:tailwindcss@3.4",
-    "tailwindcss/": "npm:/tailwindcss@3.4/"
+    "tailwindcss/": "npm:/tailwindcss@3.4/",
+    "postcss": "npm:postcss@8.4"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "exclude": ["_fresh/", "**/_fresh/*"]

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,47 +9,8 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
-  corePlugins: {
-    preflight: false,
-  },
   plugins: [
-    // Tailwindcss applies `height: auto` for img and video tags by default,
-    // so imgs and videos with a height attribute, the most common practice
-    // to resize media in markdown, are broken because height property in CSS
-    // has a higher priority than the attribute on the DOM.
-    //
-    // see also: https://github.com/tailwindlabs/tailwindcss/pull/7742#issuecomment-1061332148
-    plugin(({ addBase }) => {
-      const preflight = postcss.parse(
-        Deno.readTextFileSync(
-          new URL(
-            "./node_modules/tailwindcss/lib/css/preflight.css",
-            import.meta.url,
-          ),
-        ),
-      );
-
-      preflight.walkRules(/^img,\s*video$/, (rule) => {
-        rule.nodes = rule.nodes.filter((node) =>
-          !(node.type === "decl" && node.prop === "height" &&
-            node.value === "auto")
-        );
-      });
-
-      preflight.append(
-        "img:not([height]):not([class]), video:not([height]):not([class]) {\n" +
-          "  height: auto;\n" +
-          "}",
-      );
-
-      addBase([
-        postcss.comment({
-          text:
-            `! tailwindcss v${tailwindPkgJson.version} | MIT License | https://tailwindcss.com`,
-        }) as unknown as CSSRuleObject,
-        ...preflight.nodes as unknown as CSSRuleObject[],
-      ]);
-    }),
+    rewritePreflight(),
   ],
   theme: {
     fontFamily: {
@@ -196,3 +157,41 @@ export default {
     },
   },
 } satisfies Config;
+
+function rewritePreflight() {
+  return plugin(({ addBase }) => {
+    const preflight = postcss.parse(
+      Deno.readTextFileSync(
+        new URL(
+          "./node_modules/tailwindcss/lib/css/preflight.css",
+          import.meta.url,
+        ),
+      ),
+    );
+
+    // Tailwindcss applies `height: auto` for img and video tags in preflight css,
+    // which disrupts the common practice of resizing medias in markdown through the height attributes,
+    // because the height property in CSS has a higher priority than the DOM attribute.
+    //
+    // This should be able to be safely removed,
+    // see: https://github.com/tailwindlabs/tailwindcss/pull/7742#issuecomment-1061332148
+    preflight.walkRules(/^img,\s*video$/, (rule) => {
+      rule.nodes = rule.nodes.filter((node) =>
+        !(node.type === "decl" && node.prop === "height" &&
+          node.value === "auto")
+      );
+    });
+
+    addBase([
+      postcss.comment({
+        text:
+          `! tailwindcss v${tailwindPkgJson.version} | MIT License | https://tailwindcss.com`,
+      }) as unknown as CSSRuleObject,
+      ...preflight.nodes as unknown as CSSRuleObject[],
+    ]);
+  }, {
+    corePlugins: {
+      preflight: false,
+    },
+  });
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -18,29 +18,34 @@ export default {
     // to resize media in markdown, are broken because height property in CSS
     // has a higher priority than the attribute on the DOM.
     //
-    // see also: https://github.com/tailwindlabs/tailwindcss/pull/7742#issuecomment-1061332148 
+    // see also: https://github.com/tailwindlabs/tailwindcss/pull/7742#issuecomment-1061332148
     plugin(({ addBase }) => {
       const preflight = postcss.parse(
         Deno.readTextFileSync(
-          new URL("./node_modules/tailwindcss/lib/css/preflight.css", import.meta.url)
+          new URL(
+            "./node_modules/tailwindcss/lib/css/preflight.css",
+            import.meta.url,
+          ),
         ),
       );
 
       preflight.walkRules(/^img,\s*video$/, (rule) => {
         rule.nodes = rule.nodes.filter((node) =>
-          !(node.type === 'decl' && node.prop === "height" && node.value === "auto")
+          !(node.type === "decl" && node.prop === "height" &&
+            node.value === "auto")
         );
       });
 
       preflight.append(
         "img:not([height]):not([class]), video:not([height]):not([class]) {\n" +
-        "  height: auto;\n" +
-        "}",
+          "  height: auto;\n" +
+          "}",
       );
 
       addBase([
         postcss.comment({
-          text: `! tailwindcss v${tailwindPkgJson.version} | MIT License | https://tailwindcss.com`,
+          text:
+            `! tailwindcss v${tailwindPkgJson.version} | MIT License | https://tailwindcss.com`,
         }) as unknown as CSSRuleObject,
         ...preflight.nodes as unknown as CSSRuleObject[],
       ]);

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -180,6 +180,10 @@ function rewritePreflight() {
         !(node.type === "decl" && node.prop === "height" &&
           node.value === "auto")
       );
+      preflight.insertAfter(
+        rule,
+        "img:not(.markdown img), video:not(.markdown video) { height: auto; }",
+      );
     });
 
     addBase([


### PR DESCRIPTION
Tailwindcss applies `height: auto` for img and video tags by default in its preflight.css, so imgs and videos with a height attribute, the most common practice to resize media in markdown, are broken because height property in CSS has a higher priority than the attribute on the DOM.

This PR reimplements the preflight core plugin for tailwindcss and modifies the preflight.css to address this issue.

fixes #120 