### PR TITLE
feat: add an API to assign reserved scopes

### DIFF
--- a/api/src/api/scope.rs
+++ b/api/src/api/scope.rs
@@ -89,7 +89,7 @@ async fn create_handler(mut req: Request<Body>) -> ApiResult<ApiScope> {
     serde_json::from_str(reserved_scopes).unwrap()
   });
 
-  if reserved_scopes.contains(&scope_without_hyphens) && !user.is_staff {
+  if reserved_scopes.contains(&scope_without_hyphens) {
     return Err(ApiError::ScopeNameReserved);
   }
 

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -904,3 +904,10 @@ pub struct ApiCreatedToken {
   pub secret: String,
   pub token: ApiToken,
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiAssignScopeRequest {
+  pub scope: ScopeName,
+  pub user_id: Uuid,
+}

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "tasks": {
     "services:macos": "./tools/bin/darwin-arm64/jaeger-all-in-one  & ./tools/bin/darwin-arm64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
-    "services:linux": "docker-compose up & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
-    "services:linux-no-postgres": "docker-compose up jaeger & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
+    "services:linux": "docker compose up & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
+    "services:linux-no-postgres": "docker compose up jaeger & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
     "dev:api": "cd api && cargo run",
     "dev:frontend": "cd frontend && OLTP_ENDPOINT=http://localhost:4318 deno task start",
     "prod:frontend": "deno run -A --watch ./tools/prod_proxy.ts & cd frontend && API_ROOT=https://api.jsr.io deno task start",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     image: postgres:15

--- a/frontend/components/URLQuerySearch.tsx
+++ b/frontend/components/URLQuerySearch.tsx
@@ -1,7 +1,7 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 export function URLQuerySearch({ query }: { query: string }) {
   return (
-    <form method="GET" class="flex mt-4">
+    <form method="GET" class="flex mt-4 flex-grow">
       <input
         type="text"
         name="search"

--- a/frontend/fresh.gen.ts
+++ b/frontend/fresh.gen.ts
@@ -19,7 +19,8 @@ import * as $account_tokens_index from "./routes/account/tokens/index.tsx";
 import * as $admin_middleware from "./routes/admin/_middleware.ts";
 import * as $admin_index from "./routes/admin/index.tsx";
 import * as $admin_publishingTasks from "./routes/admin/publishingTasks.tsx";
-import * as $admin_scopes from "./routes/admin/scopes.tsx";
+import * as $admin_scopes_assign from "./routes/admin/scopes/assign.tsx";
+import * as $admin_scopes_index from "./routes/admin/scopes/index.tsx";
 import * as $admin_users from "./routes/admin/users.tsx";
 import * as $auth from "./routes/auth.tsx";
 import * as $badges_package from "./routes/badges/package.ts";
@@ -95,7 +96,8 @@ const manifest = {
     "./routes/admin/_middleware.ts": $admin_middleware,
     "./routes/admin/index.tsx": $admin_index,
     "./routes/admin/publishingTasks.tsx": $admin_publishingTasks,
-    "./routes/admin/scopes.tsx": $admin_scopes,
+    "./routes/admin/scopes/assign.tsx": $admin_scopes_assign,
+    "./routes/admin/scopes/index.tsx": $admin_scopes_index,
     "./routes/admin/users.tsx": $admin_users,
     "./routes/auth.tsx": $auth,
     "./routes/badges/package.ts": $badges_package,

--- a/frontend/routes/admin/scopes/assign.tsx
+++ b/frontend/routes/admin/scopes/assign.tsx
@@ -1,0 +1,57 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+import { Handlers, PageProps } from "$fresh/server.ts";
+import type { State } from "../../../util.ts";
+import { AdminNav } from "../(_components)/AdminNav.tsx";
+import { path } from "../../../utils/api.ts";
+
+export default function Scopes({}: PageProps<void, State>) {
+  return (
+    <div class="mb-20">
+      <AdminNav currentTab="scopes" />
+      <h2 class="mt-4 text-xl font-sans font-bold">
+        Assign scope to user
+      </h2>
+      <p class="mt-4 max-w-3xl">
+        This will assign the given scope to a user, without that user having to
+        be invited and accepting the invite. This bypasses the normal reserved
+        scope checks, or scope quota limit checks.
+      </p>
+      <form method="POST" class="flex mt-4">
+        <input
+          type="text"
+          name="scope"
+          placeholder="Scope"
+          class="block w-full p-1.5 input-container input"
+        />
+        <input
+          type="text"
+          name="user_id"
+          placeholder="User ID"
+          class="ml-4 block w-full p-1.5 input-container input"
+        />
+        <button type="submit" class="button-primary ml-4">
+          Assign
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export const handler: Handlers<void, State> = {
+  async POST(req, ctx) {
+    const form = await req.formData();
+    const scope = form.get("scope");
+    const userId = form.get("user_id");
+
+    const res = await ctx.state.api.post(path`/admin/scopes`, {
+      scope,
+      userId,
+    });
+    if (!res.ok) throw res;
+
+    return new Response(null, {
+      status: 303,
+      headers: { Location: "/admin/scopes" },
+    });
+  },
+};

--- a/frontend/routes/admin/scopes/index.tsx
+++ b/frontend/routes/admin/scopes/index.tsx
@@ -1,12 +1,13 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import { Handlers, PageProps } from "$fresh/server.ts";
-import type { PaginationData, State } from "../../util.ts";
-import type { FullScope, List } from "../../utils/api_types.ts";
-import ScopeEdit from "../../islands/admin/ScopeEdit.tsx";
-import { Table } from "../../components/Table.tsx";
-import { path } from "../../utils/api.ts";
-import { AdminNav } from "./(_components)/AdminNav.tsx";
-import { URLQuerySearch } from "../../components/URLQuerySearch.tsx";
+import type { PaginationData, State } from "../../../util.ts";
+import type { FullScope, List } from "../../../utils/api_types.ts";
+import ScopeEdit from "../../../islands/admin/ScopeEdit.tsx";
+import { Table } from "../../../components/Table.tsx";
+import { path } from "../../../utils/api.ts";
+import { AdminNav } from "../(_components)/AdminNav.tsx";
+import { URLQuerySearch } from "../../../components/URLQuerySearch.tsx";
+import IconArrowRight from "$tabler_icons/arrow-right.tsx";
 
 interface Data extends PaginationData {
   scopes: FullScope[];
@@ -17,7 +18,12 @@ export default function Scopes({ data, url }: PageProps<Data>) {
   return (
     <div class="mb-20">
       <AdminNav currentTab="scopes" />
-      <URLQuerySearch query={data.query} />
+      <div class="flex gap-4">
+        <URLQuerySearch query={data.query} />
+        <a class="button-primary mt-4" href="/admin/scopes/assign">
+          Assign Scope <IconArrowRight />
+        </a>
+      </div>
       <Table
         class="mt-8"
         columns={[


### PR DESCRIPTION
This alleviates the need for users being assigned
scopes to manually accept an invitation.
