### PR TITLE
docs: fix heading hierarchy in FAQ page

### DIFF
--- a/frontend/docs/faq.md
+++ b/frontend/docs/faq.md
@@ -3,7 +3,7 @@ title: Frequently Asked Questions
 description: Answers to frequently asked questions about JSR.
 ---
 
-### What is JSR?
+## What is JSR?
 
 JSR is a new package registry for JavaScript. It is a free alternative to npm,
 that is designed to work well with all JavaScript tools and runtimes, like
@@ -11,7 +11,7 @@ Node.js, Deno, Bun, Vite, and more.
 
 [Learn more about why we built JSR.](/docs/why)
 
-### How do I use JSR?
+## How do I use JSR?
 
 If you want to consume packages, read the [Using packages](/docs/using-packages)
 guide.
@@ -19,18 +19,18 @@ guide.
 If you want to publish packages, read the
 [Publishing packages](/docs/publishing-packages) guide.
 
-### Is JSR a package manager like `npm`, `yarn`, or `pnpm`?
+## Is JSR a package manager like `npm`, `yarn`, or `pnpm`?
 
 No. JSR is a package registry (the server storing the packages), not a package
 manager (the tool that installs packages). You can use existing package managers
 like `npm`, `yarn`, or `pnpm` with JSR.
 
-### Is JSR open source?
+## Is JSR open source?
 
 Yes. JSR is open source and licensed under the MIT License. You can find the
 source code on [GitHub](https://github.com/jsr-io/jsr).
 
-### How is JSR different from npm?
+## How is JSR different from npm?
 
 JSR is designed to be a superset of npm, allowing existing tools that use npm to
 seamlessly work with JSR. JSR is designed to be better than npm:
@@ -43,7 +43,7 @@ seamlessly work with JSR. JSR is designed to be better than npm:
 - Secure, token-less publishing for resistance against supply chain attacks
 - and more... [Learn more about why we built JSR.](/docs/why)
 
-### How is JSR funded? / Do I have to pay for JSR?
+## How is JSR funded? / Do I have to pay for JSR?
 
 JSR is designed to be a public good for the JavaScript community, and will thus
 always be free to use.
@@ -54,7 +54,7 @@ alternative means, like sponsorships, donations, or a foundation. We expect that
 the Deno Company will be able to continue paying for JSR's hosting bills for the
 foreseeable future - JSR is designed to be very cheap to run.
 
-### Can I delete a package from JSR?
+## Can I delete a package from JSR?
 
 Source code published to JSR can not be deleted.
 [Learn more about immutability.](/docs/immutability)
@@ -66,14 +66,14 @@ default view, but it will still be available to users who depend on it.
 You may delete a package if it has no published versions.
 [Learn more about deleting empty packages.](/docs/packages#deleting-a-package)
 
-### Why are there quotas for scopes and package versions on JSR?
+## Why are there quotas for scopes and package versions on JSR?
 
 To prevent abuse, JSR has quotas for scopes and package versions. These quotas
 are designed to be generous and should not affect your normal usage. If you need
 a quota increase, please reach out to us at quotas@jsr.io - we will happily
 increase your quota if you run into it.
 
-### What is JSR's policy on name squatting?
+## What is JSR's policy on name squatting?
 
 We disallow name squatting on JSR. We define name squatting as the act of
 registering a scope / package name with no intention of using it, or to prevent
@@ -81,7 +81,7 @@ someone with a legitimate use from using it (e.g. to sell it to them).
 
 [Learn more about the JSR usage policy](/docs/usage-policy).
 
-### How do I report a security vulnerability in JSR?
+## How do I report a security vulnerability in JSR?
 
 Please follow the Deno Company's
 [security policy](https://docs.deno.com/deploy/manual/security) to report
@@ -91,7 +91,7 @@ You may also report security vulnerabilities in individual packages to the
 package's scope owner. If the scope owner is unresponsive, please reach out to
 us at security@jsr.io.
 
-### How do I report a bug in JSR?
+## How do I report a bug in JSR?
 
 > During the open beta, please email us at help@jsr.io, or chat in the `#jsr`
 > channel on the Deno Discord (https://discord.gg/deno).
@@ -99,7 +99,7 @@ us at security@jsr.io.
 Please open an issue on the JSR GitHub repository at
 [jsr-io/jsr](https://github.com/jsr-io/jsr).
 
-### Why does JSR ask to "Act on your behalf" when I log in with GitHub?
+## Why does JSR ask to "Act on your behalf" when I log in with GitHub?
 
 When signing in with GitHub, GitHub presents you with a screen that asks for
 your permission to authorize JSR. This screen includes a list of resources that


### PR DESCRIPTION
It's best practice to not skip heading levels in the hierarchy.