### PR TITLE
fix: update styles on symbol detail pages

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -230,9 +230,19 @@ body .ddoc .anchorable.docEntry > .markdown_border {
   @apply border-none pl-0 ml-0 max-w-prose;
 }
 
+/* should get a better css class to target this */
+body .ddoc .anchorable.example > details > .markdown_border {
+  @apply border-none pl-0 ml-0 !important;
+}
+
 /* just removing the ml-2 class from this div */
 body .ddoc section div.ml-2 {
   @apply ml-0;
+}
+
+/* can replace the space-y-3 with space-y-2 in ddoc */
+body .ddoc section div.ml-2.space-y-3 {
+  @apply mt-2 !important;
 }
 
 body .ddoc .markdown :not(pre) > code {

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -225,6 +225,10 @@ body .ddoc .anchorable.docEntry > .docEntryHeader {
   @apply md:text-base;
 }
 
+body .ddoc .anchorable.docEntry > .docEntryHeader > span {
+  @apply items-baseline;
+}
+
 /* should get a better css class to target this */
 body .ddoc .anchorable.docEntry > .markdown_border {
   @apply border-none pl-0 ml-0 max-w-prose;

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -209,6 +209,32 @@ body .ddoc .markdown pre {
   }
 }
 
+body .ddoc article a.context_button {
+  @apply border-none hover:bg-jsr-cyan-50;
+}
+
+body .ddoc .docEntryHeader a {
+  @apply link font-medium;
+}
+
+body .ddoc .anchorable.docEntry {
+  @apply md:text-sm mb-4 !important;
+}
+
+body .ddoc .anchorable.docEntry > .docEntryHeader {
+  @apply md:text-base;
+}
+
+/* should get a better css class to target this */
+body .ddoc .anchorable.docEntry > .markdown_border {
+  @apply border-none pl-0 ml-0 max-w-prose;
+}
+
+/* just removing the ml-2 class from this div */
+body .ddoc section div.ml-2 {
+  @apply ml-0;
+}
+
 body .ddoc .markdown :not(pre) > code {
   @apply bg-jsr-cyan-100/50 rounded-md;
   @apply px-1.5;


### PR DESCRIPTION
First attempt at updating some of the styles on the symbol detail pages. I tried to leave some comments on bits where the thing I was changing could actually be fixed by applying a different tailwind class in deno_doc (like changing margin-top when I really want a `space-y-3` to be a `space-y-2`

Same caveat as the last one, this could be used as a TODO list for changes that should happen back in deno_doc or merged in and used as a reference for refactoring later.

Example page of these styles on Oak/oak since that contains a large amount of varied text to format. (sidebar omitted from screenshot since that's changing in a different PR and I didn't want it to distract)
![jsr test_@oak_oak_doc_~_Context](https://github.com/jsr-io/jsr/assets/776987/085d5e49-005b-4545-8452-d9f208682be2)
