### PR TITLE
fix: update name and email from GitHub every sign-in

### DIFF
--- a/api/.sqlx/query-75a9fca2cd2d0327c9e402315ae81d63b606376548adbd6f98b81f9e09163f50.json
+++ b/api/.sqlx/query-75a9fca2cd2d0327c9e402315ae81d63b606376548adbd6f98b81f9e09163f50.json
@@ -1,0 +1,93 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO users (name, email, avatar_url, github_id, is_blocked, is_staff)\n      VALUES ($1, $2, $3, $4, $5, $6)\n      ON CONFLICT(github_id) DO UPDATE\n      SET name = $1, email = $2, avatar_url = $3\n      RETURNING id, name, email, avatar_url, updated_at, created_at, github_id, is_blocked, is_staff, scope_limit,\n        (SELECT COUNT(created_at) FROM scope_invites WHERE target_user_id = id) as \"invite_count!\",\n        (SELECT COUNT(created_at) FROM scopes WHERE creator = id) as \"scope_usage!\"\n      ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "github_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_blocked",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_staff",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "scope_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "invite_count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "scope_usage!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Text",
+        "Int8",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "75a9fca2cd2d0327c9e402315ae81d63b606376548adbd6f98b81f9e09163f50"
+}

--- a/api/migrations/20240305163250_github_id_unique.sql
+++ b/api/migrations/20240305163250_github_id_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD CONSTRAINT github_id_unique UNIQUE (github_id);


### PR DESCRIPTION
Previously we'd only sync name and email from GitHub on signup. We now do this in both signup, and signin.

Fixes #173