### PR TITLE
fix: update layout and breadcrumb/nav styles

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -32,10 +32,10 @@ export function DocsView(
         />
       )}
 
-      <div class="grid grid-cols-1 lg:grid-cols-4 gap-8 lg:gap-12">
+      <div class="grid grid-cols-1 lg:grid-cols-10 gap-8 lg:gap-12">
         <div
           class={`min-w-0 ${
-            docs.toc ? "lg:col-span-3 lg:row-start-1" : "col-span-full"
+            docs.toc ? "lg:col-span-7 lg:row-start-1" : "col-span-full"
           }`}
         >
           <div class="ddoc" dangerouslySetInnerHTML={{ __html: docs.main }} />
@@ -83,7 +83,7 @@ export function DocsView(
         </div>
         {docs.toc && (
           <div
-            class={`max-lg:row-start-1 lg:col-[span_1_/_-1] lg:top-0 lg:sticky lg:max-h-screen flex flex-col box-border gap-y-4 -mt-4 pt-4 ${
+            class={`max-lg:row-start-1 lg:col-[span_3/_-1] lg:top-0 lg:sticky lg:max-h-screen flex flex-col box-border gap-y-4 -mt-4 pt-4 ${
               docs.breadcrumbs ? "lg:-mt-20 lg:pt-20" : ""
             }`}
           >

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -58,7 +58,7 @@ export function PackageHeader(
                       is {selectedVersion.newerVersionsCount}{" "}
                       version{selectedVersion.newerVersionsCount !== 1 && "s"}
                       {" "}
-                      behind (v{pkg.latestVersion})
+                      behind {pkg.latestVersion}
                     </span>{" "}
                     — the latest version of @{pkg.scope}/{pkg.name}.
                   </>
@@ -187,7 +187,7 @@ export function PackageHeader(
                 >
                   {`${
                     twas(new Date(selectedVersion.createdAt))
-                  } (v${pkg.latestVersion})`}
+                  } (${selectedVersion.version})`}
                 </div>
               </div>
             )}

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -58,7 +58,7 @@ export function PackageHeader(
                       is {selectedVersion.newerVersionsCount}{" "}
                       version{selectedVersion.newerVersionsCount !== 1 && "s"}
                       {" "}
-                      behind {pkg.latestVersion}
+                      behind (v{pkg.latestVersion})
                     </span>{" "}
                     — the latest version of @{pkg.scope}/{pkg.name}.
                   </>
@@ -185,7 +185,9 @@ export function PackageHeader(
                       10,
                     )}
                 >
-                  {twas(new Date(selectedVersion.createdAt))}
+                  {`${
+                    twas(new Date(selectedVersion.createdAt))
+                  } (v${pkg.latestVersion})`}
                 </div>
               </div>
             )}

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -57,9 +57,6 @@ export function PackageNav(
       <NavItem href={`${base}/versions`} active={currentTab === "Versions"}>
         <span class="flex items-center">
           Versions
-          <span class="chip tabular-nums bg-jsr-cyan-200 ml-2 leading-[0] w-[1.5em] aspect-square flex items-center justify-center">
-            {versionCount}
-          </span>
         </span>
       </NavItem>
       {(latestVersion || params.version) && (

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -57,6 +57,9 @@ export function PackageNav(
       <NavItem href={`${base}/versions`} active={currentTab === "Versions"}>
         <span class="flex items-center">
           Versions
+          <span class="chip tabular-nums border-1 border-white bg-jsr-cyan-100 ml-2 flex items-center justify-center">
+            {versionCount}
+          </span>
         </span>
       </NavItem>
       {(latestVersion || params.version) && (

--- a/frontend/routes/package/(_islands)/BreadcrumbsSticky.tsx
+++ b/frontend/routes/package/(_islands)/BreadcrumbsSticky.tsx
@@ -44,13 +44,13 @@ export function BreadcrumbsSticky(
           : ""
       }`}
     >
-      <div class="section-x-inset-xl flex md:items-center justify-between gap-4 max-md:flex-col-reverse lg:grid lg:grid-cols-4 lg:gap-12">
+      <div class="section-x-inset-xl flex md:items-center justify-between gap-4 max-md:flex-col-reverse lg:grid lg:grid-cols-10 lg:gap-12">
         <div
-          class="ddoc lg:col-span-3"
+          class="ddoc lg:col-span-7"
           dangerouslySetInnerHTML={{ __html: props.content }}
         />
 
-        <div class="lg:col-[span_1_/_-1]">
+        <div class="lg:col-[span_3/_-1]">
           <LocalSymbolSearch
             scope={props.scope}
             pkg={props.package}

--- a/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
+++ b/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
@@ -167,7 +167,7 @@ export function LocalSymbolSearch(
         type="text"
         placeholder={placeholder}
         id="symbol-search-input"
-        class="block text-sm w-full py-1.5 px-2 input-container input bg-white border-1.5 border-jsr-cyan-900/30"
+        class="block text-sm w-full py-2 px-2 input-container input bg-white border-jsr-cyan-300/50"
         disabled={!db}
         onInput={onInput}
         onKeyUp={onKeyUp}

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -140,10 +140,10 @@
   .section-x-inset-xl {
     @apply max-w-screen-xl mx-auto px-4 md:px-8 lg:px-10 xl:px-14;
   }
-  
+
   .-section-x-inset-xl {
     margin: 0 calc(((100vw - (min(1280px, 100vw) - 32px)) / 2) * -1);
-    
+
     @media screen(md) {
       margin: 0 calc(((100vw - (min(1280px, 100vw) - 64px)) / 2) * -1);
     }
@@ -166,7 +166,7 @@
 
   .input-container {
     @apply bg-white rounded-md leading-snug
-      border-1.5 border-jsr-cyan-900/30 focus-within:border-jsr-cyan-500;
+      border-1 border-jsr-cyan-900/30 focus-within:border-jsr-cyan-500;
   }
 
   select:not([data-locked="true"]):disabled.input-container,
@@ -188,7 +188,7 @@
   }
 
   .search-input {
-    @apply input-container border-jsr-cyan-950;
+    @apply input-container border-1.5 border-jsr-cyan-950;
   }
 
   .select {
@@ -205,87 +205,87 @@ body .ddoc {
     h1 {
       @apply mt-8 -mx-4 px-4 md:mx-0 md:px-0 text-3xl md:text-4xl font-semibold !important;
     }
-    
+
     h2 {
       @apply mt-8 -mx-4 px-4 md:mx-0 md:px-0 text-xl md:text-2xl font-bold md:font-medium !important;
     }
-    
+
     h3 {
       @apply mt-6 -mx-4 px-4 md:mx-0 md:px-0 font-bold md:font-medium !important;
     }
-    
+
     h4 {
       @apply mt-6 -mx-4 px-4 md:mx-0 md:px-0 font-bold md:font-medium !important;
     }
-    
+
     :not(pre) > code {
       @apply bg-jsr-cyan-100/50;
     }
-    
+
     a:not(.no_color) {
       @apply link;
     }
-    
+
     .highlight .context_button {
       @apply border-none hover:bg-jsr-cyan-50;
     }
   }
-  
+
   .markdown_summary {
     a:not(.no_color) {
       @apply link;
     }
-    
+
     :not(pre) > code {
       @apply bg-jsr-cyan-100/50 !important;
     }
   }
-  
+
   .symbolGroup article a.context_button {
     @apply border-none hover:bg-jsr-cyan-50;
   }
-  
+
   .docEntryHeader a {
     @apply link;
   }
-  
+
   .contextLink {
     /* cyan 700 at 25%; */
     text-decoration-color: #0e659040;
     color: theme("colors.jsr-cyan.700");
   }
-  
+
   .usages {
     nav details {
       > summary {
-        @apply border-none bg-jsr-cyan-100;
+        @apply border-jsr-cyan-300/50 bg-jsr-cyan-50;
       }
-      
+
       > div > div {
         @apply border-jsr-cyan-200;
       }
     }
-    
+
     pre.highlight {
-      @apply border-jsr-cyan-200;
+      @apply border-jsr-cyan-300/50;
     }
   }
-  
-  #module_doc, main {
+
+  #module_doc,
+  main {
     @apply pb-8;
   }
-  
+
   .toc .topSymbols {
     @apply max-lg:hidden;
   }
 
   @media (min-width: 768px) {
-    .usages nav details>div {
+    .usages nav details > div {
       @apply -left-8;
     }
   }
 }
-
 
 /** We hide the footer on ddoc pages so that there is no content underneath the doc pages that make scrolling experience weird */
 body:has(.ddoc) #footer {


### PR DESCRIPTION
A few different updates here:

## Update side-bar

1. The "use with" button was a little too blue and didn't offer enough contrast from the text and logos, it now matches the style we use for the package navigation. 
2. The symbol search box has matching styles to the code sample boxes
3. The width of this section was increased by raising going from a 75/25 layout to 70/30, giving a bit more space to show longer text in document navigation and the import symbol code snippet
4. Symbol search is the same width in all instances 
<img width="517" alt="Screenshot 2024-05-20 at 12 43 29 PM" src="https://github.com/jsr-io/jsr/assets/776987/0aed4b2f-bc5e-4dc8-8f8d-ca6d97519d54">

## Move version counter (cc @lucacasonato can omit unless you 👍 )

This proposes moving the version counter out of the package navigation and making note of the most recently published version in the package metadata section where we mention when a package was last published. This cleans up the UI a bit to prevent badge overload (there are already up to 3 in the page header) 
<img width="233" alt="Screenshot 2024-05-20 at 12 49 36 PM" src="https://github.com/jsr-io/jsr/assets/776987/f4109dc9-b602-4561-88b8-c27f11421af2">

## some general css auto-formatting changes
