### PR TITLE
docs: fix the default vite port (`5123` -> `5173`)

### DIFF
--- a/frontend/docs/with/vite.md
+++ b/frontend/docs/with/vite.md
@@ -40,7 +40,7 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = encodeBase64(
 ```
 
 Running `vite` to start the local development server will serve your application
-at `http://localhost:5123`. You can then visit `http://localhost:5123` to see
+at `http://localhost:5173`. You can then visit `http://localhost:5173` to see
 it.
 
 ```shell


### PR DESCRIPTION
The default port of vite server is `5173`[^1]

[^1]: https://vitejs.dev/config/server-options#server-port