### PR TITLE
fix(frontend): code block style of file

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -197,6 +197,10 @@ body .ddoc .markdown pre {
   
   & > code:first-child {
     @apply p-6 flex;
+  
+    &.flex {
+      display: flex;
+    }
   }
 }
 
@@ -214,10 +218,6 @@ body .ddoc .usage {
 
 body .ddoc .usage pre.highlight {
   @apply bg-white border-jsr-cyan-200 -mx-4 md:mx-0 border-x-0 md:border-1.5;
-  
-  & > code:first-child {
-  
-  }
 }
 
 body .ddoc .usage nav {

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -196,7 +196,7 @@ body .ddoc .markdown pre {
   @apply bg-slate-50 border-t-1.5 border-b-1.5 border-slate-300 -mx-6 rounded-none md:rounded-md md:border-1.5 md:mx-0;
   
   & > code:first-child {
-    @apply p-6;
+    @apply p-6 flex;
   }
 }
 


### PR DESCRIPTION
## Summary

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>

  <tr>
    <td>

![image](https://github.com/jsr-io/jsr/assets/45708948/fbba9c64-dc8f-4214-a7d5-64e89689251a)

</td>
    <td>

![image](https://github.com/jsr-io/jsr/assets/45708948/5d94b931-7505-4554-8b3d-8bcb8cf0b49e)

</td>
  </tr>
</table>

Test link: <https://jsr.io/@oak/oak/14.2.0/deno.json>

## Solution

The `flex` of the code block is overridden by the `display: block` in `.ddoc .markdown pre>code:first-child`. 

<img width="351" alt="image" src="https://github.com/jsr-io/jsr/assets/45708948/3166e780-ef2e-415a-bdc2-4e2f2183d02f">

[The html in the code block section comes from outside](https://github.com/jsr-io/jsr/blob/acb39921e96fb2b436d352650a1f7675d0982e98/frontend/routes/package/source.tsx#L117-L124) and it is not suitable to change `flex` to `!flex`. So choose `style.css` to add styles to override the `.ddoc .markdown pre>code:first-child` default.