### PR TITLE
#618: Add `ExternalLink` icon to GitHub Repo chip

### DIFF
--- a/frontend/components/icons/ExternalLink.tsx
+++ b/frontend/components/icons/ExternalLink.tsx
@@ -1,0 +1,19 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+export function ExternalLink(props: { class?: string }) {
+    return (
+        <svg
+          fill="none"
+          stroke-width="1.5"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          class={`size-4 ${props.class ?? ""}`}
+        >
+          <path 
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+          />
+        </svg>
+    );
+  }

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -1,5 +1,6 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import { Package, PackageVersionWithUser } from "../../../utils/api_types.ts";
+import { ExternalLink } from "../../../components/icons/ExternalLink.tsx";
 import { GitHub } from "../../../components/icons/GitHub.tsx";
 import { RuntimeCompatIndicator } from "../../../components/RuntimeCompatIndicator.tsx";
 import { getScoreTextColorClass } from "../../../utils/score_ring_color.ts";
@@ -141,6 +142,7 @@ export function PackageHeader(
                   <span>
                     {pkg.githubRepository.owner}/{pkg.githubRepository.name}
                   </span>
+                  <ExternalLink />
                 </a>
               )}
             </div>


### PR DESCRIPTION
In this PR:

- An `ExternalLink` icon is added, sourced from [Hero Icons](https://heroicons.dev/).
- `ExternalLink` icon is added to the GitHub repo chip on `[routes/package/(_components)/PackageHeader.tsx](https://github.com/jsr-io/jsr/compare/main...alectrocute:AA/618?expand=1#diff-582c4864144cf2df26b1937b120ca9b37e29168c391792a36abefcfdf8e00639)` to help signify that it's an external link, a needed #618.