### PR TITLE
fix: display the default package manager

### DIFF
--- a/frontend/routes/package/(_components)/Docs.tsx
+++ b/frontend/routes/package/(_components)/Docs.tsx
@@ -18,7 +18,7 @@ const preferredUsage = localStorage.getItem('preferredUsage');
 
 if (preferredUsage) {
   document.querySelectorAll('input[name="usage"]').forEach((el) => {
-    el.checked = el.id === preferredUsage
+    if (el.id === preferredUsage) el.checked = true;
   });
 }
 


### PR DESCRIPTION
This fixes a bug that occurred in #548.


If you select Bun in a package(e.g. https://jsr.io/@std/assert) and move to another package(e.g. https://jsr.io/@std/archive) where Bun does not work, the package manager will not display correctly.


![image](https://github.com/jsr-io/jsr/assets/114303361/ad3b555d-5d71-4750-9a9e-f07394e0a303)
