### PR TITLE
fix: better warning when a package is yanked or pre-release

### DIFF
--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -31,19 +31,25 @@ export function PackageHeader(
           <div class="text-sm md:text-base flex items-center justify-center gap-4 md:gap-2">
             <WarningTriangle class="text-jsr-yellow-400 flex-none" />
             <span class="font-medium">
-              This release is{" "}
-              {isPrerelease && selectedVersion.newerVersionsCount == 0
+              This release {selectedVersion.yanked
                 ? (
                   <>
-                    a pre-release — the latest stable version of @{pkg
+                    was yanked — the latest stable version of @{pkg
+                      .scope}/{pkg.name} is {pkg.latestVersion}.
+                  </>
+                )
+                : isPrerelease && selectedVersion.newerVersionsCount == 0
+                ? (
+                  <>
+                    is a pre-release — the latest stable version of @{pkg
                       .scope}/{pkg.name} is {pkg.latestVersion}.
                   </>
                 )
                 : (
                   <>
                     <span class="bold">
-                      {selectedVersion.newerVersionsCount}{" "}
-                      version{selectedVersion.newerVersionsCount > 1 && "s"}
+                      is {selectedVersion.newerVersionsCount}{" "}
+                      version{selectedVersion.newerVersionsCount !== 1 && "s"}
                       {" "}
                       behind {pkg.latestVersion}
                     </span>{" "}
@@ -54,8 +60,8 @@ export function PackageHeader(
                 class="link font-medium whitespace-nowrap"
                 href={`/@${pkg.scope}/${pkg.name}`}
               >
-                Jump to latest{" "}
-                {isPrerelease && selectedVersion.newerVersionsCount == 0 &&
+                Jump to latest {(selectedVersion.yanked ||
+                  (isPrerelease && selectedVersion.newerVersionsCount == 0)) &&
                   "stable"}
               </a>
             </span>


### PR DESCRIPTION
BEFORE
![image](https://github.com/jsr-io/jsr/assets/7829205/bf0ca603-43c0-4edf-a034-82d2bf7fbabc)
![image](https://github.com/jsr-io/jsr/assets/7829205/f36ca28c-958f-4c2e-9d38-d5a2d164cefd)

AFTER
![image](https://github.com/jsr-io/jsr/assets/7829205/2afc6d0d-51a4-4b1c-bfc4-c791d46e80ed)
![image](https://github.com/jsr-io/jsr/assets/7829205/24213b30-97c5-44d0-9cc6-9f05fd22aa6b)

Fixes #489
Fixes #488