### PR TITLE
fix: Add missing background on GitHub Workflow .yml example

### DIFF
--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -235,7 +235,7 @@ function GitHubActions({ pkg, canEdit, user }: {
       </p>
 
       <div class="mt-2 -mb-2">
-        <div class="text-white rounded-t font-mono text-sm px-2 py-0.5 inline-block">
+        <div class="bg-gray-700 text-white rounded-t font-mono text-sm px-2 py-0.5 inline-block select-none">
           .github/workflows/publish.yml
         </div>
       </div>


### PR DESCRIPTION
In this PR:

- Add missing background on GitHub Workflow .yml example
  - The text is currently invisible and makes for a confusing experience

<img width="528" alt="Screenshot 2024-07-01 at 3 06 14 PM" src="https://github.com/jsr-io/jsr/assets/35377827/ddc43685-10ce-4aa9-9a46-91d9bd0c7ea9">

<img width="537" alt="Screenshot 2024-07-01 at 3 06 02 PM" src="https://github.com/jsr-io/jsr/assets/35377827/f3749353-739e-4a29-87c4-b969c8dd8a23">
