### PR TITLE
fix(#443): Improve `RuntimeCompatIndicator` sort and accessibility

### DIFF
--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -25,9 +25,6 @@ export function RuntimeCompatIndicator(
     compact?: boolean;
   },
 ) {
-  const hasExplicitCompat = Object.values(runtimeCompat).some((v) => v);
-  if (!hasExplicitCompat) return null;
-
   const worksWithArray: string[] = [];
   const unknownWithArray: string[] = [];
 

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -1,6 +1,9 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import type { RuntimeCompat } from "../utils/api_types.ts";
 
+const KNOWN_WORKING_PREFIX: string = "This package works with";
+const UNKNOWN_WORKING_PREFIX: string = "It is unknown whether this package works with";
+
 export const RUNTIME_COMPAT_KEYS: [
   key: keyof RuntimeCompat,
   name: string,
@@ -28,7 +31,7 @@ export function RuntimeCompatIndicator(
   const worksWithArray: string[] = [];
   const unknownWithArray: string[] = [];
 
-  for (const [key, name] of RUNTIME_COMPAT_KEYS.toReversed()) {
+  for (const [key, name] of RUNTIME_COMPAT_KEYS) {
     const status = runtimeCompat[key];
 
     if (status) {
@@ -50,21 +53,26 @@ export function RuntimeCompatIndicator(
       >
         {worksWithArray.length > 0 && (
           <span className="sr-only">
-            This package works with {worksWithArray.join(", ")}
+            {KNOWN_WORKING_PREFIX}{" "}{worksWithArray.join(", ")}
           </span>
         )}
         {unknownWithArray.length > 0 && (
           <span className="sr-only">
-            It is unknown whether this package works with{" "}
-            {unknownWithArray.join(", ")}
+            {UNKNOWN_WORKING_PREFIX}{" "}{unknownWithArray.join(", ")}
           </span>
         )}
-        {RUNTIME_COMPAT_KEYS.toReversed().map(
-          ([key, _name, icon, w, h]) => {
+        {RUNTIME_COMPAT_KEYS
+          .sort(([key]) => runtimeCompat[key] ? 1 : -1)
+          .map(
+          ([key, name, icon, w, h]) => {
             const value = runtimeCompat[key];
+
             if (
               value === false || (hideUnknown && value === undefined)
             ) return null;
+
+            const ICON_TITLE_TEXT = `${value === undefined ? UNKNOWN_WORKING_PREFIX : KNOWN_WORKING_PREFIX} ${name}`;
+
             return (
               <div
                 class="relative h-4 md:h-5"
@@ -74,7 +82,8 @@ export function RuntimeCompatIndicator(
                   src={icon}
                   width={w}
                   height={h}
-                  alt=""
+                  alt={ICON_TITLE_TEXT}
+                  title={ICON_TITLE_TEXT}
                   class={`h-4 md:h-5 select-none ${
                     value === undefined ? "filter grayscale opacity-40" : ""
                   }`}
@@ -82,6 +91,7 @@ export function RuntimeCompatIndicator(
                 {value === undefined && (
                   <div
                     aria-hidden="true"
+                    title={ICON_TITLE_TEXT}
                     class="absolute inset-0 h-full w-full text-jsr-cyan-600 text-center leading-4 md:leading-5 drop-shadow-md font-bold text-md md:text-xl select-none"
                   >
                     ?

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -59,7 +59,13 @@ export function RuntimeCompatIndicator(
           </span>
         )}
         {RUNTIME_COMPAT_KEYS
-          .sort(([key]) => runtimeCompat[key] ? 1 : -1)
+          .sort(([keyA], [keyB]) => {
+            if (runtimeCompat[keyA]) {
+              return keyA > keyB ? -1 : 1;
+            } else {
+              return -1;
+            }
+          })
           .map(
           ([key, name, icon, w, h]) => {
             const value = runtimeCompat[key];

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -63,7 +63,7 @@ export function RuntimeCompatIndicator(
             if (runtimeCompat[keyA]) {
               return keyA > keyB ? -1 : 1;
             } else {
-              return -1;
+              return 1;
             }
           })
           .map(

--- a/frontend/components/RuntimeCompatIndicator.tsx
+++ b/frontend/components/RuntimeCompatIndicator.tsx
@@ -2,7 +2,8 @@
 import type { RuntimeCompat } from "../utils/api_types.ts";
 
 const KNOWN_WORKING_PREFIX: string = "This package works with";
-const UNKNOWN_WORKING_PREFIX: string = "It is unknown whether this package works with";
+const UNKNOWN_WORKING_PREFIX: string =
+  "It is unknown whether this package works with";
 
 export const RUNTIME_COMPAT_KEYS: [
   key: keyof RuntimeCompat,
@@ -50,12 +51,12 @@ export function RuntimeCompatIndicator(
       >
         {worksWithArray.length > 0 && (
           <span className="sr-only">
-            {KNOWN_WORKING_PREFIX}{" "}{worksWithArray.join(", ")}
+            {KNOWN_WORKING_PREFIX} {worksWithArray.join(", ")}
           </span>
         )}
         {unknownWithArray.length > 0 && (
           <span className="sr-only">
-            {UNKNOWN_WORKING_PREFIX}{" "}{unknownWithArray.join(", ")}
+            {UNKNOWN_WORKING_PREFIX} {unknownWithArray.join(", ")}
           </span>
         )}
         {RUNTIME_COMPAT_KEYS
@@ -67,43 +68,47 @@ export function RuntimeCompatIndicator(
             }
           })
           .map(
-          ([key, name, icon, w, h]) => {
-            const value = runtimeCompat[key];
+            ([key, name, icon, w, h]) => {
+              const value = runtimeCompat[key];
 
-            if (
-              value === false || (hideUnknown && value === undefined)
-            ) return null;
+              if (
+                value === false || (hideUnknown && value === undefined)
+              ) return null;
 
-            const ICON_TITLE_TEXT = `${value === undefined ? UNKNOWN_WORKING_PREFIX : KNOWN_WORKING_PREFIX} ${name}`;
+              const ICON_TITLE_TEXT = `${
+                value === undefined
+                  ? UNKNOWN_WORKING_PREFIX
+                  : KNOWN_WORKING_PREFIX
+              } ${name}`;
 
-            return (
-              <div
-                class="relative h-4 md:h-5"
-                style={`aspect-ratio: ${w} / ${h}`}
-              >
-                <img
-                  src={icon}
-                  width={w}
-                  height={h}
-                  alt={ICON_TITLE_TEXT}
-                  title={ICON_TITLE_TEXT}
-                  class={`h-4 md:h-5 select-none ${
-                    value === undefined ? "filter grayscale opacity-40" : ""
-                  }`}
-                />
-                {value === undefined && (
-                  <div
-                    aria-hidden="true"
+              return (
+                <div
+                  class="relative h-4 md:h-5"
+                  style={`aspect-ratio: ${w} / ${h}`}
+                >
+                  <img
+                    src={icon}
+                    width={w}
+                    height={h}
+                    alt={ICON_TITLE_TEXT}
                     title={ICON_TITLE_TEXT}
-                    class="absolute inset-0 h-full w-full text-jsr-cyan-600 text-center leading-4 md:leading-5 drop-shadow-md font-bold text-md md:text-xl select-none"
-                  >
-                    ?
-                  </div>
-                )}
-              </div>
-            );
-          },
-        )}
+                    class={`h-4 md:h-5 select-none ${
+                      value === undefined ? "filter grayscale opacity-40" : ""
+                    }`}
+                  />
+                  {value === undefined && (
+                    <div
+                      aria-hidden="true"
+                      title={ICON_TITLE_TEXT}
+                      class="absolute inset-0 h-full w-full text-jsr-cyan-600 text-center leading-4 md:leading-5 drop-shadow-md font-bold text-md md:text-xl select-none"
+                    >
+                      ?
+                    </div>
+                  )}
+                </div>
+              );
+            },
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
In this PR:

- Improve `RuntimeCompatIndicator` sorting and accessibility
  - Sort unknown runtimes to beginning of list to improve readability at quick glance
  - Add `title` and `alt` attributes where applicable to improve accessibility and UX
- If `runtimeCompat` prop is an empty object, then show all runtimes with unknown status instead of rendering empty container, which resolves https://github.com/jsr-io/jsr/issues/443.

<img width="1621" alt="Screenshot 2024-07-01 at 12 53 27 PM" src="https://github.com/jsr-io/jsr/assets/35377827/a8fb8ce1-d3a1-413b-885a-14c90ca55410">
