### PR TITLE
feat(#424): Only apply background color to odd `ListPanel` children if there's more than one

### DIFF
--- a/frontend/components/ListPanel.tsx
+++ b/frontend/components/ListPanel.tsx
@@ -30,7 +30,7 @@ export function ListPanel(
       <ol class="border-1.5 border-jsr-cyan-950 rounded list-none overflow-hidden">
         {children.map((entry) => {
           return (
-            <li class="odd:bg-jsr-cyan-50">
+            <li class={children.length > 1 ? "odd:bg-jsr-cyan-50" : ""}>
               <a
                 class={`flex px-4 items-center py-3 group focus-visible:ring-2 ring-jsr-cyan-700 ring-inset outline-none hover:bg-jsr-yellow-200 focus-visible:bg-jsr-yellow-200 ${
                   entry.value === selected ? "text-cyan-700 font-bold" : ""


### PR DESCRIPTION
In this PR:

- Only apply background color to odd `ListPanel` children if there's more than one
  - `ListPanel` is used by `[id].tsx` to show which scopes you're a member of. If the user is only a member of one scope, then `ListPanel` will add a background color. This has a side effect of making it look like an input field. I propose we disable coloring the background if there's only a single child.
- Resolves https://github.com/jsr-io/jsr/issues/424

<img width="1190" alt="Screenshot 2024-07-01 at 3 24 33 PM" src="https://github.com/jsr-io/jsr/assets/35377827/8f40fb7d-2dc6-407b-8c52-4adf6cb33150">
