### PR TITLE
fix: emit .d.ts and .js files into _dist folder and other fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,9 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -1145,6 +1148,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019d17f2c2457c5a70a7cf4505b1a562ca8ab168c0ac0c005744efbd29fcb8fe"
 dependencies = [
+ "allocator-api2",
+ "bumpalo",
  "num-bigint",
  "rustc-hash",
  "swc_atoms",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -79,7 +79,7 @@ flate2 = "1"
 thiserror = "1"
 async-tar = "0.4.2"
 deno_graph = "0.74.1"
-deno_ast = "0.38.1"
+deno_ast = { version = "0.38.1", features = ["view"] }
 deno_doc = { version = "0.128.0", features = ["tree-sitter"] }
 comrak = { version = "0.20.0", default-features = false }
 async-trait = "0.1.73"

--- a/api/src/npm/emit.rs
+++ b/api/src/npm/emit.rs
@@ -9,8 +9,10 @@ use deno_ast::SourceMap;
 use deno_ast::SourceMapOption;
 use deno_ast::TranspileOptions;
 use deno_graph::FastCheckTypeModule;
+use url::Url;
 
 use crate::npm::import_transform::ImportRewriteTransformer;
+use crate::npm::specifiers::relative_import_specifier;
 
 use super::specifiers::RewriteKind;
 use super::specifiers::SpecifierRewriter;
@@ -18,15 +20,18 @@ use super::specifiers::SpecifierRewriter;
 pub fn transpile_to_js(
   source: &ParsedSource,
   specifier_rewriter: SpecifierRewriter,
-) -> Result<String, anyhow::Error> {
+  target_specifier: &Url,
+) -> Result<(String, String), anyhow::Error> {
+  let basename = target_specifier.path().rsplit_once('/').unwrap().1;
   let emit_options = deno_ast::EmitOptions {
-    source_map: SourceMapOption::Inline,
-    source_map_file: None,
+    source_map: SourceMapOption::Separate,
+    source_map_file: Some(basename.to_owned()),
     inline_sources: false,
     keep_comments: true,
   };
 
-  let file_name = source.specifier().path().split('/').last().unwrap();
+  let file_name =
+    relative_import_specifier(target_specifier, source.specifier());
   let source_map =
     SourceMap::single(file_name, source.text_info().text_str().to_owned());
 
@@ -60,9 +65,16 @@ pub fn transpile_to_js(
       source.diagnostics(),
     )?;
 
-    let emitted = emit(&program, &comments, &source_map, &emit_options)?;
+    let EmittedSource {
+      mut text,
+      source_map,
+    } = emit(&program, &comments, &source_map, &emit_options)?;
+    if !text.ends_with('\n') {
+      text.push('\n');
+    }
+    text.push_str(format!("//# sourceMappingURL={}.map", basename).as_str());
 
-    Ok(emitted.text)
+    Ok((text, source_map.unwrap()))
   })
 }
 
@@ -70,17 +82,20 @@ pub fn transpile_to_dts(
   source: &ParsedSource,
   fast_check_module: &FastCheckTypeModule,
   specifier_rewriter: SpecifierRewriter,
-) -> Result<String, anyhow::Error> {
+  target_specifier: &Url,
+) -> Result<(String, String), anyhow::Error> {
   let dts = fast_check_module.dts.as_ref().unwrap();
 
+  let basename = target_specifier.path().rsplit_once('/').unwrap().1;
   let emit_options = deno_ast::EmitOptions {
-    source_map: SourceMapOption::Inline,
-    source_map_file: None,
+    source_map: SourceMapOption::Separate,
+    source_map_file: Some(basename.to_owned()),
     inline_sources: false,
     keep_comments: true,
   };
 
-  let file_name = source.specifier().path().split('/').last().unwrap();
+  let file_name =
+    relative_import_specifier(target_specifier, source.specifier());
   let source_map =
     SourceMap::single(file_name, source.text_info().text_str().to_owned());
 
@@ -94,8 +109,14 @@ pub fn transpile_to_dts(
   };
   program.visit_mut_with(&mut import_rewrite_transformer);
 
-  let EmittedSource { text, .. } =
-    emit(&program, &comments, &source_map, &emit_options)?;
+  let EmittedSource {
+    mut text,
+    source_map,
+  } = emit(&program, &comments, &source_map, &emit_options)?;
+  if !text.ends_with('\n') {
+    text.push('\n');
+  }
+  text.push_str(format!("//# sourceMappingURL={}.map", basename).as_str());
 
-  Ok(text)
+  Ok((text, source_map.unwrap()))
 }

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -29,7 +29,7 @@ pub use self::tarball::NpmTarballOptions;
 pub use self::types::NpmMappedJsrPackageName;
 use self::types::NpmVersionInfo;
 
-pub const NPM_TARBALL_REVISION: u32 = 9;
+pub const NPM_TARBALL_REVISION: u32 = 10;
 
 pub async fn generate_npm_version_manifest<'a>(
   db: &Database,

--- a/api/src/npm/specifiers.rs
+++ b/api/src/npm/specifiers.rs
@@ -1,5 +1,6 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use deno_ast::ModuleSpecifier;
@@ -40,7 +41,8 @@ impl<'a> SpecifierRewriter<'a> {
       RewriteKind::Declaration => self.declaration_rewrites,
     };
 
-    let resolved_specifier = follow_specifier(specifier, rewrites)?;
+    let mut resolved_specifier =
+      Cow::Borrowed(follow_specifier(specifier, rewrites)?);
 
     if let Some(specifier) =
       rewrite_npm_and_jsr_specifier(resolved_specifier.as_str())
@@ -48,14 +50,32 @@ impl<'a> SpecifierRewriter<'a> {
       return Some(specifier);
     };
 
-    if resolved_specifier == specifier {
+    if matches!(kind, RewriteKind::Declaration)
+      && resolved_specifier.scheme() == "file"
+    {
+      let path = resolved_specifier.path();
+      if path.ends_with(".d.ts") || path.ends_with(".d.mts") {
+        // If the base specifier is a declaration file, and a dependency is also a
+        // declaration file, TypeScript will not allow the import (TS2846). In
+        // this case, replace the `.d.ts` extension in the resolved specifier
+        // with `.js` so that TypeScript thinks we're importing a source file,
+        // which is allowed. It will then probe for the `.d.ts` file, which it
+        // will find.
+        // We do not use extensionless imports, because TypeScript does not
+        // allow them under `moduleResolution: "nodenext"` (TS2835).
+        let path = rewrite_path_extension(path, Extension::Js).unwrap();
+        resolved_specifier.to_mut().set_path(&path);
+      }
+    }
+
+    if *resolved_specifier == *specifier {
       // No need to rewrite if the specifier is the same as the resolved
       // specifier.
       return None;
     }
 
     let new_specifier = if resolved_specifier.scheme() == "file" {
-      relative_import_specifier(self.base_specifier, resolved_specifier)
+      relative_import_specifier(self.base_specifier, &resolved_specifier)
     } else {
       resolved_specifier.to_string()
     };
@@ -142,14 +162,18 @@ pub enum Extension {
   Dts,
 }
 
-pub fn rewrite_file_specifier_extension(
+pub fn rewrite_file_specifier(
   specifier: &ModuleSpecifier,
+  prefix: &str,
   new_extension: Extension,
 ) -> Option<ModuleSpecifier> {
   assert_eq!(specifier.scheme(), "file");
   let path = specifier.path();
   let rewritten_path = rewrite_path_extension(path, new_extension)?;
-  Some(ModuleSpecifier::parse(&format!("file://{}", rewritten_path)).unwrap())
+  Some(
+    ModuleSpecifier::parse(&format!("file://{prefix}{rewritten_path}"))
+      .unwrap(),
+  )
 }
 
 pub fn rewrite_path_extension(

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -38,7 +38,7 @@ use super::emit::transpile_to_dts;
 use super::emit::transpile_to_js;
 use super::specifiers::follow_specifier;
 use super::specifiers::relative_import_specifier;
-use super::specifiers::rewrite_file_specifier_extension;
+use super::specifiers::rewrite_file_specifier;
 use super::specifiers::Extension;
 use super::specifiers::RewriteKind;
 use super::specifiers::SpecifierRewriter;
@@ -136,7 +136,7 @@ pub async fn create_npm_tarball<'a>(
       }
       deno_ast::MediaType::Jsx => {
         let source_specifier =
-          rewrite_file_specifier_extension(module.specifier(), Extension::Js);
+          rewrite_file_specifier(module.specifier(), "/_dist", Extension::Js);
         if let Some(source_specifier) = source_specifier {
           source_rewrites.insert(module.specifier(), source_specifier);
         }
@@ -153,14 +153,15 @@ pub async fn create_npm_tarball<'a>(
       }
       deno_ast::MediaType::TypeScript | deno_ast::MediaType::Mts => {
         let source_specifier =
-          rewrite_file_specifier_extension(module.specifier(), Extension::Js);
+          rewrite_file_specifier(module.specifier(), "/_dist", Extension::Js);
         if let Some(source_specifier) = source_specifier.clone() {
           source_rewrites.insert(module.specifier(), source_specifier);
         }
 
         if js.fast_check_module().is_some() {
-          let declaration_specifier = rewrite_file_specifier_extension(
+          let declaration_specifier = rewrite_file_specifier(
             module.specifier(),
+            "/_dist",
             Extension::Dts,
           );
           if let Some(declaration_specifier) = declaration_specifier {
@@ -178,19 +179,18 @@ pub async fn create_npm_tarball<'a>(
   }
 
   for js in to_be_rewritten {
-    let specifier_rewriter = SpecifierRewriter {
-      base_specifier: &js.specifier,
-      source_rewrites: &source_rewrites,
-      declaration_rewrites: &declaration_rewrites,
-      dependencies: &js.dependencies,
-    };
-
     match js.media_type {
       deno_ast::MediaType::JavaScript | deno_ast::MediaType::Mjs => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
         let module_info = sources
           .analyze(&js.specifier, js.source.clone(), js.media_type)
           .unwrap();
+        let specifier_rewriter = SpecifierRewriter {
+          base_specifier: &js.specifier,
+          source_rewrites: &source_rewrites,
+          declaration_rewrites: &declaration_rewrites,
+          dependencies: &js.dependencies,
+        };
         let rewritten = rewrite_specifiers(
           parsed_source.text_info(),
           &module_info,
@@ -205,6 +205,12 @@ pub async fn create_npm_tarball<'a>(
         let module_info = sources
           .analyze(&js.specifier, js.source.clone(), js.media_type)
           .unwrap();
+        let specifier_rewriter = SpecifierRewriter {
+          base_specifier: &js.specifier,
+          source_rewrites: &source_rewrites,
+          declaration_rewrites: &declaration_rewrites,
+          dependencies: &js.dependencies,
+        };
         let rewritten = rewrite_specifiers(
           parsed_source.text_info(),
           &module_info,
@@ -216,17 +222,34 @@ pub async fn create_npm_tarball<'a>(
       }
       deno_ast::MediaType::Jsx => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
-        let source =
-          transpile_to_js(&parsed_source, specifier_rewriter).unwrap();
         let source_target = source_rewrites.get(&js.specifier).unwrap();
+        let specifier_rewriter = SpecifierRewriter {
+          base_specifier: source_target,
+          source_rewrites: &source_rewrites,
+          declaration_rewrites: &declaration_rewrites,
+          dependencies: &js.dependencies,
+        };
+        let (source, source_map) =
+          transpile_to_js(&parsed_source, specifier_rewriter, source_target)
+            .unwrap();
         package_files
           .insert(source_target.path().to_owned(), source.into_bytes());
+        package_files.insert(
+          format!("{}.map", source_target.path()),
+          source_map.into_bytes(),
+        );
       }
       deno_ast::MediaType::TypeScript | deno_ast::MediaType::Mts => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
         let module_info = sources
           .analyze(&js.specifier, js.source.clone(), js.media_type)
           .unwrap();
+        let specifier_rewriter = SpecifierRewriter {
+          base_specifier: &js.specifier,
+          source_rewrites: &source_rewrites,
+          declaration_rewrites: &declaration_rewrites,
+          dependencies: &js.dependencies,
+        };
         let rewritten = rewrite_specifiers(
           parsed_source.text_info(),
           &module_info,
@@ -237,23 +260,45 @@ pub async fn create_npm_tarball<'a>(
           .insert(js.specifier.path().to_owned(), rewritten.into_bytes());
 
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
-        let source =
-          transpile_to_js(&parsed_source, specifier_rewriter).unwrap();
         let source_target = source_rewrites.get(&js.specifier).unwrap();
+        let specifier_rewriter = SpecifierRewriter {
+          base_specifier: source_target,
+          source_rewrites: &source_rewrites,
+          declaration_rewrites: &declaration_rewrites,
+          dependencies: &js.dependencies,
+        };
+        let (source, source_map) =
+          transpile_to_js(&parsed_source, specifier_rewriter, source_target)
+            .unwrap();
         package_files
           .insert(source_target.path().to_owned(), source.into_bytes());
+        package_files.insert(
+          format!("{}.map", source_target.path()),
+          source_map.into_bytes(),
+        );
 
         if let Some(fast_check_module) = js.fast_check_module() {
-          let declaration = transpile_to_dts(
+          let declaration_target =
+            declaration_rewrites.get(&js.specifier).unwrap();
+          let specifier_rewriter = SpecifierRewriter {
+            base_specifier: declaration_target,
+            source_rewrites: &source_rewrites,
+            declaration_rewrites: &declaration_rewrites,
+            dependencies: &js.dependencies,
+          };
+          let (declaration, declaration_map) = transpile_to_dts(
             &parsed_source,
             fast_check_module,
             specifier_rewriter,
+            declaration_target,
           )?;
-          let declaration_target =
-            declaration_rewrites.get(&js.specifier).unwrap();
           package_files.insert(
             declaration_target.path().to_owned(),
             declaration.into_bytes(),
+          );
+          package_files.insert(
+            format!("{}.map", declaration_target.path()),
+            declaration_map.into_bytes(),
           );
         }
       }
@@ -376,18 +421,19 @@ fn rewrite_specifiers(
 ) -> String {
   let mut text_changes = vec![];
 
+  let file_start_pos = source_text_info.range().start;
+
   let add_text_change = |text_changes: &mut Vec<TextChange>,
                          new_specifier: String,
                          range: &PositionRange| {
-    let start_pos = source_text_info.range().start;
     let mut start = range
       .start
       .as_source_pos(source_text_info)
-      .as_byte_index(start_pos);
+      .as_byte_index(file_start_pos);
     let mut end = range
       .end
       .as_source_pos(source_text_info)
-      .as_byte_index(start_pos);
+      .as_byte_index(file_start_pos);
 
     let to_be_replaced = &source_text_info.text_str()[start..end];
     if to_be_replaced.starts_with('\'')

--- a/api/testdata/specs/npm_tarballs/additional_files.txt
+++ b/api/testdata/specs/npm_tarballs/additional_files.txt
@@ -21,6 +21,20 @@ this is data
 }
 
 # output
+== /_dist/foo.d.ts ==
+export declare const foo: string;
+//# sourceMappingURL=foo.d.ts.map
+
+== /_dist/foo.d.ts.map ==
+{"version":3,"file":"foo.d.ts","sources":["../foo.ts"],"names":[],"mappings":"AAAA,OAAO,cAAM,KAAK,MAAM,CAAS"}
+
+== /_dist/foo.js ==
+export const foo = 'bar';
+//# sourceMappingURL=foo.js.map
+
+== /_dist/foo.js.map ==
+{"version":3,"file":"foo.js","sources":["../foo.ts"],"names":[],"mappings":"AAAA,OAAO,MAAM,MAAc,MAAM"}
+
 == /bar.json ==
 console.log('foo');
 
@@ -28,12 +42,7 @@ console.log('foo');
 this is data
 
 == /foo.d.ts ==
-export declare const foo: string;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLGNBQU0sS0FBSyxNQUFNLENBQVMifQ==
-
-== /foo.js ==
-export const foo = 'bar';
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLE1BQU0sTUFBYyxNQUFNIn0=
+// unrelated content is overwritten
 
 == /foo.ts ==
 export const foo: string = 'bar';
@@ -57,8 +66,8 @@ export const foo: string = 'bar';
   "dependencies": {},
   "exports": {
     "./foo": {
-      "types": "./foo.d.ts",
-      "default": "./foo.js"
+      "types": "./_dist/foo.d.ts",
+      "default": "./_dist/foo.js"
     },
     "./bar": {
       "default": "./bar.json"

--- a/api/testdata/specs/npm_tarballs/import_jsr.txt
+++ b/api/testdata/specs/npm_tarballs/import_jsr.txt
@@ -33,20 +33,26 @@ await import("jsr:@luca/flag@1")
 <external>
 
 # output
+== /_dist/baz.d.ts ==
+
+//# sourceMappingURL=baz.d.ts.map
+
+== /_dist/baz.d.ts.map ==
+{"version":3,"file":"baz.d.ts","sources":[],"names":[],"mappings":""}
+
+== /_dist/baz.js ==
+import { html } from "@jsr/luca__flag";
+html();
+await import("@jsr/luca__flag");
+//# sourceMappingURL=baz.js.map
+
+== /_dist/baz.js.map ==
+{"version":3,"file":"baz.js","sources":["../baz.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,0BAA2B;AACxC;AACA,MAAM,MAAM,CAAC"}
+
 == /bar.mjs ==
 
 import { html } from "@jsr/luca__flag";
 await import("@jsr/luca__flag")
-
-== /baz.d.ts ==
-
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9
-
-== /baz.js ==
-import { html } from "@jsr/luca__flag";
-html();
-await import("@jsr/luca__flag");
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhei50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxTQUFTLElBQUksMEJBQTJCO0FBQ3hDO0FBQ0EsTUFBTSxNQUFNLENBQUMifQ==
 
 == /baz.ts ==
 import { html } from "@jsr/luca__flag";
@@ -91,8 +97,8 @@ await import("@jsr/luca__flag")
       "default": "./bar.mjs"
     },
     "./baz": {
-      "types": "./baz.d.ts",
-      "default": "./baz.js"
+      "types": "./_dist/baz.d.ts",
+      "default": "./_dist/baz.js"
     },
     "./fizz": {
       "default": "./fizz.d.ts"

--- a/api/testdata/specs/npm_tarballs/import_npm.txt
+++ b/api/testdata/specs/npm_tarballs/import_npm.txt
@@ -33,20 +33,26 @@ await import("npm:lit@^2.2.7")
 <external>
 
 # output
+== /_dist/baz.d.ts ==
+
+//# sourceMappingURL=baz.d.ts.map
+
+== /_dist/baz.d.ts.map ==
+{"version":3,"file":"baz.d.ts","sources":[],"names":[],"mappings":""}
+
+== /_dist/baz.js ==
+import { html } from "lit";
+html();
+await import("lit");
+//# sourceMappingURL=baz.js.map
+
+== /_dist/baz.js.map ==
+{"version":3,"file":"baz.js","sources":["../baz.ts"],"names":[],"mappings":"AAAA,SAAS,IAAI,cAAyB;AACtC;AACA,MAAM,MAAM,CAAC"}
+
 == /bar.mjs ==
 
 import { html } from "lit";
 await import("lit")
-
-== /baz.d.ts ==
-
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9
-
-== /baz.js ==
-import { html } from "lit";
-html();
-await import("lit");
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhei50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxTQUFTLElBQUksY0FBeUI7QUFDdEM7QUFDQSxNQUFNLE1BQU0sQ0FBQyJ9
 
 == /baz.ts ==
 import { html } from "lit";
@@ -91,8 +97,8 @@ await import("lit")
       "default": "./bar.mjs"
     },
     "./baz": {
-      "types": "./baz.d.ts",
-      "default": "./baz.js"
+      "types": "./_dist/baz.d.ts",
+      "default": "./_dist/baz.js"
     },
     "./fizz": {
       "default": "./fizz.d.ts"

--- a/api/testdata/specs/npm_tarballs/js_with_dts.txt
+++ b/api/testdata/specs/npm_tarballs/js_with_dts.txt
@@ -56,7 +56,7 @@ export class A {
 == /main.d.ts ==
 /// <reference path="@types/node" />
 
-export { A } from "./a.d.ts";
+export { A } from "./a.js";
 export const foo: number;
 
 == /main.js ==

--- a/api/testdata/specs/npm_tarballs/jsdoc_import.txt
+++ b/api/testdata/specs/npm_tarballs/jsdoc_import.txt
@@ -19,23 +19,29 @@ export type Num = number;
 }
 
 # output
-== /foo.d.ts ==
+== /_dist/foo.d.ts ==
 export type Num = number;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxZQUFZLE1BQU0sTUFBTSJ9
+//# sourceMappingURL=foo.d.ts.map
 
-== /foo.js ==
+== /_dist/foo.d.ts.map ==
+{"version":3,"file":"foo.d.ts","sources":["../foo.ts"],"names":[],"mappings":"AAAA,YAAY,MAAM,MAAM"}
 
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9
+== /_dist/foo.js ==
+
+//# sourceMappingURL=foo.js.map
+
+== /_dist/foo.js.map ==
+{"version":3,"file":"foo.js","sources":[],"names":[],"mappings":""}
 
 == /foo.ts ==
 export type Num = number;
 
 == /index.d.ts ==
-export const a: import("./foo.d.ts").Num;
+export const a: import("./_dist/foo.js").Num;
 
 == /index.js ==
 
-/** @type {import("./foo.d.ts").Num} */
+/** @type {import("./_dist/foo.js").Num} */
 export const a = 1;
 
 == /jsr.json ==

--- a/api/testdata/specs/npm_tarballs/slow_types_transpile.txt
+++ b/api/testdata/specs/npm_tarballs/slow_types_transpile.txt
@@ -9,16 +9,19 @@ export const foo = bar();
 }
 
 # output
+== /_dist/main.js ==
+export const foo = bar();
+//# sourceMappingURL=main.js.map
+
+== /_dist/main.js.map ==
+{"version":3,"file":"main.js","sources":["../main.ts"],"names":[],"mappings":"AAAA,OAAO,MAAM,MAAM,MAAM"}
+
 == /jsr.json ==
 {
   "name": "@scope/foo",
   "version": "1.0.0",
   "exports": "./main.ts"
 }
-
-== /main.js ==
-export const foo = bar();
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1haW4udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxNQUFNLE1BQU0sTUFBTSJ9
 
 == /main.ts ==
 export const foo = bar();
@@ -32,7 +35,7 @@ export const foo = bar();
   "dependencies": {},
   "exports": {
     ".": {
-      "default": "./main.js"
+      "default": "./_dist/main.js"
     }
   },
   "_jsr_revision": 0

--- a/api/testdata/specs/npm_tarballs/transpile.txt
+++ b/api/testdata/specs/npm_tarballs/transpile.txt
@@ -18,29 +18,35 @@ export function bar(): string {
 }
 
 # output
-== /jsr.json ==
-{
-  "name": "@scope/foo",
-  "version": "1.0.0",
-  "exports": "./main.ts"
-}
-
-== /main.d.ts ==
+== /_dist/main.d.ts ==
 export declare const foo: string;
 export declare const bar: "bar";
 export interface Foo {
   foo: string;
 }
 export declare function bar(): string;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1haW4udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxjQUFNLEtBQUssTUFBTSxDQUFTO0FBQ2pDLE9BQU8sY0FBTSxLQUFNLE1BQWU7QUFFbEMsaUJBQWlCO0VBQ2YsS0FBSyxNQUFNOztBQUdiLE9BQU8saUJBQVMsT0FBTyxNQUFNIn0=
+//# sourceMappingURL=main.d.ts.map
 
-== /main.js ==
+== /_dist/main.d.ts.map ==
+{"version":3,"file":"main.d.ts","sources":["../main.ts"],"names":[],"mappings":"AAAA,OAAO,cAAM,KAAK,MAAM,CAAS;AACjC,OAAO,cAAM,KAAM,MAAe;AAElC,iBAAiB;EACf,KAAK,MAAM;;AAGb,OAAO,iBAAS,OAAO,MAAM"}
+
+== /_dist/main.js ==
 export const foo = 'foo';
 export const bar = "bar";
 export function bar() {
   return 'bar';
 }
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1haW4udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxNQUFNLE1BQWMsTUFBTTtBQUNqQyxPQUFPLE1BQU0sTUFBTSxNQUFlO0FBTWxDLE9BQU8sU0FBUztFQUNkLE9BQU87QUFDVCJ9
+//# sourceMappingURL=main.js.map
+
+== /_dist/main.js.map ==
+{"version":3,"file":"main.js","sources":["../main.ts"],"names":[],"mappings":"AAAA,OAAO,MAAM,MAAc,MAAM;AACjC,OAAO,MAAM,MAAM,MAAe;AAMlC,OAAO,SAAS;EACd,OAAO;AACT"}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./main.ts"
+}
 
 == /main.ts ==
 export const foo: string = 'foo';
@@ -63,8 +69,8 @@ export function bar(): string {
   "dependencies": {},
   "exports": {
     ".": {
-      "types": "./main.d.ts",
-      "default": "./main.js"
+      "types": "./_dist/main.d.ts",
+      "default": "./_dist/main.js"
     }
   },
   "_jsr_revision": 0

--- a/api/testdata/specs/npm_tarballs/transpile_with_imports.txt
+++ b/api/testdata/specs/npm_tarballs/transpile_with_imports.txt
@@ -16,31 +16,43 @@ export function add(a: number, b: number): number {
 }
 
 # output
-== /bar.d.ts ==
+== /_dist/bar.d.ts ==
 export declare function add(a: number, b: number): number;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLGlCQUFTLElBQUksR0FBRyxNQUFNLEVBQUUsR0FBRyxNQUFNLEdBQUcsTUFBTSJ9
+//# sourceMappingURL=bar.d.ts.map
 
-== /bar.js ==
+== /_dist/bar.d.ts.map ==
+{"version":3,"file":"bar.d.ts","sources":["../bar.ts"],"names":[],"mappings":"AAAA,OAAO,iBAAS,IAAI,GAAG,MAAM,EAAE,GAAG,MAAM,GAAG,MAAM"}
+
+== /_dist/bar.js ==
 export function add(a, b) {
   return a + b;
 }
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxPQUFPLFNBQVMsSUFBSSxDQUFTLEVBQUUsQ0FBUztFQUN0QyxPQUFPLElBQUk7QUFDYiJ9
+//# sourceMappingURL=bar.js.map
+
+== /_dist/bar.js.map ==
+{"version":3,"file":"bar.js","sources":["../bar.ts"],"names":[],"mappings":"AAAA,OAAO,SAAS,IAAI,CAAS,EAAE,CAAS;EACtC,OAAO,IAAI;AACb"}
+
+== /_dist/foo.d.ts ==
+export { add } from "./bar.js";
+//# sourceMappingURL=foo.d.ts.map
+
+== /_dist/foo.d.ts.map ==
+{"version":3,"file":"foo.d.ts","sources":["../foo.ts"],"names":[],"mappings":"AAAA,SAAS,GAAG,mBAAmB"}
+
+== /_dist/foo.js ==
+export { add } from "./bar.js";
+//# sourceMappingURL=foo.js.map
+
+== /_dist/foo.js.map ==
+{"version":3,"file":"foo.js","sources":["../foo.ts"],"names":[],"mappings":"AAAA,SAAS,GAAG,mBAAmB"}
 
 == /bar.ts ==
 export function add(a: number, b: number): number {
   return a + b;
 }
 
-== /foo.d.ts ==
-export { add } from "./bar.d.ts";
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxTQUFTLEdBQUcscUJBQW1CIn0=
-
-== /foo.js ==
-export { add } from "./bar.js";
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxTQUFTLEdBQUcsbUJBQW1CIn0=
-
 == /foo.ts ==
-export { add } from "./bar.js";
+export { add } from "./_dist/bar.js";
 
 == /jsr.json ==
 {
@@ -60,8 +72,8 @@ export { add } from "./bar.js";
   "dependencies": {},
   "exports": {
     ".": {
-      "types": "./foo.d.ts",
-      "default": "./foo.js"
+      "types": "./_dist/foo.d.ts",
+      "default": "./_dist/foo.js"
     }
   },
   "_jsr_revision": 0

--- a/api/testdata/specs/npm_tarballs/type_imports.txt
+++ b/api/testdata/specs/npm_tarballs/type_imports.txt
@@ -1,0 +1,173 @@
+# main.ts
+export { type Add as Add2 } from "./foo.js";
+export type { Add as Add3 } from "./foo.js";
+export type * from "./foo.js";
+export type * as Foo from "./foo.js";
+import { add, Add } from "./foo.js";
+
+export function createAdd(): Add {
+  return add;
+}
+
+# foo.js
+/// <reference types="./foo.d.ts" />
+
+export function add(a, b) {
+  return a + b;
+}
+
+# foo.d.ts
+export { Adder } from "./adder.js";
+
+export interface Add {
+  (a: number, b: number): number;
+}
+
+export declare const add: Add;
+
+# adder.js
+/// <reference types="./adder.d.ts" />
+
+# adder.d.ts
+export interface Adder {
+  add(a: number, b: number): number;
+}
+
+# main2.js
+/// <reference types="./main2.d.ts" />
+
+import { add } from "./foo.js";
+
+export { add };
+
+export function createAdd() {
+  return add;
+}
+
+# main2.d.ts
+export { type Add as Add2 } from "./foo.d.ts";
+export type { Add as Add3 } from "./foo.d.ts";
+export type * from "./foo.d.ts";
+export type * as Foo from "./foo.d.ts";
+import type { Add } from "./foo.d.ts";
+
+export declare function createAdd(): Add;
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "0.0.1",
+  "exports": {
+    ".": "./main.ts",
+    "./main2": "./main2.js"
+  }
+}
+
+# output
+== /_dist/main.d.ts ==
+export { type Add as Add2 } from "./foo.d.ts";
+export type { Add as Add3 } from "./foo.d.ts";
+export type * from "./foo.d.ts";
+export type * as Foo from "./foo.d.ts";
+import { Add } from "./foo.d.ts";
+export declare function createAdd(): Add;
+//# sourceMappingURL=main.d.ts.map
+
+== /_dist/main.d.ts.map ==
+{"version":3,"file":"main.d.ts","sources":["../main.ts"],"names":[],"mappings":"AAAA,SAAS,KAAK,OAAO,IAAI,QAAQ,aAAW;AAC5C,cAAc,OAAO,IAAI,QAAQ,aAAW;AAC5C,mBAAmB,aAAW;AAC9B,YAAO,KAAU,GAAG,MAAM,aAAW;AACrC,SAAc,GAAG,QAAQ,aAAW;AAEpC,OAAO,iBAAS,aAAa"}
+
+== /_dist/main.js ==
+import { add } from "./foo.js";
+export function createAdd() {
+  return add;
+}
+//# sourceMappingURL=main.js.map
+
+== /_dist/main.js.map ==
+{"version":3,"file":"main.js","sources":["../main.ts"],"names":[],"mappings":"AAIA,SAAS,GAAG,QAAa,WAAW;AAEpC,OAAO,SAAS;EACd,OAAO;AACT"}
+
+== /adder.d.ts ==
+export interface Adder {
+  add(a: number, b: number): number;
+}
+
+== /adder.js ==
+
+
+== /foo.d.ts ==
+export { Adder } from "./adder.js";
+
+export interface Add {
+  (a: number, b: number): number;
+}
+
+export declare const add: Add;
+
+== /foo.js ==
+
+
+export function add(a, b) {
+  return a + b;
+}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "0.0.1",
+  "exports": {
+    ".": "./main.ts",
+    "./main2": "./main2.js"
+  }
+}
+
+== /main.ts ==
+export { type Add as Add2 } from "./foo.js";
+export type { Add as Add3 } from "./foo.js";
+export type * from "./foo.js";
+export type * as Foo from "./foo.js";
+import { add, Add } from "./foo.js";
+
+export function createAdd(): Add {
+  return add;
+}
+
+== /main2.d.ts ==
+export { type Add as Add2 } from "./foo.js";
+export type { Add as Add3 } from "./foo.js";
+export type * from "./foo.js";
+export type * as Foo from "./foo.js";
+import type { Add } from "./foo.js";
+
+export declare function createAdd(): Add;
+
+== /main2.js ==
+
+
+import { add } from "./foo.js";
+
+export { add };
+
+export function createAdd() {
+  return add;
+}
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "0.0.1",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "types": "./_dist/main.d.ts",
+      "default": "./_dist/main.js"
+    },
+    "./main2": {
+      "types": "./main2.d.ts",
+      "default": "./main2.js"
+    }
+  },
+  "_jsr_revision": 0
+}
+

--- a/frontend/docs/troubleshooting.md
+++ b/frontend/docs/troubleshooting.md
@@ -68,6 +68,8 @@ Path rules are as follows:
 - Does not contain chars that have a special meaning in URLs (`%` or `#`)
 - Does not contain other chars that are not one of `a-z`, `A-Z`, `0-9`, `$`,
   `(`, `)`, `+`, `-`, `.`, `@`, `[`, `]`, `_`, `{`, `}`, or `~`
+- Does not start with `/_dist/`, as this is reserved for the directory JSR emits
+  `.js` and .`d.ts` files to when building an npm tarball
 
 ### `invalidExternalImport`
 

--- a/frontend/fresh.gen.ts
+++ b/frontend/fresh.gen.ts
@@ -30,6 +30,7 @@ import * as $index from "./routes/index.tsx";
 import * as $login from "./routes/login.tsx";
 import * as $logout from "./routes/logout.tsx";
 import * as $new from "./routes/new.tsx";
+import * as $package_all_symbols from "./routes/package/all_symbols.tsx";
 import * as $package_dependencies from "./routes/package/dependencies.tsx";
 import * as $package_dependents from "./routes/package/dependents.tsx";
 import * as $package_doc_file_ from "./routes/package/doc/[file].tsx";
@@ -39,7 +40,6 @@ import * as $package_publish from "./routes/package/publish.tsx";
 import * as $package_score from "./routes/package/score.tsx";
 import * as $package_settings from "./routes/package/settings.tsx";
 import * as $package_source from "./routes/package/source.tsx";
-import * as $package_symbols from "./routes/package/all_symbols.tsx";
 import * as $package_versions from "./routes/package/versions.tsx";
 import * as $packages from "./routes/packages.tsx";
 import * as $publishing_deny from "./routes/publishing/deny.tsx";
@@ -100,6 +100,7 @@ const manifest = {
     "./routes/login.tsx": $login,
     "./routes/logout.tsx": $logout,
     "./routes/new.tsx": $new,
+    "./routes/package/all_symbols.tsx": $package_all_symbols,
     "./routes/package/dependencies.tsx": $package_dependencies,
     "./routes/package/dependents.tsx": $package_dependents,
     "./routes/package/doc/[file].tsx": $package_doc_file_,
@@ -109,7 +110,6 @@ const manifest = {
     "./routes/package/score.tsx": $package_score,
     "./routes/package/settings.tsx": $package_settings,
     "./routes/package/source.tsx": $package_source,
-    "./routes/package/symbols.tsx": $package_symbols,
     "./routes/package/versions.tsx": $package_versions,
     "./routes/packages.tsx": $packages,
     "./routes/publishing/deny.tsx": $publishing_deny,


### PR DESCRIPTION
Fixes #462 

To make this work, also bans publishing packages containing a top level folder called `_dist`.

Also we now do not reference `.d.ts` files from other `.d.ts` files using the `.d.ts` extension, because otherwise tsc gets upset. So we instead use `.js` (even if the file does not exist!)

Also we emit source maps into separate files, because TSC doesn't understand embedded source maps.
