### PR TITLE
feat(ogp): Add Content-Type to OGP Image

### DIFF
--- a/frontend/routes/package/og.ts
+++ b/frontend/routes/package/og.ts
@@ -396,8 +396,8 @@ export const handler: Handlers<undefined, State> = {
 
     return new Response(await ogpImage.encode(), {
       headers: {
-        'Content-Type': 'image/png'
-      }
+        "Content-Type": "image/png",
+      },
     });
   },
 };

--- a/frontend/routes/package/og.ts
+++ b/frontend/routes/package/og.ts
@@ -394,7 +394,11 @@ export const handler: Handlers<undefined, State> = {
       HEIGHT - JSR_LOGO_HEIGHT - PADDING,
     );
 
-    return new Response(await ogpImage.encode());
+    return new Response(await ogpImage.encode(), {
+      headers: {
+        'Content-Type': 'image/png'
+      }
+    });
   },
 };
 


### PR DESCRIPTION
I added Content-Type to OGP Image.
When it's in production environment, Content-Type be `text/html` so I fixed it.