### PR TITLE
fix(UI/UX): long package names disrupting the box layout

### DIFF
--- a/frontend/components/ListPanel.tsx
+++ b/frontend/components/ListPanel.tsx
@@ -37,11 +37,11 @@ export function ListPanel(
                 }`}
                 href={entry.href}
               >
-                <span class="block group-hover:text-jsr-cyan-800 pr-4 mr-auto group-hover:underline whitespace-nowrap">
+                <span class="block group-hover:text-jsr-cyan-800 pr-4 flex-1 group-hover:underline truncate">
                   {entry.value}
                 </span>
                 {entry.label && (
-                  <div class="chip bg-jsr-cyan-200 truncate">
+                  <div class="chip bg-jsr-cyan-200 max-w-20 truncate">
                     {entry.label}
                   </div>
                 )}


### PR DESCRIPTION
Fixed it by setting a max width on the version and truncating both names and the versions.