### PR TITLE
chore: adjust badge colors

### DIFF
--- a/frontend/routes/badges/package.ts
+++ b/frontend/routes/badges/package.ts
@@ -31,8 +31,8 @@ export const handler: Handlers<unknown, State> = {
               new URL("../../static/logo.svg", import.meta.url),
             ),
             message: packageResp.data.latestVersion,
-            labelColor: "rgb(8,51,68)",
-            color: "rgb(247,223,30)",
+            labelColor: "rgb(247,223,30)",
+            color: "rgb(8,51,68)",
             logoWidth: "25",
           }),
           {

--- a/frontend/routes/badges/package_score.ts
+++ b/frontend/routes/badges/package_score.ts
@@ -35,8 +35,8 @@ export const handler: Handlers<unknown, State> = {
               new URL("../../static/logo.svg", import.meta.url),
             ),
             message: `${packageResp.data.score}%`,
-            labelColor: "rgb(8,51,68)",
-            color: "rgb(247,223,30)",
+            labelColor: "rgb(247,223,30)",
+            color: "rgb(8,51,68)",
             logoWidth: "25",
           }),
           {


### PR DESCRIPTION
This is a style proposal related to https://github.com/simple-icons/simple-icons/pull/10794#discussion_r1559656261. It has a better visual on the logo and its stroke.

### Preview

![](https://github.com/jsr-io/jsr/assets/8186898/7df8b1fa-ceab-4cdc-be14-2633d25663a2)