### PR TITLE
fix(frontend): unable to scroll the sidebar of overview tab

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -76,7 +76,7 @@ export function DocsView({ docs, params, selectedVersion }: DocsProps) {
 
   return (
     <div class="grid grid-cols-1 lg:grid-cols-4 py-2">
-      <div class="col-span-1 top-0 md:pl-0 md:pr-2 py-4 lg:sticky lg:max-h-screen box-border">
+      <div class="flex flex-col col-span-1 top-0 md:pl-0 md:pr-2 py-4 lg:sticky lg:max-h-screen box-border">
         <LocalSymbolSearch
           scope={params.scope}
           pkg={params.package}


### PR DESCRIPTION
## Summary

Previously the sidebar could not be scrolled independently. The sidebar could only be scrolled if the entire page was scrolled to the bottom

And even then there were trim issues like the ones reported at https://github.com/jsr-io/jsr/pull/260.

<img width="1277" alt="image" src="https://github.com/jsr-io/jsr/assets/45708948/c1dcebd1-36dc-4657-a5fe-148d2900dc82">

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>

  <tr>
    <td>

<img width="1279" alt="截屏2024-03-11 23 24 03" src="https://github.com/jsr-io/jsr/assets/45708948/d52ac353-e82c-4f08-b32d-324db32a16ca">

</td>
    <td>

<img width="1280" alt="截屏2024-03-11 23 26 00" src="https://github.com/jsr-io/jsr/assets/45708948/c3cfa2c1-5413-455f-ba75-713f3d9d12ad">

</td>
  </tr>
</table>

Test link: <https://jsr.io/@oak/oak>

## Solution

Add `flex`, `flex-column` class to sidebar so it doesn't overflow.

<img width="1280" alt="截屏2024-03-11 23 45 25" src="https://github.com/jsr-io/jsr/assets/45708948/22d51af1-14e6-4089-80ce-2137e23790fc">

By the way, it makes the invalid `flex-none` class of the search box work.

<img width="428" alt="image" src="https://github.com/jsr-io/jsr/assets/45708948/f02f63a8-c128-4a94-b467-47a671656f53">

<img width="171" alt="image" src="https://github.com/jsr-io/jsr/assets/45708948/43c202e0-acac-406d-801e-c9160338381c">

---

close https://github.com/jsr-io/jsr/issues/41, close https://github.com/jsr-io/jsr/pull/258, close https://github.com/jsr-io/jsr/pull/260