### PR TITLE
Fix: symbols column trimmed when it's longer than the screen

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -76,16 +76,18 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
 
   return (
     <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 lg:sticky lg:max-h-screen box-border">
-        <LocalSymbolSearch
-          scope={params.scope}
-          pkg={params.package}
-          version={selectedVersion.version}
-        />
-        <div
-          class="ddoc w-full lg:min-h-0 lg:*:!h-full"
-          dangerouslySetInnerHTML={{ __html: docs.sidepanel }}
-        />
+      <div class="col-span-1 md:pl-0 md:pr-2 py-4 box-border">
+        <div class="sticky top-0">
+          <LocalSymbolSearch
+            scope={params.scope}
+            pkg={params.package}
+            version={selectedVersion.version}
+          />
+          <div
+            class="ddoc w-full lg:min-h-0 lg:*:!h-full"
+            dangerouslySetInnerHTML={{ __html: docs.sidepanel }}
+          />
+        </div>
       </div>
       <div class="col-span-1 lg:col-span-3">
         {content}


### PR DESCRIPTION
Now the left pane in a package page is cutting some of the symbols when it's bigger than the screen:  
(which is very common)
  
<img width="700" alt="image" src="https://github.com/jsr-io/jsr/assets/5693018/75ff148a-7a32-4eec-a75f-32919bc01f2b">
  

And this is after the fix:  
<img width="700" alt="image" src="https://github.com/jsr-io/jsr/assets/5693018/2c91cc2e-585a-45c9-92c7-3a7754cb80bb">
  
Of course, it's still sticky.  
I removed the `lg:max-h-screen` because it's limiting the height of the column,  
and I wrapped the column content in another div so it won't be longer than the container,  
which disables the `position: sticky`

It also solves this https://github.com/jsr-io/jsr/issues/41 
Without height limitation at all (like here: https://github.com/jsr-io/jsr/pull/258)
