### PR TITLE
chore: Remove repeated URL parsing

### DIFF
--- a/frontend/routes/@[scope]/index.tsx
+++ b/frontend/routes/@[scope]/index.tsx
@@ -56,8 +56,8 @@ export default function ScopePackagesPage(
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const url = new URL(req.url);
+  async GET(_req, ctx) {
+    const url = ctx.url;
     const page = +(url.searchParams.get("page") || 1);
     // Default to large enough to display all of @std.
     const limit = +(url.searchParams.get("limit") || 50);

--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -12,7 +12,7 @@ export const tracer = new Tracer();
 
 const tracing: MiddlewareHandler<State> = async (req, ctx) => {
   ctx.state.span = tracer.spanForRequest(req, ctx.destination);
-  const url = new URL(req.url);
+  const url = ctx.url;
   const attributes: Record<string, string | bigint> = {
     "http.url": url.href,
     "http.method": req.method,
@@ -31,7 +31,7 @@ const tracing: MiddlewareHandler<State> = async (req, ctx) => {
 };
 
 const auth: MiddlewareHandler<State> = async (req, ctx) => {
-  const url = new URL(req.url);
+  const url = ctx.url;
   const interactive =
     (ctx.destination === "route" || ctx.destination === "notFound") &&
     !(url.pathname === "/gfm.css" || url.pathname === "/_frsh/client.js.map");

--- a/frontend/routes/admin/publishingTasks.tsx
+++ b/frontend/routes/admin/publishingTasks.tsx
@@ -101,8 +101,8 @@ export default function PublishingTasks({ data, url }: PageProps<Data>) {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const reqUrl = new URL(req.url);
+  async GET(_req, ctx) {
+    const reqUrl = ctx.url;
     const query = reqUrl.searchParams.get("search") || "";
     const page = +(reqUrl.searchParams.get("page") || 1);
     const limit = +(reqUrl.searchParams.get("limit") || 20);

--- a/frontend/routes/admin/scopes.tsx
+++ b/frontend/routes/admin/scopes.tsx
@@ -39,8 +39,8 @@ export default function Scopes({ data, url }: PageProps<Data>) {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const reqUrl = new URL(req.url);
+  async GET(_req, ctx) {
+    const reqUrl = ctx.url;
     const query = reqUrl.searchParams.get("search") || "";
     const page = +(reqUrl.searchParams.get("page") || 1);
     const limit = +(reqUrl.searchParams.get("limit") || 20);

--- a/frontend/routes/admin/users.tsx
+++ b/frontend/routes/admin/users.tsx
@@ -40,8 +40,8 @@ export default function Users({ data, url }: PageProps<Data>) {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const reqUrl = new URL(req.url);
+  async GET(_req, ctx) {
+    const reqUrl = ctx.url;
     const query = reqUrl.searchParams.get("search") || "";
     const page = +(reqUrl.searchParams.get("page") || 1);
     const limit = +(reqUrl.searchParams.get("limit") || 20);

--- a/frontend/routes/auth.tsx
+++ b/frontend/routes/auth.tsx
@@ -150,8 +150,8 @@ function PermissionTile({ permission }: { permission: Permission | null }) {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const url = new URL(req.url);
+  async GET(_req, ctx) {
+    const url = ctx.url;
     const code = url.searchParams.get("code") ?? "";
     const [user, authorizationResp] = await Promise.all([
       ctx.state.userPromise,

--- a/frontend/routes/badges/package.ts
+++ b/frontend/routes/badges/package.ts
@@ -43,7 +43,7 @@ export const handler: Handlers<unknown, State> = {
         );
       }
     } else {
-      const url = new URL(req.url);
+      const url = ctx.url;
       url.protocol = "https:";
 
       const shieldsUrl = new URL("https://img.shields.io/endpoint");

--- a/frontend/routes/badges/package_score.ts
+++ b/frontend/routes/badges/package_score.ts
@@ -47,7 +47,7 @@ export const handler: Handlers<unknown, State> = {
         );
       }
     } else {
-      const url = new URL(req.url);
+      const url = ctx.url;
       url.protocol = "https:";
 
       const shieldsUrl = new URL("https://img.shields.io/endpoint");

--- a/frontend/routes/logout.tsx
+++ b/frontend/routes/logout.tsx
@@ -2,8 +2,8 @@
 import { Handlers, RouteConfig } from "$fresh/server.ts";
 
 export const handler: Handlers = {
-  GET(req, ctx) {
-    const url = new URL(req.url);
+  GET(_req, ctx) {
+    const url = ctx.url;
     const redirectPath = url.searchParams.get("redirect") ?? "/";
     return new Response(null, {
       status: 302,

--- a/frontend/routes/new.tsx
+++ b/frontend/routes/new.tsx
@@ -121,7 +121,7 @@ export default function New(props: PageProps<Data, State>) {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
+  async GET(_req, ctx) {
     let newPackage = undefined;
     const scopesResp =
       await (ctx.state.api.hasToken()
@@ -129,7 +129,7 @@ export const handler: Handlers<Data, State> = {
         : Promise.resolve(null));
     if (scopesResp && !scopesResp.ok) throw scopesResp; // gracefully handle this
     const scopes = scopesResp?.data.map((scope) => scope.scope) ?? [];
-    const url = new URL(req.url);
+    const url = ctx.url;
     let scope = "";
     let initialScope;
     if (url.searchParams.has("scope")) {

--- a/frontend/routes/package/dependents.tsx
+++ b/frontend/routes/package/dependents.tsx
@@ -112,8 +112,8 @@ function Dependent(
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const reqUrl = new URL(req.url);
+  async GET(_req, ctx) {
+    const reqUrl = ctx.url;
     const page = +(reqUrl.searchParams.get("page") || 1);
     const limit = +(reqUrl.searchParams.get("limit") || 20);
 

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -52,8 +52,8 @@ const apiKey = Deno.env.get("ORAMA_PUBLIC_API_KEY");
 const indexId = Deno.env.get("ORAMA_PUBLIC_INDEX_ID");
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const reqUrl = new URL(req.url);
+  async GET(_req, ctx) {
+    const reqUrl = ctx.url;
     const query = reqUrl.searchParams.get("search") || "";
     const page = +(reqUrl.searchParams.get("page") || 1);
     const limit = +(reqUrl.searchParams.get("limit") || 20);

--- a/frontend/routes/publishing/index.tsx
+++ b/frontend/routes/publishing/index.tsx
@@ -85,8 +85,8 @@ function PackageListItem(props: {
 }
 
 export const handler: Handlers<Data, State> = {
-  async GET(req, ctx) {
-    const url = new URL(req.url);
+  async GET(_req, ctx) {
+    const url = ctx.url;
 
     const authorizedVersions = url.searchParams.getAll("v");
     const date = url.searchParams.get("date");


### PR DESCRIPTION
Fresh alread stores a parsed `URL` instance under `ctx.url`. No need to construct that yourself.