### PR TITLE
fix(frontend): made sidebar on package page scroll independently

### DIFF
--- a/frontend/routes/_layout.tsx
+++ b/frontend/routes/_layout.tsx
@@ -20,14 +20,17 @@ export default function Layout(
         </a>
         <Header user={state.user} sudo={state.sudo} url={url} />
         <div
-          class="section-x-inset-xl py-4 md:py-6 focus-visible:ring-0 focus-visible:outline-none"
+          class="section-x-inset-xl pt-4 md:pt-6 focus-visible:ring-0 focus-visible:outline-none"
           id="main-content"
           tabIndex={-1}
         >
           <Component />
         </div>
       </div>
-      <footer class="text-xs text-center p-4 text-gray-500">
+      <footer
+        id="footer"
+        class="text-xs text-center mt-4 md:mt-6 p-4 text-gray-500"
+      >
         JSR - It is {new Date().toLocaleString("en-ZA", {
           timeZoneName: "short",
           timeZone: "Etc/UTC",

--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -83,7 +83,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
           version={selectedVersion.version}
         />
         <div
-          class="ddoc w-full lg:min-h-0 lg:*:!h-full"
+          class="ddoc w-full lg:*:max-h-[calc(100vh-75px)]"
           dangerouslySetInnerHTML={{ __html: docs.sidepanel }}
         />
       </div>

--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -9,11 +9,14 @@ interface DocsProps {
   docs: Docs;
   params: Params;
   selectedVersion: PackageVersionWithUser;
+  showProvenanceBadge?: boolean;
 }
 
-export function DocsView({ docs, params, selectedVersion }: DocsProps) {
+export function DocsView(
+  { docs, params, selectedVersion, showProvenanceBadge }: DocsProps,
+) {
   const content = (
-    <div class="flex-1 min-w-0 px-2 lg:px-6 py-4">
+    <div class="flex-1 min-w-0 px-2 lg:px-6 pt-4">
       <Head>
         <style dangerouslySetInnerHTML={{ __html: docs.css }} />
         <script dangerouslySetInnerHTML={{ __html: docs.script }} defer />
@@ -27,8 +30,8 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
       )}
       <div class="ddoc" dangerouslySetInnerHTML={{ __html: docs.main }} />
 
-      {selectedVersion.rekorLogId && (
-        <div class="mt-12 border-2 border-jsr-cyan-500 max-w-xl rounded-md py-4 px-6">
+      {showProvenanceBadge && selectedVersion.rekorLogId && (
+        <div class="mt-8 mb-8 border-2 border-jsr-cyan-500 max-w-xl rounded-md py-4 px-6">
           <div class="flex flex-row items-end justify-between">
             <div className="items-center">
               <span className="text-sm text-jsr-gray-300">
@@ -75,15 +78,15 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
   }
 
   return (
-    <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 lg:sticky lg:max-h-screen box-border">
+    <div class="grid grid-cols-1 lg:grid-cols-4 pt-2">
+      <div class="col-span-1 top-0 md:pl-0 md:pr-2 pt-4 lg:sticky lg:max-h-screen box-border">
         <LocalSymbolSearch
           scope={params.scope}
           pkg={params.package}
           version={selectedVersion.version}
         />
         <div
-          class="ddoc w-full lg:*:max-h-[calc(100vh-75px)]"
+          class="ddoc w-full lg:*:max-h-[calc(100vh-55px)] b-0"
           dangerouslySetInnerHTML={{ __html: docs.sidepanel }}
         />
       </div>

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -24,7 +24,7 @@ export default function File({ data, params, state }: PageProps<Data, State>) {
   const iam = scopeIAM(state, data.member);
 
   return (
-    <div class="mb-20">
+    <div>
       <Head>
         <title>
           {params.entrypoint || "index"} - @{params.scope}/{params.package}{" "}

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -26,7 +26,7 @@ export default function Symbol(
   const iam = scopeIAM(state, data.member);
 
   return (
-    <div class="mb-20">
+    <div>
       <Head>
         <title>
           {/* TODO: print symbol kind here (function / class / etc) */}

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -23,7 +23,7 @@ export default function PackagePage(
   const iam = scopeIAM(state, data.member);
 
   return (
-    <div class="mb-20">
+    <div>
       <Head>
         <title>
           @{params.scope}/{params.package} - JSR
@@ -54,6 +54,7 @@ export default function PackagePage(
             docs={data.docs}
             params={params as unknown as Params}
             selectedVersion={data.selectedVersion}
+            showProvenanceBadge
           />
         )
         : (

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -49,7 +49,7 @@
 
   :root {
     scroll-behavior: smooth;
-    scrollbar-color: theme("colors.jsr-cyan.950") theme("colors.jsr-cyan.50");
+    scrollbar-color: theme("colors.jsr-cyan.200") theme("colors.jsr-cyan.50");
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -170,6 +170,11 @@ body .ddoc #sidepanel a:active {
   background-color: theme("colors.cyan.200");
 }
 
+body .ddoc #sidepanel {
+  @apply pb-4;
+  height: unset !important;
+}
+
 /* !important seems necessary for taking precedent over current ddoc styling */
 
 body .ddoc .markdown h1 {
@@ -229,7 +234,21 @@ body .ddoc .usage nav label {
 }
 
 body .ddoc > section > nav.py-4 {
-  @apply pt-0 top-4;
+  @apply pt-0 pb-0;
+}
+
+body .ddoc > section > nav.py-4 > ul {
+  padding: 1rem 0;
+  scrollbar-width: thin;
+}
+
+body .ddoc #module_doc, body .ddoc main {
+  @apply pb-8;
+}
+
+/** We hide the footer on ddoc pages so that there is no content underneath the doc pages that make scrolling experience weird */
+body:has(.ddoc) #footer {
+  display: none;
 }
 
 body .ddoc .markdown tr:nth-child(2n) {


### PR DESCRIPTION
Fixes https://github.com/jsr-io/jsr/issues/41

Since the layout is designed in a way that the viewport always scrolls (even when the page content is smaller) as it has full width top elements with a sticky sidebar and a large whitespace before the footer (with `class="mb-20"`) on every page, it made sense to make sidebar scrollable independently.

If we don't want viewport to scroll when the page content is smaller, we might want to revisit the layout. (I really like the approach of https://docs.rs on this) But for now independent scrolling should be sufficient imo.