### PR TITLE
fix: allow all github flavor markdown codeblock styles for examples

### DIFF
--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -32,6 +32,7 @@ use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReqReference;
 use futures::FutureExt;
 use once_cell::sync::Lazy;
+use regex::bytes::Regex as BytesRegex;
 use regex::Regex;
 use tracing::instrument;
 use tracing::Instrument;
@@ -241,6 +242,9 @@ async fn analyze_package_inner(
   })
 }
 
+static INDENTED_CODE_BLOCK_RE: Lazy<BytesRegex> =
+  Lazy::new(|| BytesRegex::new(r#"\n\s*?\n( {4}|\t)[^\S\n]*\S"#).unwrap());
+
 fn generate_score(
   main_entrypoint: Option<ModuleSpecifier>,
   doc_nodes_by_url: &DocNodesByUrl,
@@ -257,15 +261,21 @@ fn generate_score(
         .map(|node| &node.js_doc)
     });
 
-  let has_readme_examples = readme
-    .is_some_and(|(_, readme)| readme.windows(3).any(|chars| chars == b"```" || chars == b"~~~"))
-    || main_entrypoint_doc.is_some_and(|js_doc| {
-      js_doc.doc.as_ref().is_some_and(|doc| doc.contains("```") || doc.contains("~~~"))
-        || js_doc
-          .tags
-          .iter()
-          .any(|tag| matches!(tag, deno_doc::js_doc::JsDocTag::Example { .. }))
-    });
+  let has_readme_examples = readme.is_some_and(|(_, readme)| {
+    readme
+      .windows(3)
+      .any(|chars| chars == b"```" || chars == b"~~~")
+      || INDENTED_CODE_BLOCK_RE.is_match(readme)
+  }) || main_entrypoint_doc.is_some_and(|js_doc| {
+    js_doc
+      .doc
+      .as_ref()
+      .is_some_and(|doc| doc.contains("```") || doc.contains("~~~"))
+      || js_doc
+        .tags
+        .iter()
+        .any(|tag| matches!(tag, deno_doc::js_doc::JsDocTag::Example { .. }))
+  });
 
   PackageVersionMeta {
     has_readme: readme.is_some()

--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -258,9 +258,9 @@ fn generate_score(
     });
 
   let has_readme_examples = readme
-    .is_some_and(|(_, readme)| readme.windows(3).any(|chars| chars == b"```"))
+    .is_some_and(|(_, readme)| readme.windows(3).any(|chars| chars == b"```" || chars == b"~~~"))
     || main_entrypoint_doc.is_some_and(|js_doc| {
-      js_doc.doc.as_ref().is_some_and(|doc| doc.contains("```"))
+      js_doc.doc.as_ref().is_some_and(|doc| doc.contains("```") || doc.contains("~~~"))
         || js_doc
           .tags
           .iter()


### PR DESCRIPTION
This PR adds additional checks for [tilde fenced code blocks](https://github.github.com/gfm/#fenced-code-blocks) and [indented code blocks](https://github.github.com/gfm/#indented-code-blocks) when scoring a package on readme examples. Both fenced and indented codeblocks are checked for in the readme, whereas the `@module` JSDoc is only checked for fenced code blocks.

Closes #449