### PR TITLE
fix: remember the users package manager preference

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -116,7 +116,9 @@ export function DocsView(
               class="ddoc w-full lg:overflow-y-auto pb-4"
               dangerouslySetInnerHTML={{ __html: docs.toc }}
             />
-            <script dangerouslySetInnerHTML={{ __html: USAGE_SELECTOR_SCRIPT }} />
+            <script
+              dangerouslySetInnerHTML={{ __html: USAGE_SELECTOR_SCRIPT }}
+            />
           </div>
         )}
       </div>

--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -13,6 +13,23 @@ interface DocsProps {
   showProvenanceBadge?: boolean;
 }
 
+const USAGE_SELECTOR_SCRIPT = `(() => {
+const preferredUsage = localStorage.getItem('preferredUsage');
+
+if (preferredUsage) {
+  document.querySelectorAll('input[name="usage"]').forEach((el) => {
+    el.checked = el.id === preferredUsage
+  });
+}
+
+document.querySelector('.usages').addEventListener('change', (e) => {
+  const target = e.target;
+  if (target instanceof HTMLInputElement && target.name === 'usage') {
+    localStorage.setItem('preferredUsage', target.id);
+  } 
+});
+})()`;
+
 export function DocsView(
   { docs, params, selectedVersion, showProvenanceBadge }: DocsProps,
 ) {
@@ -99,6 +116,7 @@ export function DocsView(
               class="ddoc w-full lg:overflow-y-auto pb-4"
               dangerouslySetInnerHTML={{ __html: docs.toc }}
             />
+            <script dangerouslySetInnerHTML={{ __html: USAGE_SELECTOR_SCRIPT }} />
           </div>
         )}
       </div>


### PR DESCRIPTION
The usage box will now remember what package manager the user last selected for the next page load / session.

This data is stored on device, and thus does not sync between devices.

Closes #546
