### PR TITLE
Add 'example' namespace as reserved one.

### DIFF
--- a/api/src/reserved_scopes.json
+++ b/api/src/reserved_scopes.json
@@ -179,6 +179,7 @@
   "eventemitter2",
   "eventemitter3",
   "events",
+  "example",
   "execa",
   "expect",
   "express",


### PR DESCRIPTION
Hi, we (@yasunori, @Omochice, @ryoppippi, @take and myself) propose the `example` namespace, which guarantees that there are no modules at all. This is intended to be a safe namespace for sample code, etc.

We would like to update the doc if this is accepted. Would you mind telling me which repository to update for this namespace?