### PR TITLE
docs(readme): fix local development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ making changes to the API.
     2. Copy `api/.env.example` to `api/.env`
     3. Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to the values from the
        GitHub App you created in step 1.
+    4. Set `DATABASE_URL` to point to your local Postgres database.
 - Install `sqlx` by running `cargo install sqlx-cli`
 
 **macOS**

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ making changes to the API.
 **Linux**
 
 - `docker` & `docker-compose` installed and running
+- Run `cd api`
+- Run `cargo sqlx migrate run`
+  - If you get the error `role "postgres" does not exist`, run
+    `createuser -s postgres`.
 
 ### Running jsr
 


### PR DESCRIPTION
This commit fixes the local development guide in README to avoid confusion when contributors set up their local.

(These points are what I noticed while I was preparing for my slides for my JSR meetup talk)