### PR TITLE
fix(frontend): Big and small accessibility improvements

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -57,6 +57,7 @@ export function Header({
             <a
               href="/"
               class="outline-none focus-visible:ring-2 ring-cyan-700"
+              aria-label="Home"
             >
               <HeaderLogo class="h-8 flex-none" />
             </a>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -94,7 +94,7 @@ export function Header({
               )}
             {searchKind !== "docs" && (
               <>
-                <span class="text-gray-200 select-none">|</span>
+                <Divider />
                 <a
                   href="/docs"
                   class="link-header"
@@ -103,7 +103,7 @@ export function Header({
                 </a>
               </>
             )}
-            <span class="text-gray-200 select-none">|</span>
+            <Divider />
             {user
               ? <UserMenu user={user} sudo={sudo} logoutUrl={logoutUrl} />
               : (
@@ -127,4 +127,8 @@ export function Header({
       </div>
     </>
   );
+}
+
+function Divider() {
+  return <span class="text-gray-200 select-none" aria-hidden="true">|</span>;
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -108,7 +108,7 @@ export function Header({
               ? <UserMenu user={user} sudo={sudo} logoutUrl={logoutUrl} />
               : (
                 <a href={loginUrl} class="link-header flex items-center gap-2">
-                  <GitHub class="size-5 flex-none" />
+                  <GitHub class="size-5 flex-none" aria-hidden={true} />
                   Sign in
                 </a>
               )}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -56,8 +56,8 @@ export function Header({
             <a
               href="/"
               class="outline-none focus-visible:ring-2 ring-cyan-700"
-              aria-label="Home"
             >
+              <span className="sr-only">Home</span>
               <HeaderLogo class="h-8 flex-none" />
             </a>
           )}

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -34,7 +34,7 @@ export default function Modal(
           onClick={(e) => e.stopPropagation()}
         >
           <button
-            class="absolute top-8 right-8 hover:text-gray-400"
+            class="absolute top-8 right-8 hover:text-jsr-gray-400"
             onClick={() => setOpen(false)}
           >
             <Cross />

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -57,7 +57,7 @@ export function RuntimeCompatIndicator(
           </span>
         )}
         {RUNTIME_COMPAT_KEYS.toReversed().map(
-          ([key, icon, w, h]) => {
+          ([key, _name, icon, w, h]) => {
             const value = runtimeCompat[key];
             if (
               value === false || (hideUnknown && value === undefined)

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -35,7 +35,10 @@ export function RuntimeCompatIndicator(
       worksWithArray.push(name);
       continue;
     }
-    unknownWithArray.push(name);
+    if (status === undefined) {
+      unknownWithArray.push(name);
+      continue;
+    }
   }
 
   return (

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -25,6 +25,19 @@ export function RuntimeCompatIndicator(
   const hasExplicitCompat = Object.values(runtimeCompat).some((v) => v);
   if (!hasExplicitCompat) return null;
 
+  const worksWithArray: string[] = [];
+  const unknownWithArray: string[] = [];
+
+  for (const [key, name] of RUNTIME_COMPAT_KEYS.toReversed()) {
+    const status = runtimeCompat[key];
+
+    if (status) {
+      worksWithArray.push(name);
+      continue;
+    }
+    unknownWithArray.push(name);
+  }
+
   return (
     <div class="min-w-content font-semibold select-none">
       <div
@@ -32,8 +45,19 @@ export function RuntimeCompatIndicator(
           compact ? "*:-mx-1" : "*:mx-0.5"
         } flex-row-reverse`}
       >
+        {worksWithArray.length > 0 && (
+          <span className="sr-only">
+            This package works with {worksWithArray.join(", ")}
+          </span>
+        )}
+        {unknownWithArray.length > 0 && (
+          <span className="sr-only">
+            It is unknown whether this package works with{" "}
+            {unknownWithArray.join(", ")}
+          </span>
+        )}
         {RUNTIME_COMPAT_KEYS.toReversed().map(
-          ([key, name, icon, w, h]) => {
+          ([key, icon, w, h]) => {
             const value = runtimeCompat[key];
             if (
               value === false || (hideUnknown && value === undefined)
@@ -42,17 +66,7 @@ export function RuntimeCompatIndicator(
               <div
                 class="relative h-4 md:h-5"
                 style={`aspect-ratio: ${w} / ${h}`}
-                title={`${
-                  value === undefined
-                    ? "It is unknown whether this package works"
-                    : "This package works"
-                } with ${name}.`}
               >
-                <div className="sr-only">
-                  {value === undefined
-                    ? "It is unknown whether this package works"
-                    : "This package works"} with {name}
-                </div>
                 <img
                   src={icon}
                   width={w}

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -6,7 +6,8 @@ export function Tooltip({ children, tooltip }: {
   tooltip: string;
 }) {
   return (
-    <div class="group/tooltip" aria-label={tooltip}>
+    <div class="group/tooltip">
+      <span className="sr-only">{tooltip}</span>
       {children}
       <div class="w-full flex justify-center">
         <div class="absolute">

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -6,7 +6,7 @@ export function Tooltip({ children, tooltip }: {
   tooltip: string;
 }) {
   return (
-    <div class="group/tooltip">
+    <div class="group/tooltip" aria-label={tooltip}>
       {children}
       <div class="w-full flex justify-center">
         <div class="absolute">

--- a/frontend/components/icons/Check.tsx
+++ b/frontend/components/icons/Check.tsx
@@ -3,6 +3,7 @@ export function Check(props: { class?: string }) {
   return (
     <svg
       class={`size-4 ${props.class ?? ""}`}
+      aria-hidden="true"
       viewBox="0 0 24 24"
       strokeWidth={2}
       stroke="currentColor"

--- a/frontend/components/icons/CheckmarkStamp.tsx
+++ b/frontend/components/icons/CheckmarkStamp.tsx
@@ -3,6 +3,7 @@
 export function CheckmarkStamp(props: { class?: string }) {
   return (
     <svg
+      aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       class={`size-4 ${props.class ?? ""}`}
       viewBox="0 0 24 24"

--- a/frontend/components/icons/ChevronRight.tsx
+++ b/frontend/components/icons/ChevronRight.tsx
@@ -3,6 +3,7 @@ export function ChevronRight(props: { class?: string }) {
   return (
     <svg
       class={`h-4 w-4 ${props.class ?? ""}`}
+      aria-hidden="true"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/components/icons/Cross.tsx
+++ b/frontend/components/icons/Cross.tsx
@@ -3,6 +3,7 @@ export function Cross(props: { class?: string }) { // Size not normalized
   return (
     <svg
       class={`size-6 ${props.class ?? ""}`}
+      aria-hidden="true"
       stroke="currentColor"
       fill="none"
       viewBox="0 0 24 24"

--- a/frontend/components/icons/Error.tsx
+++ b/frontend/components/icons/Error.tsx
@@ -8,6 +8,7 @@ export function ErrorIcon(props: { class?: string }) {
       strokeWidth={1.5}
       stroke="currentColor"
       class={`size-4 ${props.class ?? ""}`}
+      aria-hidden="true"
     >
       <path
         strokeLinecap="round"

--- a/frontend/components/icons/Folder.tsx
+++ b/frontend/components/icons/Folder.tsx
@@ -3,6 +3,7 @@ export function Folder(props: { class?: string }) {
   return (
     <svg
       class={`w-4 h-4 ${props.class ?? ""}`}
+      aria-hidden="true"
       viewBox="0 0 14 14"
       fill="none"
     >

--- a/frontend/components/icons/GitHub.tsx
+++ b/frontend/components/icons/GitHub.tsx
@@ -1,8 +1,9 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-export function GitHub(props: { class?: string }) {
+export function GitHub(props: { class?: string; "aria-hidden"?: boolean }) {
   return (
     <svg
       class={`size-6 ${props.class ?? ""}`}
+      aria-hidden={props["aria-hidden"] ?? false}
       fill="currentColor"
       viewBox="0 0 24 24"
     >

--- a/frontend/components/icons/Plus.tsx
+++ b/frontend/components/icons/Plus.tsx
@@ -3,6 +3,7 @@ export function Plus(props: { class?: string }) {
   return (
     <svg
       class={`w-4 h-4 ${props.class ?? ""}`}
+      aria-hidden="true"
       viewBox="0 0 14 14"
       fill="none"
     >

--- a/frontend/components/icons/Source.tsx
+++ b/frontend/components/icons/Source.tsx
@@ -3,6 +3,7 @@ export function Source(props: { class?: string }) {
   return (
     <svg
       class={`w-4 h-4 ${props.class ?? ""}`}
+      aria-hidden="true"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/islands/GlobalSearch.tsx
+++ b/frontend/islands/GlobalSearch.tsx
@@ -222,7 +222,7 @@ export function GlobalSearch(
           {kindPlaceholder}
         </label>
         <input
-          type="text"
+          type="search"
           name="search"
           class={`block w-full search-input bg-white/90 input rounded-r-none ${sizeClasses} relative`}
           placeholder={placeholder}

--- a/frontend/islands/HomepageHeroParticles.tsx
+++ b/frontend/islands/HomepageHeroParticles.tsx
@@ -126,6 +126,7 @@ export function HomepageHeroParticles() {
           ".particles-js-canvas-el",
         ) as HTMLCanvasElement;
         canvas.style.opacity = "1";
+        canvas.ariaHidden = "true";
       },
     );
   }, []);

--- a/frontend/routes/_layout.tsx
+++ b/frontend/routes/_layout.tsx
@@ -6,6 +6,7 @@ import { State } from "../util.ts";
 export default function Layout(
   { Component, state, url }: PageProps<undefined, State>,
 ) {
+  const currentDatetime = new Date();
   return (
     <>
       <div
@@ -36,10 +37,14 @@ export default function Layout(
         id="footer"
         class="text-xs text-center mt-4 md:mt-6 p-4 text-gray-500"
       >
-        JSR - It is {new Date().toLocaleString("en-ZA", {
-          timeZoneName: "short",
-          timeZone: "Etc/UTC",
-        })} -{" "}
+        JSR - It is{" "}
+        <time datetime={currentDatetime.toISOString()}>
+          {currentDatetime.toLocaleString("en-ZA", {
+            timeZoneName: "short",
+            timeZone: "Etc/UTC",
+          })}
+        </time>{" "}
+        -{" "}
         <a
           href="/docs"
           class="text-cyan-700 hover:text-blue-400 underline"

--- a/frontend/routes/account/tokens/(_islands)/RevokeToken.tsx
+++ b/frontend/routes/account/tokens/(_islands)/RevokeToken.tsx
@@ -19,7 +19,7 @@ export function RevokeToken(props: { id: string }) {
   }
 
   return (
-    <button class="text-red-500 underline hover:text-red-700" onClick={onClick}>
+    <button class="text-red-600 underline hover:text-red-700" onClick={onClick}>
       Revoke token
     </button>
   );

--- a/frontend/routes/account/tokens/index.tsx
+++ b/frontend/routes/account/tokens/index.tsx
@@ -106,17 +106,17 @@ function PersonalTokenRow({ token }: { token: Token }) {
           {isActive
             ? (
               <span
-                class={expiresSoon ? "text-orange-500" : "text-green-500"}
+                class={expiresSoon ? "text-orange-700" : "text-green-700"}
               >
                 <b>Active</b> {expiresAt === null
                   ? "forever"
-                  : `- expires ${
+                  : `– expires ${
                     twas(new Date(), expiresAt).replace("ago", "from now")
                   }`}
               </span>
             )
             : (
-              <span class="text-red-500">
+              <span class="text-red-600">
                 <b>Inactive</b> - expired {twas(expiresAt)}
               </span>
             )}
@@ -159,16 +159,16 @@ function SessionRow({ token }: { token: Token }) {
           <p class="text-sm">
             {isActive
               ? (
-                <span class="text-green-500">
+                <span class="text-green-700">
                   <b>Active</b> {expiresAt === null
                     ? "forever"
-                    : `- expires ${
+                    : `– expires ${
                       twas(new Date(), expiresAt).replace("ago", "from now")
                     }`}
                 </span>
               )
               : (
-                <span class="text-red-500">
+                <span class="text-red-600">
                   <b>Inactive</b> - expired {twas(expiresAt)}
                 </span>
               )}

--- a/frontend/routes/index.tsx
+++ b/frontend/routes/index.tsx
@@ -98,7 +98,7 @@ export default function Home({ data }: PageProps<Data>) {
           <img
             loading="lazy"
             src="/logos/typescript.svg"
-            alt="TypeScript logo"
+            alt=""
             class="w-full max-w-16 lg:max-w-36 lg:col-span-2 lg:mx-auto select-none"
             draggable={false}
           />
@@ -125,21 +125,21 @@ export default function Home({ data }: PageProps<Data>) {
             <img
               loading="lazy"
               src="/logos/npm.svg"
-              alt="npm logo"
+              alt=""
               class="w-full max-w-16 lg:max-w-28 select-none"
               draggable={false}
             />
             <img
               loading="lazy"
               src="/logos/yarn.svg"
-              alt="Yarn logo"
+              alt=""
               class="w-full max-w-16 lg:max-w-28 select-none"
               draggable={false}
             />
             <img
               loading="lazy"
               src="/logos/pnpm.svg"
-              alt="pnpm logo"
+              alt=""
               class="w-full max-w-16 lg:max-w-28 select-none"
               draggable={false}
             />
@@ -166,28 +166,28 @@ export default function Home({ data }: PageProps<Data>) {
             <img
               loading="lazy"
               src="/logos/node.svg"
-              alt="Node.js logo"
+              alt=""
               class="w-full max-w-9 lg:max-w-20 select-none"
               draggable={false}
             />
             <img
               loading="lazy"
               src="/logos/deno.svg"
-              alt="Deno logo"
+              alt=""
               class="w-full max-w-10 lg:max-w-20 select-none"
               draggable={false}
             />
             <img
               loading="lazy"
               src="/logos/bun.svg"
-              alt="Bun logo"
+              alt=""
               class="w-full max-w-11 lg:max-w-20 select-none"
               draggable={false}
             />
             <img
               loading="lazy"
               src="/logos/cloudflare-workers.svg"
-              alt="Cloudflare Workers logo"
+              alt=""
               class="w-full max-w-10 lg:max-w-20 select-none"
               draggable={false}
             />

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -131,8 +131,9 @@ export function PackageHeader(
                   href={`https://github.com/${pkg.githubRepository.owner}/${pkg.githubRepository.name}`}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="GitHub repository"
                 >
-                  <GitHub class="text-black !size-4" />
+                  <GitHub class="text-black !size-4" aria-hidden={true} />
                   <span>
                     {pkg.githubRepository.owner}/{pkg.githubRepository.name}
                   </span>

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -83,11 +83,13 @@ export function PackageHeader(
                   <a
                     href={`/@${pkg.scope}`}
                     class="link font-bold no-underline"
+                    aria-label={`Scope: @${pkg.scope}`}
                   >
                     @{pkg.scope}
                   </a>/<a
                     href={`/@${pkg.scope}/${pkg.name}`}
                     class="link font-semibold no-underline"
+                    aria-label={`Package: ${pkg.name}`}
                   >
                     {pkg.name}
                   </a>
@@ -95,7 +97,10 @@ export function PackageHeader(
 
                 {selectedVersion &&
                   (
-                    <span class="text-lg md:text-[0.75em] font-bold">
+                    <span
+                      class="text-lg md:text-[0.75em] font-bold"
+                      aria-label={`Version: ${selectedVersion.version}`}
+                    >
                       <span class="relative text-[0.80em] -top-[0.175em] font-[800]">
                         @
                       </span>

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -152,7 +152,7 @@ export function PackageHeader(
             {runtimeCompat &&
               (
                 <div class="flex flex-row md:flex-col items-center md:items-end gap-2 md:gap-1.5 text-sm font-bold">
-                  <div>Works with</div>
+                  <div aria-hidden="true">Works with</div>
                   {runtimeCompat}
                 </div>
               )}

--- a/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
+++ b/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
@@ -164,7 +164,7 @@ export function LocalSymbolSearch(
   return (
     <div class="flex-none" ref={ref}>
       <input
-        type="text"
+        type="search"
         placeholder={placeholder}
         id="symbol-search-input"
         class="block text-sm w-full py-2 px-2 input-container input bg-white border-jsr-cyan-300/50"

--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -204,8 +204,9 @@ function GitHubActions({ pkg, canEdit, user }: {
   return (
     <>
       <p class="mt-4">
-        This package is linked to <GitHub class="inline size-5 -mt-[2px]" />
-        {" "}
+        This package is linked to{" "}
+        <GitHub class="inline size-5 -mt-[2px]" aria-hidden={true} />{" "}
+        <span className="sr-only">GitHub</span>{" "}
         <a
           href={`https://github.com/${pkg.githubRepository.owner}/${pkg.githubRepository.name}`}
           class="link"

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -253,10 +253,25 @@ function ScoreItem(
   return (
     <li class="grid grid-cols-[auto_1fr_auto] gap-x-3 py-3 first:pt-0 items-start">
       {status === "complete"
-        ? <Check class="size-6 stroke-green-500 stroke-2 -mt-px" />
+        ? (
+          <>
+            <Check class="size-6 stroke-green-500 stroke-2 -mt-px" />
+            <span class="sr-only">Complete score</span>
+          </>
+        )
         : (status === "partial"
-          ? <ErrorIcon class="size-6 stroke-yellow-500 stroke-2 -mt-px" />
-          : <Cross class="size-6 stroke-red-500 stroke-2 -mt-px" />)}
+          ? (
+            <>
+              <ErrorIcon class="size-6 stroke-yellow-500 stroke-2 -mt-px" />
+              <span class="sr-only">Partial score</span>
+            </>
+          )
+          : (
+            <>
+              <Cross class="size-6 stroke-red-500 stroke-2 -mt-px" />
+              <span class="sr-only">Missing score</span>
+            </>
+          ))}
 
       <div class="max-w-xl pr-2">
         <h3 class="leading-tight">{props.title}</h3>

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -278,7 +278,7 @@ function ScoreItem(
         <p class="text-gray-500 text-sm leading-tight mt-1">{props.children}</p>
       </div>
 
-      <div class="text-sm text-gray-400 pt-[0.2em]">
+      <div class="text-sm text-jsr-gray-400 pt-[0.2em]">
         {typeof props.value === "number"
           ? (
             <span>

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -199,7 +199,7 @@ function Version({
             ? "bg-blue-50 border-blue-200"
             : (isLatestInReleaseTrack
               ? "bg-green-50 hover:bg-green-100 border-green-200 hover:border-green-300"
-              : "hover:bg-gray-100 border-gray-200 hover:border-gray-400"))
+              : "hover:bg-gray-100 border-gray-200 hover:border-jsr-gray-400"))
       }`}
     >
       <div class="flex items-center justify-between">

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -39,7 +39,7 @@ export default function PackageListPage({
         </ListDisplay>
 
         <div className="mt-2 flex flex-wrap items-start justify-between px-2">
-          <span className="text-sm text-gray-400 block">
+          <span className="text-sm text-gray-500 block">
             Changes made in the last 15 minutes may not be visible yet. Packages
             with no published versions are not shown.
           </span>

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -39,7 +39,7 @@ export default function PackageListPage({
         </ListDisplay>
 
         <div className="mt-2 flex flex-wrap items-start justify-between px-2">
-          <span className="text-sm text-gray-500 block">
+          <span className="text-sm text-jsr-gray-400 block">
             Changes made in the last 15 minutes may not be visible yet. Packages
             with no published versions are not shown.
           </span>

--- a/frontend/routes/packages.tsx
+++ b/frontend/routes/packages.tsx
@@ -45,7 +45,8 @@ export default function PackageListPage({
           </span>
           <div class="flex items-center gap-1">
             <span className="text-sm text-gray-500">powered by</span>
-            <img className="h-4" src="/logos/orama-dark.svg" />
+            <span className="sr-only">Orama</span>
+            <img className="h-4" src="/logos/orama-dark.svg" alt="" />
           </div>
         </div>
       </div>

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -314,11 +314,11 @@ body .ddoc:has(.toc) {
 }
 
 .score-text-yellow {
-  @apply text-yellow-500;
+  @apply text-yellow-700;
 }
 
 .score-text-green {
-  @apply text-green-500;
+  @apply text-green-600;
 }
 
 @layer base {


### PR DESCRIPTION
This PR includes a bunch of big and small accessibility improvements spread across the whole frontend-part of JSR.

If you have any questions please let me know :)

Here is a list of what I've changed, fixed and improved:

- Removed all alt-text from the logos on the frontpage.
  - Since they are purely decoration they only add noise to a screen reader, eg: "Works with any runtime... <paragraph>... Deno logo. Bun logo." etc.
- Moved the timestamp in the footer inside a [`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)-element.
- Replaced the `type="text"` for global and symbol search with `type="search"`.
- Fixed contrasting colors a bunch of different places
  - This is the one I'm most uncertain of because I don't know if you are attached to the failing colors, if they are coming from a design system or something similar.
- Fixed the "Powered by Orama" string, the screen reader was reading just "Powered by"
- Added `aria-label` to the logo/home item in the navbar.
- Added `aria-hidden` to a bunch of icons and other misc. stuff that are purely decorative.
  - As well as the canvas on the frontpage.
- Fixed "Works with" on the package page. Now it reads everything in one go instead of the full phrase: "This package works with Deno" + "This package works with Bun" etc.
- Added `aria-label` to the tooltip.
- Made @<scope>/<package> assessible with screen reader in PackageHeader

Again, if you have any questions or additions, please let me know! :)
