### PR TITLE
Small style updates and UI fixes (including one-col symbol layout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Setup postgres for tests
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Build
         run: cargo build --all-targets --tests
@@ -271,4 +271,3 @@ jobs:
           ORAMA_DOCS_INDEX_ID: ${{ secrets.ORAMA_DOCS_INDEX_ID }}
           ORAMA_DOCS_PRIVATE_API_KEY: ${{ secrets.ORAMA_DOCS_PRIVATE_API_KEY }}
         run: deno task tools:orama:docs_reindex
-

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -297,7 +297,10 @@ body .ddoc {
     @apply hidden md:block text-xs;
   }
 
-  .symbolGroup article > div:hover .context_button,
+  .symbolGroup article > div:hover > div + a.context_button {
+    @apply md:visible;
+  }
+
   .docEntryHeader:hover > .context_button {
     @apply md:visible;
   }

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -202,8 +202,15 @@
 /* !important seems necessary for taking precedent over current ddoc styling */
 body .ddoc {
   .markdown {
+    @apply max-w-prose;
+
     h1 {
       @apply mt-8 -mx-4 px-4 md:mx-0 md:px-0 text-3xl md:text-4xl font-semibold !important;
+    }
+
+    /* Styles the first H1 in a readme a little differently */
+    h1:first-of-type {
+      @apply mt-0 border-none mb-6 !important;
     }
 
     h2 {
@@ -271,10 +278,55 @@ body .ddoc {
     }
   }
 
+  .usageContent .markdown {
+    @apply max-w-full;
+  }
+
+  /* Hides the link to code button unless you hover over the section or are on mobile */
+  .symbolGroup article > div:hover .context_button {
+    @apply md:visible;
+  }
+
+  .docEntryHeader:hover > .context_button {
+    @apply md:visible;
+  }
+
+  .context_button {
+    @apply flex flex-row gap-2 items-center md:invisible;
+  }
+
+  .context_button {
+    @apply rounded no-underline !important;
+  }
+
+  .context_button::before {
+    content: "View code";
+    @apply hidden md:block text-xs;
+  }
+
+  /* Style overrides for a better single column layout on symbol pages */
+  .namespaceSection {
+    @apply grid-cols-1 gap-2 max-w-prose !important;
+  }
+
+  .docNodeKindIcon div {
+    @apply h-4 w-4 leading-4;
+  }
+
+  .markdown_summary p {
+    @apply leading-normal;
+  }
+
+  .section > div:first-child > h2 {
+    @apply mb-4 !important;
+  }
+
   #module_doc,
   main {
     @apply pb-8;
   }
+
+  /* Table of contents adjustments */
 
   .toc .topSymbols {
     @apply max-lg:hidden;

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -281,7 +281,8 @@ body .ddoc {
   .usageContent .markdown {
     @apply max-w-full;
   }
-
+    
+  /* START Upstream to deno_doc  */
   /* Hides the link to code button unless you hover over the section or are on mobile */
 
   .context_button {
@@ -314,6 +315,8 @@ body .ddoc {
     @apply h-4 w-4 leading-4;
   }
 
+  /* END Upstream to deno_doc  */
+    
   .markdown_summary p {
     @apply leading-normal;
   }

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -283,13 +283,6 @@ body .ddoc {
   }
 
   /* Hides the link to code button unless you hover over the section or are on mobile */
-  .symbolGroup article > div:hover .context_button {
-    @apply md:visible;
-  }
-
-  .docEntryHeader:hover > .context_button {
-    @apply md:visible;
-  }
 
   .context_button {
     @apply flex flex-row gap-2 items-center md:invisible;
@@ -302,6 +295,11 @@ body .ddoc {
   .context_button::before {
     content: "View code";
     @apply hidden md:block text-xs;
+  }
+
+  .symbolGroup article > div:hover .context_button,
+  .docEntryHeader:hover > .context_button {
+    @apply md:visible;
   }
 
   /* Style overrides for a better single column layout on symbol pages */


### PR DESCRIPTION
A few small things addressed in this PR

- One column symbol layout 
- Link to code snippets visible on hover instead of by default 
- H1 at the top of readme gets a special style treatment
- Fixed some bugs with mobile viewport rendering of the usage block

<img width="1385" alt="Screenshot 2024-08-01 at 4 17 56 PM" src="https://github.com/user-attachments/assets/e40cf5f2-add7-44fa-9fb9-cf4570f78af6">

<img width="856" alt="Screenshot 2024-08-01 at 4 17 10 PM" src="https://github.com/user-attachments/assets/6bbe605a-ed68-49d8-bbf3-24ea2c6694f1">

<img width="1385" alt="Screenshot 2024-08-01 at 4 16 46 PM" src="https://github.com/user-attachments/assets/bc494ff7-0ed9-45fe-90af-a04af0e9d235">

https://jam.dev/c/6a322747-f14b-4f3e-be9d-2b81669ff8d0