### PR TITLE
fix(frontend): add links to the settings page in the score page

### DIFF
--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -61,6 +61,7 @@ export default function Score(
             name={data.package.name}
             scorePercentage={data.package.score}
             score={data.score}
+            canAdmin={iam.canAdmin}
           />
         )
         : (
@@ -78,8 +79,9 @@ function ScoreInfo(props: {
   name: string;
   scorePercentage: number;
   score: PackageScore;
+  canAdmin: boolean;
 }) {
-  const { scope, name, scorePercentage, score } = props;
+  const { scope, name, scorePercentage, score, canAdmin } = props;
 
   return (
     <div class="mt-8 grid items-center justify-items-center grid-cols-1 md:grid-cols-3 gap-12">
@@ -173,8 +175,14 @@ function ScoreInfo(props: {
           scoreValue={1}
           title="Has a description"
         >
-          The package should have a description set in the package settings to
-          help users find this package via search.
+          The package should have a description set in {canAdmin
+            ? (
+              <a class="link" href="settings#description">
+                the package settings
+              </a>
+            )
+            : "the package settings"}{" "}
+          to help users find this package via search.
         </ScoreItem>
         <ScoreItem
           value={score.atLeastOneRuntimeCompatible}
@@ -182,8 +190,14 @@ function ScoreInfo(props: {
           title="At least one runtime is marked as compatible"
         >
           The package should be marked with at least one runtime as "compatible"
-          in the package settings to aid users in understanding where they can
-          use this package.
+          in {canAdmin
+            ? (
+              <a class="link" href="settings#runtime_compat">
+                the package settings
+              </a>
+            )
+            : "the package settings"}{" "}
+          to aid users in understanding where they can use this package.
         </ScoreItem>
         <ScoreItem
           value={score.multipleRuntimesCompatible}
@@ -191,7 +205,13 @@ function ScoreInfo(props: {
           title="At least two runtimes are marked as compatible"
         >
           The package should be compatible with more than one runtime, and be
-          marked as such in the package settings.
+          marked as such in {canAdmin
+            ? (
+              <a class="link" href="settings#runtime_compat">
+                the package settings
+              </a>
+            )
+            : "the package settings"}.
         </ScoreItem>
         <ScoreItem
           value={score.hasProvenance}

--- a/frontend/routes/package/settings.tsx
+++ b/frontend/routes/package/settings.tsx
@@ -100,7 +100,7 @@ function GitHubRepository(props: { package: Package }) {
 function DescriptionEditor(props: { description: string }) {
   return (
     <form class="mt-8" method="POST">
-      <h2 class="text-xl font-sans font-bold">Description</h2>
+      <h2 class="text-xl font-sans font-bold" id="description">Description</h2>
 
       <p class="mt-2 text-gray-600 max-w-3xl">
         The package description is shown on the package page and in search
@@ -117,7 +117,9 @@ function DescriptionEditor(props: { description: string }) {
 function RuntimeCompatEditor(props: { runtimeCompat: RuntimeCompat }) {
   return (
     <form class="border-t pt-8 mt-12" method="POST">
-      <h2 class="text-xl font-sans font-bold">Runtime Compat</h2>
+      <h2 class="text-xl font-sans font-bold" id="runtime_compat">
+        Runtime Compat
+      </h2>
 
       <p class="mt-2 text-gray-600 max-w-3xl">
         Set which packages this package is compatible with. This information is


### PR DESCRIPTION
This PR adds links to the settings page in the score page.

Closes #423 


Before:

<img width="830" alt="image" src="https://github.com/jsr-io/jsr/assets/3132889/cff9ef0e-4e12-4491-a4c2-2c563b5b3783">

After(with admin role): 

<img width="841" alt="image" src="https://github.com/jsr-io/jsr/assets/3132889/12d3791d-e193-498c-9df9-5b1dc4f74053">

After(without admin role): 

<img width="830" alt="image" src="https://github.com/jsr-io/jsr/assets/3132889/71a17259-cd0f-4078-9d2f-385c8fe4b99d">

