### PR TITLE
fix: serve empty json at registry root

### DIFF
--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -39,6 +39,14 @@ resource "google_storage_bucket" "npm" {
   }
 }
 
+resource "google_storage_bucket_object" "npm_root_json" {
+  bucket        = google_storage_bucket.npm.name
+  cache_control = "public, max-age=0, no-cache"
+  content       = "{}"
+  content_type  = "application/json"
+  name          = "root.json"
+}
+
 resource "google_storage_bucket_object" "npm_404_txt" {
   bucket        = google_storage_bucket.npm.name
   cache_control = "public, max-age=0, no-cache"
@@ -65,12 +73,17 @@ resource "google_compute_backend_bucket" "modules" {
     "x-jsr-cache-status: {cdn_cache_status}",
     "X-Robots-Tag: noindex",
   ]
+
   cdn_policy {
     cache_mode         = "USE_ORIGIN_HEADERS"
     default_ttl        = 0        # no caching unless specified by the backend
     max_ttl            = 31622400 # 1 year
     serve_while_stale  = 0        # no caching unless specified by the backend
     request_coalescing = true
+  }
+
+  lifecycle {
+    ignore_changes = [cdn_policy[0].client_ttl, cdn_policy[0].max_ttl]
   }
 }
 
@@ -99,5 +112,9 @@ resource "google_compute_backend_bucket" "npm" {
     max_ttl            = 31622400 # 1 year
     serve_while_stale  = 0        # no caching unless specified by the backend
     request_coalescing = true
+  }
+
+  lifecycle {
+    ignore_changes = [cdn_policy[0].client_ttl, cdn_policy[0].max_ttl]
   }
 }

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -147,6 +147,10 @@ resource "google_compute_backend_service" "registry_api" {
   backend {
     group = google_compute_region_network_endpoint_group.registry_api.id
   }
+
+  lifecycle {
+    ignore_changes = [cdn_policy[0].client_ttl, cdn_policy[0].max_ttl]
+  }
 }
 
 resource "google_cloud_run_service_iam_member" "api_public_policy" {

--- a/terraform/cloud_run_frontend.tf
+++ b/terraform/cloud_run_frontend.tf
@@ -90,6 +90,10 @@ resource "google_compute_backend_service" "registry_frontend" {
       group = google_compute_region_network_endpoint_group.registry_frontend[backend.key].id
     }
   }
+
+  lifecycle {
+    ignore_changes = [cdn_policy[0].client_ttl, cdn_policy[0].max_ttl]
+  }
 }
 
 resource "google_cloud_run_service_iam_member" "frontend_public_policy" {

--- a/terraform/https.tf
+++ b/terraform/https.tf
@@ -62,7 +62,18 @@ resource "google_compute_url_map" "frontend_https" {
   }
 
   path_matcher {
-    name            = "npm"
+    name = "npm"
+
+    path_rule {
+      paths = ["/"]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/root.json"
+        }
+      }
+      service = google_compute_backend_bucket.npm.self_link
+    }
+
     default_service = google_compute_backend_bucket.npm.self_link
   }
 


### PR DESCRIPTION
This allows adding JSR's npm endpoint as an upstream to private registries like Azure DevOps Artifacts.