### PR TITLE
fix: broken badge urls

### DIFF
--- a/e2e/main_test.ts
+++ b/e2e/main_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-import { assertStringIncludes } from "./utils/assert.ts";
+import { assertNotMatch, assertStringIncludes } from "./utils/assert.ts";
 import { assertEquals } from "./utils/assert.ts";
 import { JSR_URL } from "./utils/configuration.ts";
 
@@ -322,4 +322,28 @@ if (import.meta.main) {
     response.headers.get("content-type"),
     "text/typescript",
   );
+});
+
+Deno.test("[GET /badges/@luca/flag] works", async (t) => {
+  await t.step("Package badge", async () => {
+    const res = await fetch(`${JSR_URL}badges/@luca/flag`);
+    const text = await res.text();
+    assertEquals(res.status, 200);
+    assertNotMatch(text, /please use https/);
+  });
+
+  // Skipping: These are not registered with shields.io yet
+  // await t.step("Package score badge", async () => {
+  //   const res = await fetch(`${JSR_URL}badges/@luca/flag/score`);
+  //   const text = await res.text();
+  //   assertEquals(res.status, 200);
+  //   assertNotMatch(text, /please use https/);
+  // });
+
+  // await t.step("Scope badge", async () => {
+  //   const res = await fetch(`${JSR_URL}badges/@luca`);
+  //   const text = await res.text();
+  //   assertEquals(res.status, 200);
+  //   assertNotMatch(text, /please use https/);
+  // });
 });

--- a/frontend/routes/badges/package.ts
+++ b/frontend/routes/badges/package.ts
@@ -31,9 +31,12 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
+      const url = new URL(req.url);
+      url.protocol = "https:";
+
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
-      shieldsUrl.search = ctx.url.search;
-      shieldsUrl.searchParams.set("url", ctx.url.href);
+      shieldsUrl.search = url.search;
+      shieldsUrl.searchParams.set("url", url.href);
       shieldsUrl.searchParams.set("logo", "jsr");
       shieldsUrl.searchParams.set("logoColor", "rgb(8,51,68)");
       shieldsUrl.searchParams.set("logoSize", "auto");

--- a/frontend/routes/badges/package.ts
+++ b/frontend/routes/badges/package.ts
@@ -31,8 +31,7 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
-      const url = new URL(req.url);
-      url.protocol = "https:";
+      const url = new URL("https://jsr.io" + ctx.url.pathname + ctx.url.search);
 
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
       shieldsUrl.search = url.search;

--- a/frontend/routes/badges/package_score.ts
+++ b/frontend/routes/badges/package_score.ts
@@ -35,9 +35,12 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
+      const url = new URL(req.url);
+      url.protocol = "https:";
+
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
-      shieldsUrl.search = ctx.url.search;
-      shieldsUrl.searchParams.set("url", ctx.url.href);
+      shieldsUrl.search = url.search;
+      shieldsUrl.searchParams.set("url", url.href);
       shieldsUrl.searchParams.set("logo", "jsr");
       shieldsUrl.searchParams.set("logoColor", "rgb(8,51,68)");
       shieldsUrl.searchParams.set("logoSize", "auto");

--- a/frontend/routes/badges/package_score.ts
+++ b/frontend/routes/badges/package_score.ts
@@ -35,8 +35,7 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
-      const url = new URL(req.url);
-      url.protocol = "https:";
+      const url = new URL("https://jsr.io" + ctx.url.pathname + ctx.url.search);
 
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
       shieldsUrl.search = url.search;
@@ -45,6 +44,8 @@ export const handler: Handlers<unknown, State> = {
       shieldsUrl.searchParams.set("logoColor", "rgb(8,51,68)");
       shieldsUrl.searchParams.set("logoSize", "auto");
       shieldsUrl.searchParams.set("cacheSeconds", "300");
+
+      console.log(shieldsUrl.href);
 
       const res = await fetch(shieldsUrl);
 

--- a/frontend/routes/badges/scope.ts
+++ b/frontend/routes/badges/scope.ts
@@ -31,9 +31,12 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
+      const url = new URL(req.url);
+      url.protocol = "https:";
+
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
-      shieldsUrl.search = ctx.url.search;
-      shieldsUrl.searchParams.set("url", ctx.url.href);
+      shieldsUrl.search = url.search;
+      shieldsUrl.searchParams.set("url", url.href);
       shieldsUrl.searchParams.set("logo", "jsr");
       shieldsUrl.searchParams.set("logoColor", "rgb(8,51,68)");
       shieldsUrl.searchParams.set("logoSize", "auto");

--- a/frontend/routes/badges/scope.ts
+++ b/frontend/routes/badges/scope.ts
@@ -31,8 +31,7 @@ export const handler: Handlers<unknown, State> = {
         });
       }
     } else {
-      const url = new URL(req.url);
-      url.protocol = "https:";
+      const url = new URL("https://jsr.io" + ctx.url.pathname + ctx.url.search);
 
       const shieldsUrl = new URL("https://img.shields.io/endpoint");
       shieldsUrl.search = url.search;


### PR DESCRIPTION
We passed an incorrect url to shields.io for generating the badges. 

This regression was introduced in https://github.com/jsr-io/jsr/pull/510/files#diff-8caf5f85764d74fed531a1043245722b7f0fb15b3354df1ff3468742cd450ed7L35

Fixes https://github.com/jsr-io/jsr/issues/539