### PR TITLE
fix: don't reference .ts source in package.json types

### DIFF
--- a/api/.sqlx/query-4d1bd2eec86b947f3af850587ba6b1c1e95f030a6e9384b1c3ec510c04ec72d9.json
+++ b/api/.sqlx/query-4d1bd2eec86b947f3af850587ba6b1c1e95f030a6e9384b1c3ec510c04ec72d9.json
@@ -27,7 +27,8 @@
             "kind": {
               "Enum": [
                 "web",
-                "device"
+                "device",
+                "personal"
               ]
             }
           }

--- a/api/.sqlx/query-5201b8729ba43beca8c9749e6d797c83a4c323d0a3e2720ceedac9cea7010ec9.json
+++ b/api/.sqlx/query-5201b8729ba43beca8c9749e6d797c83a4c323d0a3e2720ceedac9cea7010ec9.json
@@ -27,7 +27,8 @@
             "kind": {
               "Enum": [
                 "web",
-                "device"
+                "device",
+                "personal"
               ]
             }
           }
@@ -69,7 +70,8 @@
             "kind": {
               "Enum": [
                 "web",
-                "device"
+                "device",
+                "personal"
               ]
             }
           }

--- a/api/migrations/20240422122600_personal_access_token.sql
+++ b/api/migrations/20240422122600_personal_access_token.sql
@@ -1,0 +1,1 @@
+ALTER TYPE token_type ADD VALUE 'personal';

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -29,7 +29,7 @@ pub use self::tarball::NpmTarballOptions;
 pub use self::types::NpmMappedJsrPackageName;
 use self::types::NpmVersionInfo;
 
-pub const NPM_TARBALL_REVISION: u32 = 8;
+pub const NPM_TARBALL_REVISION: u32 = 9;
 
 pub async fn generate_npm_version_manifest<'a>(
   db: &Database,

--- a/api/src/npm/specifiers.rs
+++ b/api/src/npm/specifiers.rs
@@ -83,20 +83,20 @@ pub fn follow_specifier<'a>(
   remapped_specifiers: &'a HashMap<&ModuleSpecifier, ModuleSpecifier>,
 ) -> Option<&'a ModuleSpecifier> {
   let mut redirects = 0;
-  let mut types_specifier = specifier;
+  let mut specifier = specifier;
   loop {
     // avoid infinite loops
     if redirects > 10 {
       return None;
     }
-    if let Some(rewritten) = remapped_specifiers.get(&types_specifier) {
-      types_specifier = rewritten;
+    if let Some(rewritten) = remapped_specifiers.get(&specifier) {
+      specifier = rewritten;
     } else {
       break;
     }
     redirects += 1;
   }
-  Some(types_specifier)
+  Some(specifier)
 }
 
 pub fn rewrite_npm_and_jsr_specifier(specifier: &str) -> Option<String> {

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -154,7 +154,7 @@ pub async fn create_npm_tarball<'a>(
       deno_ast::MediaType::TypeScript | deno_ast::MediaType::Mts => {
         let source_specifier =
           rewrite_file_specifier_extension(module.specifier(), Extension::Js);
-        if let Some(source_specifier) = source_specifier {
+        if let Some(source_specifier) = source_specifier.clone() {
           source_rewrites.insert(module.specifier(), source_specifier);
         }
 
@@ -166,6 +166,10 @@ pub async fn create_npm_tarball<'a>(
           if let Some(declaration_specifier) = declaration_specifier {
             declaration_rewrites
               .insert(module.specifier(), declaration_specifier);
+          }
+        } else {
+          if let Some(source_specifier) = source_specifier {
+            declaration_rewrites.insert(module.specifier(), source_specifier);
           }
         }
       }

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -167,10 +167,8 @@ pub async fn create_npm_tarball<'a>(
             declaration_rewrites
               .insert(module.specifier(), declaration_specifier);
           }
-        } else {
-          if let Some(source_specifier) = source_specifier {
-            declaration_rewrites.insert(module.specifier(), source_specifier);
-          }
+        } else if let Some(source_specifier) = source_specifier {
+          declaration_rewrites.insert(module.specifier(), source_specifier);
         }
       }
       _ => {}

--- a/api/testdata/specs/npm_tarballs/slow_types_transpile.txt
+++ b/api/testdata/specs/npm_tarballs/slow_types_transpile.txt
@@ -1,0 +1,40 @@
+# main.ts
+export const foo = bar();
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./main.ts"
+}
+
+# output
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./main.ts"
+}
+
+== /main.js ==
+export const foo = bar();
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1haW4udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxNQUFNLE1BQU0sTUFBTSJ9
+
+== /main.ts ==
+export const foo = bar();
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "1.0.0",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "default": "./main.js"
+    }
+  },
+  "_jsr_revision": 0
+}
+


### PR DESCRIPTION
This was happening for packages that had slow types.

Fixes #446 