### PR TITLE
docs(native-imports): updated anchor tag in native imports

### DIFF
--- a/frontend/docs/native-imports.md
+++ b/frontend/docs/native-imports.md
@@ -13,7 +13,7 @@ different tool, you can
 packages.
 
 > Would you like to add native support for JSR to your tool? Check out
-> [the guide for implementing native `jsr:` support](#implementing-in-tools).
+> [the guide for implementing native `jsr:` support](#implementing-native-jsr-imports-in-tools).
 
 ## Installing and importing JSR packages
 


### PR DESCRIPTION
I found that the anchor tag seems to be updated in the past. Therefore the anchor is not working as expected. This PR should fix it