### PR TITLE
fix(UI/UX): truncate versions instead of package names on Recent updates

### DIFF
--- a/frontend/components/ListPanel.tsx
+++ b/frontend/components/ListPanel.tsx
@@ -37,11 +37,11 @@ export function ListPanel(
                 }`}
                 href={entry.href}
               >
-                <span class="block w-full truncate group-hover:text-jsr-cyan-800 pr-4 group-hover:underline">
+                <span class="block group-hover:text-jsr-cyan-800 pr-4 mr-auto group-hover:underline whitespace-nowrap">
                   {entry.value}
                 </span>
                 {entry.label && (
-                  <div class="chip bg-jsr-cyan-200">
+                  <div class="chip bg-jsr-cyan-200 truncate">
                     {entry.label}
                   </div>
                 )}


### PR DESCRIPTION
Fixes #145.

This PR truncates package versions while ensuring to show full package names in a single line as:
<img width="411" alt="Screenshot 2024-03-12 at 16 43 33" src="https://github.com/jsr-io/jsr/assets/30751755/7edc040e-45aa-4542-b2e2-fc994646e2b9">

There is also a suggestion on excluding pre-release versions entirely [here](https://github.com/jsr-io/jsr/issues/145#issuecomment-1976846714) but we would prefer to handle that in backend imo if we decide to do it.