### PR TITLE
fix: don't ban triple slash references inside of jsdoc comments

### DIFF
--- a/api/src/publish.rs
+++ b/api/src/publish.rs
@@ -1133,6 +1133,14 @@ pub mod tests {
   }
 
   #[tokio::test]
+  async fn triple_slash_reference_in_jsdoc() {
+    let t = TestSetup::new().await;
+    let bytes = create_mock_tarball("triple_slash_reference_in_jsdoc");
+    let task = process_tarball_setup(&t, bytes).await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{task:#?}");
+  }
+
+  #[tokio::test]
   async fn npm_tarball() {
     let t = TestSetup::new().await;
     let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -300,7 +300,7 @@ pub async fn process_tarball(
               ".".to_owned()
             } else {
               format!("./{}", sub_path)
-            } 
+            }
           } else {
             ".".to_owned()
           };

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -300,7 +300,7 @@ pub async fn process_tarball(
               ".".to_owned()
             } else {
               format!("./{}", sub_path)
-            }
+            } 
           } else {
             ".".to_owned()
           };

--- a/api/testdata/tarballs/triple_slash_reference_in_jsdoc/jsr.json
+++ b/api/testdata/tarballs/triple_slash_reference_in_jsdoc/jsr.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/foo",
+  "version": "1.2.3",
+  "exports": "./mod.ts"
+}

--- a/api/testdata/tarballs/triple_slash_reference_in_jsdoc/mod.ts
+++ b/api/testdata/tarballs/triple_slash_reference_in_jsdoc/mod.ts
@@ -1,0 +1,21 @@
+export class Test {
+  /**
+   * Executes the given function or string whose first argument is a DOM element and returns the result of the execution.
+   *
+   * @example
+   * ```ts
+   * /// <reference lib="dom" />
+   * const value: string = await element.evaluate((element: HTMLInputElement) => element.value)
+   * ```
+   *
+   * @example
+   * ```
+   * /// <reference lib="dom" />
+   * await element.evaluate(
+   *  (el: HTMLInputElement, key: string, value: string) => el.setAttribute(key, value),
+   *  { args: ["href", "astral"] }
+   * )
+   * ```
+   */
+  async test(): Promise<void> {}
+}


### PR DESCRIPTION
Fixes #409