### PR TITLE
Pull in latest JSR posts to homepage

### DIFF
--- a/frontend/components/ListPanel.tsx
+++ b/frontend/components/ListPanel.tsx
@@ -17,9 +17,9 @@ export function ListPanel(
     <div class="w-full">
       <div class="mb-2">
         {title && (
-          <h2 class="text-xl md:text-2xl font-semibold">
+          <h3 class="text-lg md:text-xl font-semibold">
             {title}
-          </h2>
+          </h3>
         )}
         {subtitle && (
           <div class="text-base text-gray-500">

--- a/frontend/components/NewsCard.tsx
+++ b/frontend/components/NewsCard.tsx
@@ -1,0 +1,36 @@
+export function NewsCard({
+  title,
+  description,
+  image,
+  url,
+}: {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}) {
+  return (
+    <li class="group border-1.5 border-jsr-cyan-950 rounded list-none overflow-hidden hover:border-jsr-cyan-400 focus-within:border-jsr-cyan-400 transition-colors duration-150">
+      <a
+        href={url}
+        class="h-full flex flex-col justify-stretch cursor-pointer"
+        tabIndex={0}
+      >
+        <img
+          src={image}
+          crossOrigin={"anonymous"}
+          alt=""
+          class="w-full h-48 object-cover border-b-1.5 border-jsr-cyan-950 group-hover:border-jsr-cyan-400 group-focus-within:border-jsr-cyan-400 transition-colors duration-150"
+        />
+        <div class="p-4 flex flex-grow flex-col gap-4">
+          <h3 class="text-xl lg:text-2xl font-semibold !leading-tight text-balance">
+            {title}
+          </h3>
+          <p class="text-sm">
+            {description}
+          </p>
+        </div>
+      </a>
+    </li>
+  );
+}

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -42,27 +42,29 @@ export default function Home({ data }: PageProps<Data>) {
         indexId={Deno.env.get("ORAMA_PACKAGE_PUBLIC_INDEX_ID")}
       />
 
-      <section class="flex flex-col gap-4 mb-16 md:mb-32">
-        <h2 class="text-3xl md:text-4xl mb-4 md:mb-8 font-semibold text-center">
-          Latest updates
-        </h2>
-        <ul class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-8">
-          {data?.posts?.slice(0, 3).map((post) => (
-            <NewsCard
-              image={post.image}
-              title={post.title}
-              description={post.description}
-              url={post.url}
-            />
-          ))}
-        </ul>
-        <a
-          href="https://deno.com/blog?tag=jsr"
-          class="underline block mt-4 w-full text-center"
-        >
-          More JSR updates <span aria-hidden="true">&rsaquo;</span>
-        </a>
-      </section>
+      {data.posts?.length && (
+        <section class="flex flex-col gap-4 mb-16 md:mb-32">
+          <h2 class="text-3xl md:text-4xl mb-4 md:mb-8 font-semibold text-center">
+            Latest updates
+          </h2>
+          <ul class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-8">
+            {data?.posts?.slice(0, 3).map((post) => (
+              <NewsCard
+                image={post.image}
+                title={post.title}
+                description={post.description}
+                url={post.url}
+              />
+            ))}
+          </ul>
+          <a
+            href="https://deno.com/blog?tag=jsr"
+            class="underline block mt-4 w-full text-center"
+          >
+            More JSR updates <span aria-hidden="true">&rsaquo;</span>
+          </a>
+        </section>
+      )}
 
       <section class="flex flex-col gap-4">
         <h2 class="text-3xl md:text-4xl mb-4 md:mb-8 font-semibold text-center">
@@ -272,7 +274,7 @@ export const handler: Handlers<Data, State> = {
     const posts = await jsrPosts.json() as Post[];
 
     if (!statsResp.ok) throw statsResp; // gracefully handle this
-    return ctx.render({ stats: statsResp.data, posts }, {
+    return ctx.render({ stats: statsResp.data, posts: posts || [] }, {
       headers: ctx.state.api.hasToken()
         ? undefined
         : { "Cache-Control": "public, s-maxage=60" },

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -8,6 +8,7 @@ import { path } from "../utils/api.ts";
 import { ListDisplay } from "../components/List.tsx";
 import { PackageHit } from "../components/PackageHit.tsx";
 import { processFilter } from "../islands/GlobalSearch.tsx";
+import { NewsCard } from "../components/NewsCard.tsx";
 
 interface Data extends PaginationData {
   packages: OramaPackageHit[] | Package[];

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -8,7 +8,6 @@ import { path } from "../utils/api.ts";
 import { ListDisplay } from "../components/List.tsx";
 import { PackageHit } from "../components/PackageHit.tsx";
 import { processFilter } from "../islands/GlobalSearch.tsx";
-import { NewsCard } from "../components/NewsCard.tsx";
 
 interface Data extends PaginationData {
   packages: OramaPackageHit[] | Package[];


### PR DESCRIPTION
Now that there's a JSON API for Deno blog posts that allows us to filter by tags, we can pull in the three latest JSR blog posts and display them on the JSR homepage.

<img width="1279" alt="image" src="https://github.com/jsr-io/jsr/assets/22334764/cd2c2675-1cbf-4098-9ba0-1762c674d706">
