### PR TITLE
refactor: use `passthrough_jsr_specifier` deno_graph option

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.72.0"
+source = "git+https://github.com/denoland/deno_graph?rev=d179f32b6879770119a00e408d9452567f0bbee8#d179f32b6879770119a00e408d9452567f0bbee8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -931,8 +931,6 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508791f6140a8b5b1ac40bac1842db04281b61db4b64c5fd5bf9f1f7259f328a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -100,3 +100,6 @@ sitemap-rs = "0.2.1"
 [dev-dependencies]
 flate2 = "1"
 deno_semver = "0.5.1"
+
+[patch.crates-io]
+deno_graph = { path = "../../../denoland/deno_graph" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -102,4 +102,4 @@ flate2 = "1"
 deno_semver = "0.5.1"
 
 [patch.crates-io]
-deno_graph = { path = "../../../denoland/deno_graph" }
+deno_graph = { git = "https://github.com/denoland/deno_graph", rev = "d179f32b6879770119a00e408d9452567f0bbee8" }

--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -155,7 +155,9 @@ async fn analyze_package_inner(
     )
     .await;
   assert!(diagnostics.is_empty());
-  graph.valid().map_err(PublishError::GraphError)?;
+  graph
+    .valid()
+    .map_err(|e| PublishError::GraphError(Box::new(e)))?;
   graph.build_fast_check_type_graph(BuildFastCheckTypeGraphOptions {
     fast_check_cache: None,
     fast_check_dts: true,

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -1,13 +1,12 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-use crate::analysis::RegistryLoader;
 use crate::buckets::Buckets;
 use crate::orama::OramaClient;
 use crate::NpmUrl;
+use crate::RegistryUrl;
 use hyper::Body;
 use hyper::Request;
 use routerify::prelude::RequestExt;
 use routerify::Router;
-use std::sync::Arc;
 use tracing::field;
 use tracing::instrument;
 use tracing::Instrument;
@@ -263,7 +262,7 @@ pub async fn requeue_publishing_tasks(req: Request<Body>) -> ApiResult<()> {
     queue.task_buffer(None, Some(body.into())).await?;
   } else {
     let buckets = req.data::<Buckets>().unwrap().clone();
-    let registry = req.data::<Arc<dyn RegistryLoader>>().unwrap().clone();
+    let registry = req.data::<RegistryUrl>().unwrap().0.clone();
     let npm_url = req.data::<NpmUrl>().unwrap().0.clone();
 
     let span = Span::current();

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -603,6 +603,10 @@ impl ExportsMap {
   pub fn into_inner(self) -> IndexMap<String, String> {
     self.0
   }
+
+  pub fn contains_key(&self, key: &str) -> bool {
+    self.0.contains_key(key)
+  }
 }
 
 impl sqlx::Decode<'_, sqlx::Postgres> for ExportsMap {

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -765,7 +765,7 @@ mod tests {
     for (path, spec) in specs {
       test_npm_tarball(&path, spec)
         .await
-        .unwrap_or_else(|_| panic!("failed to test npm tarball {path:?}"));
+        .unwrap_or_else(|e| panic!("failed to test npm tarball {path:?}: {e}"));
     }
   }
 }

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -570,7 +570,6 @@ mod tests {
 
   use async_tar::Archive;
   use deno_ast::ModuleSpecifier;
-  use deno_graph::source::JsrUrlProvider;
   use deno_graph::source::MemoryLoader;
   use deno_graph::source::NullFileSystem;
   use deno_graph::source::Source;
@@ -584,10 +583,10 @@ mod tests {
   use deno_semver::package::PackageReqReference;
   use futures::AsyncReadExt;
   use futures::StreamExt;
-  use once_cell::sync::Lazy;
   use url::Url;
 
   use crate::analysis::ModuleAnalyzer;
+  use crate::analysis::PassthroughJsrUrlProvider;
   use crate::db::DependencyKind;
   use crate::ids::PackagePath;
   use crate::npm::tests::helpers;
@@ -598,17 +597,6 @@ mod tests {
   use super::create_npm_tarball;
   use super::NpmTarballFiles;
   use super::NpmTarballOptions;
-
-  pub static DEFAULT_JSR_TEST_URL: Lazy<Url> =
-    Lazy::new(|| Url::parse("http://jsr.test").unwrap());
-
-  struct JsrTestUrlProvider;
-
-  impl JsrUrlProvider for JsrTestUrlProvider {
-    fn url(&self) -> &Url {
-      &DEFAULT_JSR_TEST_URL
-    }
-  }
 
   async fn test_npm_tarball(
     spec_path: &Path,
@@ -683,7 +671,8 @@ mod tests {
           resolver: None,
           npm_resolver: None,
           reporter: None,
-          jsr_url_provider: &JsrTestUrlProvider,
+          jsr_url_provider: &PassthroughJsrUrlProvider,
+          passthrough_jsr_specifiers: true,
           ..Default::default()
         },
       )
@@ -692,7 +681,7 @@ mod tests {
     graph.build_fast_check_type_graph(BuildFastCheckTypeGraphOptions {
       fast_check_cache: Default::default(),
       fast_check_dts: true,
-      jsr_url_provider: Some(&JsrTestUrlProvider),
+      jsr_url_provider: Some(&PassthroughJsrUrlProvider),
       module_parser: Some(&module_analyzer.analyzer),
       resolver: None,
       npm_resolver: None,

--- a/api/src/npm/tests.rs
+++ b/api/src/npm/tests.rs
@@ -39,9 +39,10 @@ pub mod helpers {
     }
 
     pub fn url(&self) -> Url {
-      if !self.specifier.starts_with("file")
-        && !self.specifier.starts_with("http")
-        && !self.specifier.starts_with("npm")
+      if !self.specifier.starts_with("file:")
+        && !self.specifier.starts_with("http:")
+        && !self.specifier.starts_with("npm:")
+        && !self.specifier.starts_with("jsr:")
       {
         Url::parse(&format!("file:///{}", self.specifier)).unwrap()
       } else {

--- a/api/src/publish.rs
+++ b/api/src/publish.rs
@@ -1,9 +1,7 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 
-use crate::analysis::RegistryLoader;
 use crate::api::ApiError;
 use crate::buckets::Buckets;
 use crate::buckets::UploadTaskBody;
@@ -33,6 +31,7 @@ use crate::tarball::ProcessTarballOutput;
 use crate::util::decode_json;
 use crate::util::ApiResult;
 use crate::NpmUrl;
+use crate::RegistryUrl;
 use deno_semver::package::PackageReqReference;
 use hyper::Body;
 use hyper::Request;
@@ -55,13 +54,13 @@ pub async fn publish_handler(mut req: Request<Body>) -> ApiResult<()> {
   let db = req.data::<Database>().unwrap().clone();
   let buckets = req.data::<Buckets>().unwrap().clone();
   let orama_client = req.data::<Option<OramaClient>>().unwrap().clone();
-  let registry = req.data::<Arc<dyn RegistryLoader>>().unwrap().clone();
+  let registry_url = req.data::<RegistryUrl>().unwrap().0.clone();
   let npm_url = req.data::<NpmUrl>().unwrap().0.clone();
 
   publish_task(
     publishing_task_id,
     buckets,
-    registry,
+    registry_url,
     npm_url,
     db,
     orama_client,
@@ -73,13 +72,13 @@ pub async fn publish_handler(mut req: Request<Body>) -> ApiResult<()> {
 
 #[instrument(
   name = "publish_task",
-  skip(buckets, db, registry, orama_client),
+  skip(buckets, db, registry_url, orama_client),
   err
 )]
 pub async fn publish_task(
   publish_id: Uuid,
   buckets: Buckets,
-  registry: Arc<dyn RegistryLoader>,
+  registry_url: Url,
   npm_url: Url,
   db: Database,
   orama_client: Option<OramaClient>,
@@ -99,7 +98,7 @@ pub async fn publish_task(
         let res = process_publishing_task(
           &db,
           &buckets,
-          registry.clone(),
+          registry_url.clone(),
           &mut publishing_task,
         )
         .await;
@@ -153,7 +152,7 @@ pub async fn publish_task(
 async fn process_publishing_task(
   db: &Database,
   buckets: &Buckets,
-  registry: Arc<dyn RegistryLoader>,
+  registry_url: Url,
   publishing_task: &mut PublishingTask,
 ) -> Result<(), anyhow::Error> {
   *publishing_task = db
@@ -165,31 +164,32 @@ async fn process_publishing_task(
     )
     .await?;
 
-  let output = match process_tarball(buckets, registry, publishing_task).await {
-    Ok(output) => output,
-    Err(err) => match err.user_error_code() {
-      Some(code) => {
-        // non retryable, fatal error
-        error!("Error processing tarball, fatal: {}", err);
-        *publishing_task = db
-          .update_publishing_task_status(
-            publishing_task.id,
-            PublishingTaskStatus::Processing,
-            PublishingTaskStatus::Failure,
-            Some(PublishingTaskError {
-              code: code.to_owned(),
-              message: err.to_string(),
-            }),
-          )
-          .await?;
-        return Ok(());
-      }
-      None => {
-        // retryable errors
-        return Err(anyhow::Error::from(err));
-      }
-    },
-  };
+  let output =
+    match process_tarball(db, buckets, registry_url, publishing_task).await {
+      Ok(output) => output,
+      Err(err) => match err.user_error_code() {
+        Some(code) => {
+          // non retryable, fatal error
+          error!("Error processing tarball, fatal: {}", err);
+          *publishing_task = db
+            .update_publishing_task_status(
+              publishing_task.id,
+              PublishingTaskStatus::Processing,
+              PublishingTaskStatus::Failure,
+              Some(PublishingTaskError {
+                code: code.to_owned(),
+                message: err.to_string(),
+              }),
+            )
+            .await?;
+          return Ok(());
+        }
+        None => {
+          // retryable errors
+          return Err(anyhow::Error::from(err));
+        }
+      },
+    };
 
   let ProcessTarballOutput {
     file_infos,
@@ -501,7 +501,7 @@ pub mod tests {
     publish_task(
       task.id,
       t.buckets(),
-      t.registry(),
+      t.registry_url(),
       t.npm_url(),
       t.db(),
       None,
@@ -964,7 +964,7 @@ pub mod tests {
     assert_eq!(task.status, PublishingTaskStatus::Failure, "{task:#?}");
     let error = task.error.unwrap();
     assert_eq!(error.code, "invalidExternalImport");
-    assert_eq!(error.message, "invalid external import to 'https://deno.land/r/std/http/server.ts', only 'jsr:', 'npm:', 'data:' and 'node:' imports are allowed (non-JSR http(s) import)");
+    assert_eq!(error.message, "invalid external import to 'https://deno.land/r/std/http/server.ts', only 'jsr:', 'npm:', 'data:' and 'node:' imports are allowed (http(s) import)");
   }
 
   async fn uses_npm(t: &TestSetup, task: &crate::db::PublishingTask) -> bool {
@@ -1025,8 +1025,8 @@ pub mod tests {
     .await;
     assert_eq!(task.status, PublishingTaskStatus::Failure, "{task:#?}");
     let error = task.error.unwrap();
-    assert_eq!(error.code, "graphError");
-    assert_eq!(error.message, "failed to build module graph: Unknown package: @scope/foo\n  Specifier: jsr:@scope/foo@1\n    at file:///mod.ts:1:8");
+    assert_eq!(error.code, "unresolvableJsrDependency");
+    assert_eq!(error.message, "unresolvable 'jsr:' dependency: '@scope/foo@1', no published version matches the constraint");
   }
 
   #[tokio::test]

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -3,7 +3,6 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io;
-use std::sync::Arc;
 use std::sync::OnceLock;
 
 use async_tar::EntryType;
@@ -12,6 +11,7 @@ use deno_ast::MediaType;
 use deno_graph::ModuleGraphError;
 use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
+use deno_semver::package::PackageReq;
 use deno_semver::package::PackageReqReference;
 use deno_semver::package::PackageReqReferenceParseError;
 use futures::AsyncReadExt;
@@ -25,14 +25,15 @@ use sha2::Digest;
 use thiserror::Error;
 use tracing::instrument;
 use tracing::Span;
+use url::Url;
 use uuid::Uuid;
 
 use crate::analysis::analyze_package;
 use crate::analysis::PackageAnalysisData;
 use crate::analysis::PackageAnalysisOutput;
-use crate::analysis::RegistryLoader;
 use crate::buckets::Buckets;
 use crate::buckets::UploadTaskBody;
+use crate::db::Database;
 use crate::db::ExportsMap;
 use crate::db::PublishingTask;
 use crate::db::{DependencyKind, PackageVersionMeta};
@@ -45,6 +46,7 @@ use crate::gcs_paths::npm_tarball_path;
 use crate::ids::PackagePath;
 use crate::ids::PackagePathValidationError;
 use crate::ids::ScopedPackageName;
+use crate::ids::ScopedPackageNameValidateError;
 use crate::ids::Version;
 use crate::npm::NPM_TARBALL_REVISION;
 
@@ -75,12 +77,13 @@ pub struct NpmTarballInfo {
 
 #[instrument(
   name = "process_tarball",
-  skip(buckets, registry, publishing_task),
+  skip(buckets, registry_url, publishing_task),
   err
 )]
 pub async fn process_tarball(
+  db: &Database,
   buckets: &Buckets,
-  registry: Arc<dyn RegistryLoader>,
+  registry_url: Url,
   publishing_task: &PublishingTask,
 ) -> Result<ProcessTarballOutput, PublishError> {
   let tarball_path = gcs_tarball_path(publishing_task.id);
@@ -262,7 +265,7 @@ pub async fn process_tarball(
   } = tokio::task::spawn_blocking(|| {
     analyze_package(
       span,
-      registry,
+      registry_url,
       scope,
       package,
       version,
@@ -272,6 +275,54 @@ pub async fn process_tarball(
   })
   .await
   .unwrap()?;
+
+  // ensure all of the JSR dependencies are resolvable
+  for (kind, req) in dependencies.iter() {
+    if kind == &DependencyKind::Jsr {
+      let package_scope = ScopedPackageName::new(req.req.name.clone())
+        .map_err(|e| {
+          PublishError::InvalidJsrScopedPackageName(req.req.name.clone(), e)
+        })?;
+
+      let mut versions = db
+        .list_package_versions(&package_scope.scope, &package_scope.package)
+        .await?
+        .into_iter()
+        .map(|v| v.0)
+        .collect::<Vec<_>>();
+      versions.sort_by_cached_key(|v| v.version.clone());
+
+      let mut found = false;
+      for version in versions.iter().rev() {
+        if req.req.version_req.matches(&version.version.0) {
+          let exports_key = if let Some(sub_path) = &req.sub_path {
+            if sub_path.is_empty() {
+              ".".to_owned()
+            } else {
+              format!("./{}", sub_path)
+            }
+          } else {
+            ".".to_owned()
+          };
+
+          if !version.exports.contains_key(&exports_key) {
+            return Err(PublishError::InvalidJsrDependencySubPath {
+              req: req.clone(),
+              resolved_version: version.version.clone(),
+              exports_key,
+            });
+          }
+
+          found = true;
+          break;
+        }
+      }
+
+      if !found {
+        return Err(PublishError::UnresolvableJsrDependency(req.req.clone()));
+      }
+    }
+  }
 
   // TO ENSURE CONSISTENCY OF FILES IN GCS, ALL ERRORS RETURNED AFTER THIS POINT MUST BE RETRYABLE
 
@@ -408,6 +459,9 @@ pub enum PublishError {
   #[error("untar error: {0}")]
   UntarError(io::Error),
 
+  #[error("database error")]
+  DatabaseError(#[from] sqlx::Error),
+
   #[error(
     "entry at '{path}' is a link, only regular files and directories are allowed"
   )]
@@ -521,6 +575,19 @@ pub enum PublishError {
 
   #[error("specifier '{0}' is missing a version constraint")]
   NpmMissingConstraint(NpmPackageReqReference),
+
+  #[error("invalid scoped package name in 'jsr:' specifier '{0}': {1}")]
+  InvalidJsrScopedPackageName(String, ScopedPackageNameValidateError),
+
+  #[error("unresolvable 'jsr:' dependency: '{0}', no published version matches the constraint")]
+  UnresolvableJsrDependency(PackageReq),
+
+  #[error("invalid 'jsr:' dependency subpath: '{req}', resolved to {resolved_version}, has no export '{exports_key}'")]
+  InvalidJsrDependencySubPath {
+    req: PackageReqReference,
+    resolved_version: Version,
+    exports_key: String,
+  },
 }
 
 impl PublishError {
@@ -532,6 +599,7 @@ impl PublishError {
       PublishError::GcsUploadError(_) => None,
       PublishError::UntarError(_) => None,
       PublishError::MissingTarball => None,
+      PublishError::DatabaseError(_) => None,
       PublishError::LinkInTarball { .. } => Some("linkInTarball"),
       PublishError::InvalidEntryType { .. } => Some("invalidEntryType"),
       PublishError::InvalidPath { .. } => Some("invalidPath"),
@@ -569,6 +637,15 @@ impl PublishError {
       PublishError::InvalidNpmSpecifier(_) => Some("invalidNpmSpecifier"),
       PublishError::JsrMissingConstraint(_) => Some("jsrMissingConstraint"),
       PublishError::NpmMissingConstraint(_) => Some("npmMissingConstraint"),
+      PublishError::InvalidJsrScopedPackageName(_, _) => {
+        Some("invalidJsrScopedPackageName")
+      }
+      PublishError::UnresolvableJsrDependency(_) => {
+        Some("unresolvableJsrDependency")
+      }
+      PublishError::InvalidJsrDependencySubPath { .. } => {
+        Some("invalidJsrDependencySubPath")
+      }
     }
   }
 }

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -307,7 +307,7 @@ pub async fn process_tarball(
 
           if !version.exports.contains_key(&exports_key) {
             return Err(PublishError::InvalidJsrDependencySubPath {
-              req: req.clone(),
+              req: Box::new(req.clone()),
               resolved_version: version.version.clone(),
               exports_key,
             });
@@ -556,7 +556,7 @@ pub enum PublishError {
   },
 
   #[error("failed to build module graph: {}", .0.to_string_with_range())]
-  GraphError(ModuleGraphError),
+  GraphError(Box<ModuleGraphError>),
 
   #[error("failed to generate documentation: {0:?}")]
   DocError(anyhow::Error),
@@ -584,7 +584,7 @@ pub enum PublishError {
 
   #[error("invalid 'jsr:' dependency subpath: '{req}', resolved to {resolved_version}, has no export '{exports_key}'")]
   InvalidJsrDependencySubPath {
-    req: PackageReqReference,
+    req: Box<PackageReqReference>,
     resolved_version: Version,
     exports_key: String,
   },

--- a/api/testdata/specs/npm_tarballs/import_jsr.txt
+++ b/api/testdata/specs/npm_tarballs/import_jsr.txt
@@ -29,26 +29,7 @@ await import("jsr:@luca/flag@1")
   }
 }
 
-# http://jsr.test/@luca/flag/meta.json
-{
-  "scope": "luca",
-  "name": "flag",
-  "latest": "1.0.0",
-  "versions": {
-    "1.0.0": {}
-  }
-}
-
-# http://jsr.test/@luca/flag/1.0.0_meta.json
-{
-  "manifest": {
-  },
-  "exports": {
-    ".": "./main.ts"
-  }
-}
-
-# http://jsr.test/@luca/flag/1.0.0/main.ts
+# jsr:@luca/flag@1
 <external>
 
 # output


### PR DESCRIPTION
This cleans up a lot of code because we do not have to ensure during graph building that all JSR dependencies resolve correctly.

This is also a fix for the stuck npm tarball rebuilds that are caused by users making semver incompatible changes to their `exports` maps.
