### PR TITLE
fix: right alignment on publish and signed out link style

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -106,7 +106,7 @@ export function Header({
             {user
               ? <UserMenu user={user} sudo={sudo} logoutUrl={logoutUrl} />
               : (
-                <a href={loginUrl} class="link flex items-center gap-2">
+                <a href={loginUrl} class="link-header flex items-center gap-2">
                   <GitHub class="size-5 flex-none" />
                   Sign in
                 </a>

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -161,7 +161,7 @@ export function PackageHeader(
 
           <div>
             {selectedVersion?.createdAt && (
-              <div class="flex flex-row items-baseline md:flex-col gap-2 md:gap-1.5 text-sm font-bold">
+              <div class="flex flex-row items-baseline md:items-end md:flex-col gap-2 md:gap-1.5 text-sm font-bold">
                 <div>Published</div>
                 <div
                   class="leading-none font-normal"


### PR DESCRIPTION
two small style fixes I missed on a recent PR. The text on Published was not right aligned and the sign in button didn't get the same link styles as the other link. 

<img width="401" alt="Screenshot 2024-04-22 at 11 00 40 AM" src="https://github.com/jsr-io/jsr/assets/776987/1383a6c0-550f-498f-8444-8813dcc6d751">
