### PR TITLE
fix: clean up redirects around package pages

### DIFF
--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -19,10 +19,11 @@ type Tab =
   | "Settings";
 
 export function PackageNav(
-  { currentTab, params, canEdit, versionCount, latestVersion }: {
+  { currentTab, params, canPublish, canEdit, versionCount, latestVersion }: {
     currentTab: Tab;
     params: Params;
     versionCount: number;
+    canPublish: boolean;
     canEdit: boolean;
     latestVersion: string | null;
   },
@@ -37,7 +38,7 @@ export function PackageNav(
           Overview
         </NavItem>
       )}
-      {versionCount > 0 && (
+      {(latestVersion || params.version) && (
         <NavItem
           href={`${versionedBase}/doc`}
           active={currentTab === "Symbols"}
@@ -45,7 +46,7 @@ export function PackageNav(
           Symbols
         </NavItem>
       )}
-      {versionCount > 0 && latestVersion && (
+      {(latestVersion || params.version) && (
         <NavItem
           href={`${base}/${params.version || latestVersion}`}
           active={currentTab === "Files"}
@@ -61,14 +62,14 @@ export function PackageNav(
           </span>
         </span>
       </NavItem>
-      {versionCount > 0 && (
-        <NavItem
-          href={`${versionedBase}/dependencies`}
-          active={currentTab === "Dependencies"}
-        >
-          Dependencies
-        </NavItem>
-      )}
+      {(latestVersion || params.version) && (
+            <NavItem
+              href={`${versionedBase}/dependencies`}
+              active={currentTab === "Dependencies"}
+            >
+              Dependencies
+            </NavItem>
+          )}
       {versionCount > 0 && (
         <NavItem
           href={`${base}/dependents`}
@@ -85,22 +86,23 @@ export function PackageNav(
           Score
         </NavItem>
       )}
+      {canPublish &&
+        (
+          <NavItem
+            href={`${base}/publish`}
+            active={currentTab === "Publish"}
+          >
+            Publish
+          </NavItem>
+        )}
       {canEdit &&
         (
-          <>
-            <NavItem
-              href={`${base}/publish`}
-              active={currentTab === "Publish"}
-            >
-              Publish
-            </NavItem>
-            <NavItem
-              href={`${base}/settings`}
-              active={currentTab === "Settings"}
-            >
-              Settings
-            </NavItem>
-          </>
+          <NavItem
+            href={`${base}/settings`}
+            active={currentTab === "Settings"}
+          >
+            Settings
+          </NavItem>
         )}
     </Nav>
   );

--- a/frontend/routes/package/dependencies.tsx
+++ b/frontend/routes/package/dependencies.tsx
@@ -25,6 +25,7 @@ export default function Deps(
   { data, params, state, url }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   const deps: Record<string, { link: string; constraints: Set<string> }> = {};
@@ -64,6 +65,7 @@ export default function Deps(
       <PackageNav
         currentTab="Dependencies"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependents.tsx
+++ b/frontend/routes/package/dependents.tsx
@@ -24,6 +24,7 @@ export default function Dep(
   { data, params, state, url }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -45,6 +46,7 @@ export default function Dep(
       <PackageNav
         currentTab="Dependents"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -21,6 +21,7 @@ interface Data {
 
 export default function File({ data, params, state }: PageProps<Data, State>) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -46,6 +47,7 @@ export default function File({ data, params, state }: PageProps<Data, State>) {
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -23,6 +23,7 @@ export default function Symbol(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -50,6 +51,7 @@ export default function Symbol(
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -20,6 +20,7 @@ export default function PackagePage(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -43,6 +44,7 @@ export default function PackagePage(
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
@@ -58,7 +60,10 @@ export default function PackagePage(
         )
         : (
           <div class="mt-8 text-gray-500 text-center">
-            This package has not published any versions yet.
+            This package has not published{" "}
+            {data.package.versionCount > 0
+              ? "a stable release"
+              : "any versions"} yet.
           </div>
         )}
     </div>
@@ -83,7 +88,7 @@ export const handler: Handlers<Data, State> = {
       docs,
     } = res;
 
-    if (scopeMember && pkg.latestVersion === null) {
+    if (scopeMember && pkg.versionCount === 0) {
       return new Response(null, {
         status: 303,
         headers: {

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -27,6 +27,7 @@ export default function Score(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -48,135 +49,163 @@ export default function Score(
       <PackageNav
         currentTab="Score"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />
 
-      <div class="mt-8 grid items-center justify-items-center grid-cols-1 md:grid-cols-3 gap-12">
-        <div class="w-full h-full flex flex-col items-center justify-center border-1.5 border-jsr-cyan-100 rounded-lg p-8">
-          <div class="flex gap-2 items-center mb-4">
-            <img src="/logo.svg" class="w-16 select-none" alt="JSR logo" />
-            <h2 class="text-2xl font-semibold">
-              <span class="sr-only">JSR</span> Score
-            </h2>
+      {data.package.score
+        ? (
+          <ScoreInfo
+            scope={data.package.scope}
+            name={data.package.name}
+            scorePercentage={data.package.score}
+            score={data.score}
+          />
+        )
+        : (
+          <div class="mt-8 text-gray-500 text-center">
+            No score is available for this package, because it does not have a
+            stable release.
           </div>
-          <div class="mb-6">
-            @{data.package.scope}/{data.package.name}
-          </div>
-          <div
-            class={`flex w-full max-w-32 items-center justify-center aspect-square rounded-full p-1.5 ${
-              getScoreBgColorClass(data.package.score!)
-            }`}
-            style={`background-image: conic-gradient(transparent, transparent ${data.package.score}%, #e7e8e8 ${data.package.score}%)`}
-          >
-            <span class="rounded-full w-full h-full bg-white flex justify-center items-center text-center text-3xl font-bold">
-              {data.package.score!}%
-            </span>
-          </div>
-          <div class="text-gray-500 text-sm text-center mt-6">
-            The JSR score is a measure of the overall quality of a package,
-            based on a number of factors such as documentation and runtime
-            compatibility.
-          </div>
-        </div>
+        )}
+    </div>
+  );
+}
 
-        <ul class="flex flex-col divide-jsr-cyan-100 divide-y-1 md:col-span-2 w-full">
-          <ScoreItem
-            value={data.score.hasReadme}
-            scoreValue={2}
-            title="Has a readme or module doc"
-          >
-            The package should have a README.md in the root of the repository or
-            a{" "}
-            <a class="link" href="/docs/writing-docs#module-documentation">
-              module doc
-            </a>{" "}
-            in the main entrypoint of the package.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.hasReadmeExamples}
-            scoreValue={1}
-            title="Has examples in the readme or module doc"
-          >
-            The README or{" "}
-            <a class="link" href="/docs/writing-docs#module-documentation">
-              module doc
-            </a>{" "}
-            of the main entrypoint should have an example of how to use the
-            package, in the form of a code block.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.allEntrypointsDocs}
-            scoreValue={1}
-            title="Has module docs in all entrypoints"
-          >
-            Every entrypoint of the package should have a{" "}
-            <a class="link" href="/docs/writing-docs#module-documentation">
-              module doc
-            </a>{" "}
-            summarizing what is defined in that module.
-          </ScoreItem>
-          <ScoreItem
-            value={Math.min(data.score.percentageDocumentedSymbols / 0.8, 1)}
-            scoreValue={5}
-            title="Has docs for most symbols"
-          >
-            At least 80% of the packages' symbols should have{" "}
-            <a class="link" href="/docs/writing-docs#symbol-documentation">
-              symbol documentation
-            </a>. Currently{" "}
-            {(data.score.percentageDocumentedSymbols * 100).toFixed(0)}% of
-            symbols are documented.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.allFastCheck}
-            scoreValue={5}
-            title="No slow types are used"
-          >
-            This package uses no{" "}
-            <a class="link" href="/docs/about-slow-types">
-              slow types
-            </a>.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.hasDescription}
-            scoreValue={1}
-            title="Has a description"
-          >
-            The package has a description set in the package settings to help
-            users find this package via search.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.atLeastOneRuntimeCompatible}
-            scoreValue={1}
-            title="At least one runtime is marked as compatible"
-          >
-            This package marks at least one runtime as "compatible" in the
-            package settings to aid users in understanding where they can use
-            this package.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.multipleRuntimesCompatible}
-            scoreValue={1}
-            title="At least two runtimes are marked as compatible"
-          >
-            This package is compatible with more than one runtime, and is marked
-            as such in the package settings.
-          </ScoreItem>
-          <ScoreItem
-            value={data.score.hasProvenance}
-            scoreValue={1}
-            title="Has provenance"
-          >
-            This package is published from a verifiable CI/CD workflow, and has
-            a{" "}
-            <a class="link" href="/docs/trust">
-              public transparency log entry
-            </a>.
-          </ScoreItem>
-        </ul>
+function ScoreInfo(props: {
+  scope: string;
+  name: string;
+  scorePercentage: number;
+  score: PackageScore;
+}) {
+  const { scope, name, scorePercentage, score } = props;
+
+  return (
+    <div class="mt-8 grid items-center justify-items-center grid-cols-1 md:grid-cols-3 gap-12">
+      <div class="w-full h-full flex flex-col items-center justify-center border-1.5 border-jsr-cyan-100 rounded-lg p-8">
+        <div class="flex gap-2 items-center mb-4">
+          <img src="/logo.svg" class="w-16 select-none" alt="JSR logo" />
+          <h2 class="text-2xl font-semibold">
+            <span class="sr-only">JSR</span> Score
+          </h2>
+        </div>
+        <div class="mb-6">
+          @{scope}/{name}
+        </div>
+        <div
+          class={`flex w-full max-w-32 items-center justify-center aspect-square rounded-full p-1.5 ${
+            getScoreBgColorClass(scorePercentage)
+          }`}
+          style={`background-image: conic-gradient(transparent, transparent ${scorePercentage}%, #e7e8e8 ${scorePercentage}%)`}
+        >
+          <span class="rounded-full w-full h-full bg-white flex justify-center items-center text-center text-3xl font-bold">
+            {scorePercentage}%
+          </span>
+        </div>
+        <div class="text-gray-500 text-sm text-center mt-6">
+          The JSR score is a measure of the overall quality of a package, based
+          on a number of factors such as documentation and runtime
+          compatibility.
+        </div>
       </div>
+
+      <ul class="flex flex-col divide-jsr-cyan-100 divide-y-1 md:col-span-2 w-full">
+        <ScoreItem
+          value={score.hasReadme}
+          scoreValue={2}
+          title="Has a readme or module doc"
+        >
+          The package should have a README.md in the root of the repository or a
+          {" "}
+          <a class="link" href="/docs/writing-docs#module-documentation">
+            module doc
+          </a>{" "}
+          in the main entrypoint of the package.
+        </ScoreItem>
+        <ScoreItem
+          value={score.hasReadmeExamples}
+          scoreValue={1}
+          title="Has examples in the readme or module doc"
+        >
+          The README or{" "}
+          <a class="link" href="/docs/writing-docs#module-documentation">
+            module doc
+          </a>{" "}
+          of the main entrypoint should have an example of how to use the
+          package, in the form of a code block.
+        </ScoreItem>
+        <ScoreItem
+          value={score.allEntrypointsDocs}
+          scoreValue={1}
+          title="Has module docs in all entrypoints"
+        >
+          Every entrypoint of the package should have a{" "}
+          <a class="link" href="/docs/writing-docs#module-documentation">
+            module doc
+          </a>{" "}
+          summarizing what is defined in that module.
+        </ScoreItem>
+        <ScoreItem
+          value={Math.min(score.percentageDocumentedSymbols / 0.8, 1)}
+          scoreValue={5}
+          title="Has docs for most symbols"
+        >
+          At least 80% of the packages' symbols should have{" "}
+          <a class="link" href="/docs/writing-docs#symbol-documentation">
+            symbol documentation
+          </a>. Currently{" "}
+          {(score.percentageDocumentedSymbols * 100).toFixed(0)}% of symbols are
+          documented.
+        </ScoreItem>
+        <ScoreItem
+          value={score.allFastCheck}
+          scoreValue={5}
+          title="No slow types are used"
+        >
+          This package uses no{" "}
+          <a class="link" href="/docs/about-slow-types">
+            slow types
+          </a>.
+        </ScoreItem>
+        <ScoreItem
+          value={score.hasDescription}
+          scoreValue={1}
+          title="Has a description"
+        >
+          The package has a description set in the package settings to help
+          users find this package via search.
+        </ScoreItem>
+        <ScoreItem
+          value={score.atLeastOneRuntimeCompatible}
+          scoreValue={1}
+          title="At least one runtime is marked as compatible"
+        >
+          This package marks at least one runtime as "compatible" in the package
+          settings to aid users in understanding where they can use this
+          package.
+        </ScoreItem>
+        <ScoreItem
+          value={score.multipleRuntimesCompatible}
+          scoreValue={1}
+          title="At least two runtimes are marked as compatible"
+        >
+          This package is compatible with more than one runtime, and is marked
+          as such in the package settings.
+        </ScoreItem>
+        <ScoreItem
+          value={score.hasProvenance}
+          scoreValue={1}
+          title="Has provenance"
+        >
+          This package is published from a verifiable CI/CD workflow, and has a
+          {" "}
+          <a class="link" href="/docs/trust">
+            public transparency log entry
+          </a>.
+        </ScoreItem>
+      </ul>
     </div>
   );
 }
@@ -238,6 +267,13 @@ export const handler: Handlers<Data, State> = {
       ),
     ]);
     if (res === null) return ctx.renderNotFound();
+
+    if (res.pkg.versionCount < 1) {
+      return new Response("", {
+        status: 303,
+        headers: { Location: `/@${ctx.params.scope}/${ctx.params.package}` },
+      });
+    }
 
     // TODO: handle errors gracefully
     if (!scoreResp.ok) throw scoreResp;

--- a/frontend/routes/package/settings.tsx
+++ b/frontend/routes/package/settings.tsx
@@ -36,6 +36,7 @@ export default function Settings({ data, params }: PageProps<Data, State>) {
       <PackageNav
         currentTab="Settings"
         versionCount={data.package.versionCount}
+        canPublish={true}
         canEdit={true}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -27,6 +27,7 @@ export default function PackagePage(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   const sourceRoot =
@@ -56,6 +57,7 @@ export default function PackagePage(
       <PackageNav
         currentTab="Files"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/symbols.tsx
+++ b/frontend/routes/package/symbols.tsx
@@ -20,6 +20,7 @@ export default function Symbols(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -44,6 +45,7 @@ export default function Symbols(
       <PackageNav
         currentTab="Symbols"
         versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -31,6 +31,7 @@ export default function Versions(
   { data, params, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   const latestVersionInReleaseTrack: Record<string, SemVer> = {};
@@ -113,8 +114,9 @@ export default function Versions(
       <PackageNav
         currentTab="Versions"
         params={params as unknown as Params}
-        versionCount={data.package.versionCount}
+        canPublish={canPublish}
         canEdit={canEdit}
+        versionCount={data.package.versionCount}
         latestVersion={data.package.latestVersion}
       />
 

--- a/frontend/routes/status.tsx
+++ b/frontend/routes/status.tsx
@@ -28,6 +28,7 @@ export default function PackageListPage(
   { data, state }: PageProps<Data, State>,
 ) {
   const isStaff = state.user?.isStaff || false;
+  const canPublish = data.member !== null || isStaff;
   const canEdit = data.member?.isAdmin || isStaff;
 
   return (
@@ -43,6 +44,7 @@ export default function PackageListPage(
         <PackageNav
           currentTab="Versions"
           versionCount={data.package.versionCount}
+          canPublish={canPublish}
           canEdit={canEdit}
           params={{ scope: data.package.scope, package: data.package.name }}
           latestVersion={data.package.latestVersion}


### PR DESCRIPTION
Previously we redirected you to the publish page, even if you had a prerelease version published.

This handles the "only prereleases" scenario better in a bunch of places. Additionally it fixes an access control check on the `/publish` page - previously it was only visible to admins. Now it's also visible to package members. The content of the page is slightly different for admins and regular members.

Fixes ##222