### PR TITLE
fix: specify the cache-control for badges

### DIFF
--- a/frontend/routes/badges/package.ts
+++ b/frontend/routes/badges/package.ts
@@ -48,6 +48,7 @@ export const handler: Handlers<unknown, State> = {
       return new Response(res.body, {
         status: res.status,
         headers: {
+          "cache-control": "max-age=300, s-maxage=300",
           "content-type": res.headers.get("content-type")!,
         },
       });

--- a/frontend/routes/badges/package_score.ts
+++ b/frontend/routes/badges/package_score.ts
@@ -52,6 +52,7 @@ export const handler: Handlers<unknown, State> = {
       return new Response(res.body, {
         status: res.status,
         headers: {
+          "cache-control": "max-age=300, s-maxage=300",
           "content-type": res.headers.get("content-type")!,
         },
       });

--- a/frontend/routes/badges/scope.ts
+++ b/frontend/routes/badges/scope.ts
@@ -48,6 +48,7 @@ export const handler: Handlers<unknown, State> = {
       return new Response(res.body, {
         status: res.status,
         headers: {
+          "cache-control": "max-age=300, s-maxage=300",
           "content-type": res.headers.get("content-type")!,
         },
       });


### PR DESCRIPTION
Fixes #341

I used the same value `300` as shields.io's npm version badge.