### PR TITLE
feat: add sudo mode

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -6,8 +6,9 @@ import { UserMenu } from "../islands/UserMenu.tsx";
 import { Logo } from "./Logo.tsx";
 import { GitHub } from "./icons/GitHub.tsx";
 
-export function Header({ user, url }: {
+export function Header({ user, sudo, url }: {
   user: FullUser | null;
+  sudo: boolean;
   url: URL;
 }) {
   const redirectUrl = `${url.pathname}${url.search}${url.hash}`;
@@ -20,67 +21,75 @@ export function Header({ user, url }: {
   const isHomepage = url.pathname === "/";
 
   return (
-    <div
-      class={`section-x-inset-xl w-full py-4 sm:h-[72px] ${
-        isHomepage
-          ? "absolute z-50 top-0 left-0 right-0 bg-transparent pointer-events-none"
-          : ""
-      }`}
-    >
-      <div class="flex justify-between items-center text-base md:text-lg flex-wrap gap-4 lg:gap-8 h-full">
-        {isHomepage
-          ? <div></div>
-          : (
-            <a href="/" class="outline-none focus-visible:ring-2 ring-cyan-700">
+    <>
+      {user?.isStaff && sudo && (
+        <div class="bg-red-600 text-white text-center py-1 px-1">
+          DANGER: You have sudo mode enabled.
+        </div>
+      )}
+      <div
+        class={`section-x-inset-xl w-full py-4 sm:h-[72px] ${
+          isHomepage
+            ? "absolute z-50 top-0 left-0 right-0 bg-transparent pointer-events-none"
+            : ""
+        }`}
+      >
+        <div class="flex justify-between items-center text-base md:text-lg flex-wrap gap-4 lg:gap-8 h-full">
+          {isHomepage ? <div></div> : (
+            <a
+              href="/"
+              class="outline-none focus-visible:ring-2 ring-cyan-700"
+            >
               <span className="sr-only">JSR home</span>
               <Logo class="h-8 flex-none hover:animate-flip-rotate" />
             </a>
           )}
-        <div class="hidden sm:block grow-1 flex-1">
+          <div class="hidden sm:block grow-1 flex-1">
+            {!isHomepage && (
+              <PackageSearch
+                query={(url.pathname === "/packages"
+                  ? url.searchParams.get("search")
+                  : undefined) ?? undefined}
+                apiKey={apiKey}
+                indexId={indexId}
+              />
+            )}
+          </div>
+          <div class="flex gap-2 sm:gap-4 items-center pointer-events-auto">
+            <a
+              href="/packages"
+              class="link-header"
+            >
+              Browse packages
+            </a>
+            <span class="text-gray-200 select-none">|</span>
+            <a
+              href="/docs"
+              class="link-header"
+            >
+              Docs
+            </a>
+            <span class="text-gray-200 select-none">|</span>
+            {user
+              ? <UserMenu user={user} sudo={sudo} logoutUrl={logoutUrl} />
+              : (
+                <a href={loginUrl} class="link flex items-center gap-2">
+                  <GitHub class="h-5 w-5 flex-none" />
+                  Sign in
+                </a>
+              )}
+          </div>
+        </div>
+        <div class="mt-4 sm:hidden">
           {!isHomepage && (
             <PackageSearch
-              query={(url.pathname === "/packages"
-                ? url.searchParams.get("search")
-                : undefined) ?? undefined}
+              query={url.searchParams.get("search") ?? undefined}
               apiKey={apiKey}
               indexId={indexId}
             />
           )}
         </div>
-        <div class="flex gap-2 sm:gap-4 items-center pointer-events-auto">
-          <a
-            href="/packages"
-            class="link-header"
-          >
-            Browse packages
-          </a>
-          <span class="text-gray-200 select-none">|</span>
-          <a
-            href="/docs"
-            class="link-header"
-          >
-            Docs
-          </a>
-          <span class="text-gray-200 select-none">|</span>
-          {user
-            ? <UserMenu user={user} logoutUrl={logoutUrl} />
-            : (
-              <a href={loginUrl} class="link flex items-center gap-2">
-                <GitHub class="h-5 w-5 flex-none" />
-                Sign in
-              </a>
-            )}
-        </div>
       </div>
-      <div class="mt-4 sm:hidden">
-        {!isHomepage && (
-          <PackageSearch
-            query={url.searchParams.get("search") ?? undefined}
-            apiKey={apiKey}
-            indexId={indexId}
-          />
-        )}
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/islands/UserMenu.tsx
+++ b/frontend/islands/UserMenu.tsx
@@ -9,9 +9,14 @@ const SHARED_ITEM_CLASSES =
 const DEFAULT_ITEM_CLASSES =
   "hover:bg-jsr-yellow-300 focus-visible:bg-jsr-yellow-200 ring-jsr-yellow-700";
 
-export function UserMenu(
-  { user, logoutUrl }: { user: FullUser; logoutUrl: string },
-) {
+const SUDO_CONFIRMATION =
+  "Are you sure you want to enable sudo mode? Sudo mode will be enabled for 5 minutes.";
+
+export function UserMenu({ user, sudo, logoutUrl }: {
+  user: FullUser;
+  sudo: boolean;
+  logoutUrl: string;
+}) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -71,6 +76,23 @@ export function UserMenu(
               </span>
               <IconArrowRight class="w-4 h-4" />
             </a>
+          )}
+          {user.isStaff && (
+            <button
+              onClick={() => {
+                if (sudo) {
+                  document.cookie = "sudo=;max-age=0;path=/";
+                  location.reload();
+                } else if (confirm(SUDO_CONFIRMATION)) {
+                  document.cookie = "sudo=1;max-age=300;path=/";
+                  location.reload();
+                }
+              }}
+              tabIndex={open ? undefined : -1}
+              class="bg-red-600 hover:bg-red-400 text-white text-sm py-1 px-3 flex justify-between items-center gap-3 rounded-full mt-2"
+            >
+              {sudo ? "Disable" : "Enable"} Sudo Mode
+            </button>
           )}
         </div>
         <div class="divide-y divide-slate-200 border-t">

--- a/frontend/routes/@[scope]/(_components)/ScopeNav.tsx
+++ b/frontend/routes/@[scope]/(_components)/ScopeNav.tsx
@@ -1,12 +1,13 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import { Nav, NavItem } from "../../../components/Nav.tsx";
+import { ScopeIAM } from "../../../utils/iam.ts";
 
 export type ScopeNavTab = "Packages" | "Members" | "Settings";
 
 export interface ScopeNavProps {
   scope: string;
   active: ScopeNavTab;
-  isAdmin: boolean;
+  iam: ScopeIAM;
 }
 
 export function ScopeNav(props: ScopeNavProps) {
@@ -22,7 +23,7 @@ export function ScopeNav(props: ScopeNavProps) {
       >
         Members
       </NavItem>
-      {props.isAdmin && (
+      {props.iam.canAdmin && (
         <NavItem
           href={`${baseUrl}/~/settings`}
           active={props.active === "Settings"}

--- a/frontend/routes/@[scope]/index.tsx
+++ b/frontend/routes/@[scope]/index.tsx
@@ -17,6 +17,7 @@ import { ScopePendingInvite } from "./(_components)/ScopePendingInvite.tsx";
 import { Head } from "$fresh/runtime.ts";
 import { ListDisplay } from "../../components/List.tsx";
 import { PackageHit } from "../../components/PackageHit.tsx";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data extends PaginationData {
   scope: Scope | FullScope;
@@ -28,8 +29,7 @@ interface Data extends PaginationData {
 export default function ScopePackagesPage(
   { params, data, url, state }: PageProps<Data, State>,
 ) {
-  const isAdmin = data.scopeMember?.user.id === state.user?.id &&
-      data.scopeMember?.isAdmin || state.user?.isStaff || false;
+  const iam = scopeIAM(state, data.scopeMember);
 
   return (
     <div class="mb-20">
@@ -43,7 +43,7 @@ export default function ScopePackagesPage(
         />
       </Head>
       <ScopeHeader scope={data.scope} />
-      <ScopeNav active="Packages" isAdmin={isAdmin} scope={data.scope.scope} />
+      <ScopeNav active="Packages" iam={iam} scope={data.scope.scope} />
       <ScopePendingInvite userInvites={data.userInvites} scope={params.scope} />
       <ListDisplay
         pagination={data}

--- a/frontend/routes/_layout.tsx
+++ b/frontend/routes/_layout.tsx
@@ -18,7 +18,7 @@ export default function Layout(
         >
           Skip to main content
         </a>
-        <Header user={state.user} url={url} />
+        <Header user={state.user} sudo={state.sudo} url={url} />
         <div
           class="section-x-inset-xl py-4 md:py-6 focus-visible:ring-0 focus-visible:outline-none"
           id="main-content"

--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -35,9 +35,14 @@ const auth: MiddlewareHandler<State> = async (req, ctx) => {
   const interactive =
     (ctx.destination === "route" || ctx.destination === "notFound") &&
     !(url.pathname === "/gfm.css" || url.pathname === "/_frsh/client.js.map");
-  const token = getCookies(req.headers).token;
+  const { token, sudo } = getCookies(req.headers);
   if (interactive) {
-    ctx.state.api = new API(API_ROOT, { token, span: ctx.state.span });
+    ctx.state.sudo = sudo === "1";
+    ctx.state.api = new API(API_ROOT, {
+      token,
+      sudo: ctx.state.sudo,
+      span: ctx.state.span,
+    });
     if (ctx.state.api.hasToken()) {
       ctx.state.userPromise = (async () => {
         const userResp = await ctx.state.api.get<FullUser>(path`/user`);

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -1,5 +1,6 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import { Nav, NavItem } from "../../../components/Nav.tsx";
+import { ScopeIAM } from "../../../utils/iam.ts";
 
 export interface Params {
   scope: string;
@@ -19,12 +20,11 @@ type Tab =
   | "Settings";
 
 export function PackageNav(
-  { currentTab, params, canPublish, canEdit, versionCount, latestVersion }: {
+  { currentTab, params, iam, versionCount, latestVersion }: {
     currentTab: Tab;
     params: Params;
     versionCount: number;
-    canPublish: boolean;
-    canEdit: boolean;
+    iam: ScopeIAM;
     latestVersion: string | null;
   },
 ) {
@@ -33,7 +33,7 @@ export function PackageNav(
 
   return (
     <Nav>
-      {((canEdit && versionCount > 0) || !canEdit) && (
+      {((iam.canWrite && versionCount > 0) || !iam.canWrite) && (
         <NavItem href={versionedBase} active={currentTab === "Index"}>
           Overview
         </NavItem>
@@ -86,7 +86,7 @@ export function PackageNav(
           Score
         </NavItem>
       )}
-      {canPublish &&
+      {iam.canWrite &&
         (
           <NavItem
             href={`${base}/publish`}
@@ -95,7 +95,7 @@ export function PackageNav(
             Publish
           </NavItem>
         )}
-      {canEdit &&
+      {iam.canAdmin &&
         (
           <NavItem
             href={`${base}/settings`}

--- a/frontend/routes/package/dependencies.tsx
+++ b/frontend/routes/package/dependencies.tsx
@@ -13,6 +13,7 @@ import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { PackageNav, Params } from "./(_components)/PackageNav.tsx";
 import { Table, TableData, TableRow } from "../../components/Table.tsx";
 import { Head } from "$fresh/runtime.ts";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -24,9 +25,7 @@ interface Data {
 export default function Deps(
   { data, params, state, url }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   const deps: Record<string, { link: string; constraints: Set<string> }> = {};
 
@@ -65,8 +64,7 @@ export default function Deps(
       <PackageNav
         currentTab="Dependencies"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/dependents.tsx
+++ b/frontend/routes/package/dependents.tsx
@@ -13,6 +13,7 @@ import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { PackageNav, Params } from "./(_components)/PackageNav.tsx";
 import { Table, TableData, TableRow } from "../../components/Table.tsx";
 import { Head } from "$fresh/runtime.ts";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data extends PaginationData {
   package: Package;
@@ -23,9 +24,7 @@ interface Data extends PaginationData {
 export default function Dep(
   { data, params, state, url }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -46,8 +45,7 @@ export default function Dep(
       <PackageNav
         currentTab="Dependents"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -11,6 +11,7 @@ import { packageDataWithDocs } from "../../../utils/data.ts";
 import { PackageHeader } from "../(_components)/PackageHeader.tsx";
 import { PackageNav, Params } from "../(_components)/PackageNav.tsx";
 import { DocsView } from "../(_components)/Docs.tsx";
+import { scopeIAM } from "../../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -20,9 +21,7 @@ interface Data {
 }
 
 export default function File({ data, params, state }: PageProps<Data, State>) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -47,8 +46,7 @@ export default function File({ data, params, state }: PageProps<Data, State>) {
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -11,6 +11,7 @@ import { packageDataWithDocs } from "../../../utils/data.ts";
 import { PackageHeader } from "../(_components)/PackageHeader.tsx";
 import { PackageNav, Params } from "../(_components)/PackageNav.tsx";
 import { DocsView } from "../(_components)/Docs.tsx";
+import { scopeIAM } from "../../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -22,9 +23,7 @@ interface Data {
 export default function Symbol(
   { data, params, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -51,8 +50,7 @@ export default function Symbol(
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -8,6 +8,7 @@ import { packageDataWithDocs } from "../../utils/data.ts";
 import { PackageNav, Params } from "./(_components)/PackageNav.tsx";
 import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { DocsView } from "./(_components)/Docs.tsx";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -19,9 +20,7 @@ interface Data {
 export default function PackagePage(
   { data, params, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -44,8 +43,7 @@ export default function PackagePage(
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -16,6 +16,7 @@ import { Check } from "../../components/icons/Check.tsx";
 import { Cross } from "../../components/icons/Cross.tsx";
 import { ErrorIcon } from "../../components/icons/Error.tsx";
 import { getScoreBgColorClass } from "../../utils/score_ring_color.ts";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -26,9 +27,7 @@ interface Data {
 export default function Score(
   { data, params, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -49,8 +48,7 @@ export default function Score(
       <PackageNav
         currentTab="Score"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -14,6 +14,7 @@ import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { Folder } from "../../components/icons/Folder.tsx";
 import { Source as SourceIcon } from "../../components/icons/Source.tsx";
 import { ListDisplay } from "../../components/List.tsx";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -26,9 +27,7 @@ interface Data {
 export default function PackagePage(
   { data, params, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   const sourceRoot =
     `/@${params.scope}/${params.package}/${data.selectedVersion.version}`;
@@ -57,8 +56,7 @@ export default function PackagePage(
       <PackageNav
         currentTab="Files"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/package/symbols.tsx
+++ b/frontend/routes/package/symbols.tsx
@@ -8,6 +8,7 @@ import { packageDataWithDocs } from "../../utils/data.ts";
 import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { PackageNav, Params } from "./(_components)/PackageNav.tsx";
 import { DocsView } from "./(_components)/Docs.tsx";
+import { scopeIAM } from "../../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -19,9 +20,7 @@ interface Data {
 export default function Symbols(
   { data, params, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-20">
@@ -45,8 +44,7 @@ export default function Symbols(
       <PackageNav
         currentTab="Symbols"
         versionCount={data.package.versionCount}
-        canPublish={canPublish}
-        canEdit={canEdit}
+        iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}
       />

--- a/frontend/routes/status.tsx
+++ b/frontend/routes/status.tsx
@@ -17,6 +17,7 @@ import PublishingTaskRequeue from "../islands/PublishingTaskRequeue.tsx";
 import { Pending } from "../components/icons/Pending.tsx";
 import { Check } from "../components/icons/Check.tsx";
 import { ErrorIcon } from "../components/icons/Error.tsx";
+import { scopeIAM } from "../utils/iam.ts";
 
 interface Data {
   package: Package;
@@ -27,9 +28,7 @@ interface Data {
 export default function PackageListPage(
   { data, state }: PageProps<Data, State>,
 ) {
-  const isStaff = state.user?.isStaff || false;
-  const canPublish = data.member !== null || isStaff;
-  const canEdit = data.member?.isAdmin || isStaff;
+  const iam = scopeIAM(state, data.member);
 
   return (
     <div class="mb-24 space-y-16">
@@ -44,8 +43,7 @@ export default function PackageListPage(
         <PackageNav
           currentTab="Versions"
           versionCount={data.package.versionCount}
-          canPublish={canPublish}
-          canEdit={canEdit}
+          iam={iam}
           params={{ scope: data.package.scope, package: data.package.name }}
           latestVersion={data.package.latestVersion}
         />
@@ -109,7 +107,7 @@ export default function PackageListPage(
             </p>
           )}
 
-          {isStaff && (
+          {iam.isStaff && (
             <PublishingTaskRequeue publishingTask={data.publishingTask} />
           )}
         </div>

--- a/frontend/util.ts
+++ b/frontend/util.ts
@@ -9,6 +9,7 @@ export interface State {
   span: TraceSpan;
   userPromise: Promise<FullUser | null | Response>;
   user: FullUser | null;
+  sudo: boolean;
 }
 
 export interface Docs {

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -62,6 +62,7 @@ export function path(
 
 interface APIOptions {
   token?: string | null;
+  sudo?: boolean;
   span?: TraceSpan | null;
 }
 
@@ -73,11 +74,13 @@ interface RequestOptions {
 export class API {
   #apiRoot: string;
   #token: string | null;
+  #sudo: boolean;
   #span: TraceSpan | null;
 
-  constructor(apiRoot: string, { token, span }: APIOptions = {}) {
+  constructor(apiRoot: string, { token, sudo, span }: APIOptions = {}) {
     this.#apiRoot = apiRoot;
     this.#token = token ?? null;
+    this.#sudo = sudo ?? false;
     this.#span = span ?? null;
   }
 
@@ -162,6 +165,9 @@ export class API {
     const headers = new Headers();
     if (this.#token && !req.anonymous) {
       headers.append("Authorization", `Bearer ${this.#token}`);
+    }
+    if (this.#sudo && !req.anonymous) {
+      headers.append("x-jsr-sudo", "true");
     }
     if (req.body) {
       headers.append("Content-Type", "application/json");

--- a/frontend/utils/iam.ts
+++ b/frontend/utils/iam.ts
@@ -1,0 +1,26 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+import { State } from "../util.ts";
+import { FullUser } from "./api_types.ts";
+import { ScopeMember } from "./api_types.ts";
+
+export interface ScopeIAM {
+  isStaff: boolean;
+  canAdmin: boolean;
+  canWrite: boolean;
+}
+
+export function scopeIAM(
+  state: State,
+  scopeMember: ScopeMember | null,
+  user?: FullUser | null,
+): ScopeIAM {
+  const isStaff = !!(user ?? state.user)?.isStaff;
+  const hasSudo = isStaff && state.sudo;
+  const canWrite = scopeMember !== null || hasSudo;
+  const canAdmin = !!scopeMember?.isAdmin || hasSudo;
+  return {
+    isStaff,
+    canAdmin,
+    canWrite,
+  };
+}

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -129,7 +129,8 @@ resource "google_compute_backend_service" "registry_api" {
   cdn_policy {
     cache_mode = "USE_ORIGIN_HEADERS"
     cache_key_policy {
-      include_query_string = true
+      include_query_string  = true
+      include_named_cookies = ["token"] # segment cache by user
     }
     bypass_cache_on_request_headers {
       header_name = "authorization"


### PR DESCRIPTION
Going forward, all admin operations on projects staff members do not normally have access to, require them to enable "sudo mode". This gives them access to all projects for the duration of enablement.

Sudo mode is enabled via the admin menu, for a duration of 5 minutes. During this time, a big red banner is displayed at the top of the screen.