### PR TITLE
feat: basic filtering for runtime & scope

### DIFF
--- a/frontend/docs/faq.md
+++ b/frontend/docs/faq.md
@@ -134,3 +134,8 @@ use the query `runtime:node`. You can also combine these filters, for example
 `runtime:deno runtime:browsers` will return packages that are compatible with
 both Deno and web browsers. The possible values for the `runtime` filter are
 `deno`, `node`, `browsers`, `workerd` (Cloudflare Workers), and `bun`.
+
+## Can I filter packages by scope in the search?
+
+Yes! You can specify `scope:` in the search query to filter packages by scope.
+To only return packages in the `std` scope, you can use the query `scope:std`.

--- a/frontend/docs/faq.md
+++ b/frontend/docs/faq.md
@@ -121,3 +121,16 @@ You can read more about this in
 and in
 [this discussion thread](https://github.com/orgs/community/discussions/37117) on
 the official GitHub Discussions feedback forum.
+
+## Can I filter packages by compatible runtime in the search?
+
+Yes! You can filter the package search to only return packages that are
+compatible with one or more runtimes, by using the `runtime` filter in the
+search query.
+
+To filter for packages that are compatible with Deno, you can use the query
+`runtime:deno`. To filter for packages that are compatible with Node.js, you can
+use the query `runtime:node`. You can also combine these filters, for example
+`runtime:deno runtime:browsers` will return packages that are compatible with
+both Deno and web browsers. The possible values for the `runtime` filter are
+`deno`, `node`, `browsers`, `workerd` (Cloudflare Workers), and `bun`.

--- a/frontend/docs/packages.md
+++ b/frontend/docs/packages.md
@@ -17,14 +17,28 @@ in the same scope can have the same name. Package names must be between 2 and 20
 characters long, and can only contain lowercase letters, numbers, and hyphens.
 They cannot start with a hyphen or digit.
 
+Packages can be created at [jsr.io/new](/new). Packages are always created in a
+scope, so a scope must be created before creating a package.
+
+## Description
+
 Packages can have a description. The description is a short blurb about the
 package that is displayed on the package page and in search results.
 Descriptions should summarize what the package does for potential users. The
 description can be up to 250 characters long. The description can be updated
 from the "Settings" tab on the package page.
 
-Packages can be created at [jsr.io/new](/new). Packages are always created in a
-scope, so a scope must be created before creating a package.
+## Runtime Compatibility
+
+Packages can specify which runtimes they are compatible with. This is useful for
+package consumers, who can see at a glance which runtimes a package supports.
+This information is displayed on the package page and in search results. For
+each of the 5 supported runtimes that compatibility can be specified for (Deno,
+Node.js, Cloudflare Workers, Bun, and web browsers) a package can specify a
+support level of "Supported", "Unsupported", or "Unknown support". Unknown
+support means that the package author does not know if the package is compatible
+with the runtime. The compatibility can be updated from the "Settings" tab on
+the package page.
 
 ## Linked GitHub repository
 

--- a/frontend/islands/GlobalSearch.tsx
+++ b/frontend/islands/GlobalSearch.tsx
@@ -394,11 +394,9 @@ export function processFilter(
   const filters: [string, boolean | string][] = [];
   let query = "";
   for (const part of search.split(" ")) {
-    // TODO: enable filtering by scope - currently not supported by Orama?
-    // if (part.startsWith("scope:")) {
-    //   filters.push(["scope", part.slice(6)]);
-    // } else
-    if (part.startsWith("runtime:")) {
+    if (part.startsWith("scope:")) {
+      filters.push(["scope", part.slice(6)]);
+    } else if (part.startsWith("runtime:")) {
       const runtime = part.slice(8);
       if (RUNTIME_COMPAT_KEYS.find(([k]) => runtime == k)) {
         filters.push([`runtimeCompat.${runtime}`, true]);

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -7,7 +7,7 @@ import type { List, Package } from "../utils/api_types.ts";
 import { path } from "../utils/api.ts";
 import { ListDisplay } from "../components/List.tsx";
 import { PackageHit } from "../components/PackageHit.tsx";
-import { processFilter } from "../islands/GlobalSearch.tsx";
+import { processFilter } from "../islands/PackageSearch.tsx";
 
 interface Data extends PaginationData {
   packages: OramaPackageHit[] | Package[];

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -7,7 +7,7 @@ import type { List, Package } from "../utils/api_types.ts";
 import { path } from "../utils/api.ts";
 import { ListDisplay } from "../components/List.tsx";
 import { PackageHit } from "../components/PackageHit.tsx";
-import { processFilter } from "../islands/PackageSearch.tsx";
+import { processFilter } from "../islands/GlobalSearch.tsx";
 
 interface Data extends PaginationData {
   packages: OramaPackageHit[] | Package[];


### PR DESCRIPTION
You can now put `runtime:` and `scope:` in the search box to filter searching to a certain runtime or scope.
