### PR TITLE
fix: header alignment refinement + nav link style

### DIFF
--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -40,7 +40,7 @@ export function RuntimeCompatIndicator(
             ) return null;
             return (
               <div
-                class="relative h-5"
+                class="relative h-4 md:h-5"
                 style={`aspect-ratio: ${w} / ${h}`}
                 title={`${
                   value === undefined
@@ -58,14 +58,14 @@ export function RuntimeCompatIndicator(
                   width={w}
                   height={h}
                   alt=""
-                  class={`h-5 select-none ${
+                  class={`h-4 md:h-5 select-none ${
                     value === undefined ? "filter grayscale opacity-40" : ""
                   }`}
                 />
                 {value === undefined && (
                   <div
                     aria-hidden="true"
-                    class="absolute inset-0 h-full w-full text-blue-700 text-center leading-5 drop-shadow-md font-bold text-xl select-none"
+                    class="absolute inset-0 h-full w-full text-jsr-cyan-600 text-center leading-4 md:leading-5 drop-shadow-md font-bold text-md md:text-xl select-none"
                   >
                     ?
                   </div>

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -67,26 +67,28 @@ export function PackageHeader(
         <div class="space-y-3.5 flex-shrink">
           <div class="flex flex-row gap-x-3 gap-y-2 flex-wrap md:items-center">
             <h1 class="text-2xl md:text-3xl flex flex-wrap items-center font-sans gap-x-2">
-              <span>
-                <a
-                  href={`/@${pkg.scope}`}
-                  class="link font-bold no-underline"
-                >
-                  @{pkg.scope}
-                </a>/<span class="font-semibold">
-                  {pkg.name}
-                </span>
-              </span>
-
-              {selectedVersion &&
-                (
-                  <span class="text-lg md:text-[0.75em] font-bold">
-                    <span class="relative text-[0.85em] -top-[0.175em] font-[800]">
-                      @
-                    </span>
-                    {selectedVersion.version}
+              <div class="flex items-baseline gap-x-1">
+                <span>
+                  <a
+                    href={`/@${pkg.scope}`}
+                    class="link font-bold no-underline"
+                  >
+                    @{pkg.scope}
+                  </a>/<span class="font-semibold">
+                    {pkg.name}
                   </span>
-                )}
+                </span>
+
+                {selectedVersion &&
+                  (
+                    <span class="text-lg md:text-[0.75em] font-bold">
+                      <span class="relative text-[0.80em] -top-[0.175em] font-[800]">
+                        @
+                      </span>
+                      {selectedVersion.version}
+                    </span>
+                  )}
+              </div>
 
               {selectedVersion?.rekorLogId && (
                 <Tooltip tooltip="Built and signed on GitHub Actions">
@@ -134,7 +136,7 @@ export function PackageHeader(
           <div class="flex flex-col md:flex-row gap-2 md:gap-8 items-between">
             {runtimeCompat &&
               (
-                <div class="flex flex-row md:flex-col items-center md:items-end gap-2 md:gap-1 text-sm font-bold">
+                <div class="flex flex-row md:flex-col items-center md:items-end gap-2 md:gap-1.5 text-sm font-bold">
                   <div>Works with</div>
                   {runtimeCompat}
                 </div>
@@ -142,11 +144,15 @@ export function PackageHeader(
 
             {pkg.score !== null && (
               <a
-                class="flex flex-row md:flex-col items-baseline md:items-end gap-2 md:gap-1 text-sm font-bold"
+                class="flex flex-row md:flex-col items-baseline md:items-end gap-2 md:gap-1.5 text-sm font-bold"
                 href={`/@${pkg.scope}/${pkg.name}/score`}
               >
                 <div>JSR Score</div>
-                <div class={`md:text-xl ${getScoreTextColorClass(pkg.score)}`}>
+                <div
+                  class={`!leading-none md:text-xl ${
+                    getScoreTextColorClass(pkg.score)
+                  }`}
+                >
                   {pkg.score}%
                 </div>
               </a>
@@ -155,10 +161,10 @@ export function PackageHeader(
 
           <div>
             {selectedVersion?.createdAt && (
-              <div class="flex flex-row md:flex-col gap-2 md:gap-1 text-sm font-bold">
+              <div class="flex flex-row items-baseline md:flex-col gap-2 md:gap-1.5 text-sm font-bold">
                 <div>Published</div>
                 <div
-                  class="font-normal"
+                  class="leading-none font-normal"
                   title={new Date(selectedVersion.createdAt).toISOString()
                     .slice(
                       0,

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -139,7 +139,7 @@
   }
 
   .link-header {
-    @apply link opsize-sm font-medium hover:underline-offset-2;
+    @apply link opsize-sm font-medium decoration-jsr-cyan-700/25 hover:decoration-jsr-cyan-700 underline-offset-2;
   }
 
   .input-container {


### PR DESCRIPTION
A few random alignment things I noticed while playing around with package header to make the spacing between elements the same whether it's an image or text in the package header.

I also updated the nav links with the new underline style we're planning to use for the new breadcrumbs as I think it makes sense to use that style there as well as they serve a similar role (links as UI navigation rather than in-text links)

<img width="493" alt="Screenshot 2024-04-19 at 3 46 12 PM" src="https://github.com/jsr-io/jsr/assets/776987/ad63ed98-8489-4187-92dd-490d81a07b5a">
<img width="1230" alt="Screenshot 2024-04-19 at 3 44 51 PM" src="https://github.com/jsr-io/jsr/assets/776987/79741111-9b80-4129-8195-5ddde061dcaf">
