### PR TITLE
docs: polish custom badge example

### DIFF
--- a/frontend/docs/badges.md
+++ b/frontend/docs/badges.md
@@ -93,15 +93,15 @@ These badges can be customized by adding query parameters to the URL, for
 example:
 
 ```
-https://jsr.io/badges/@<scope>/<package>?color=blue&labelColor=121212&logoColor=red
+https://jsr.io/badges/@luca?logoColor=f7fd1e&color=f7fd1e&labelColor=083344
 ```
 
 Here's how it looks:
 
-[![JSR Scope](https://jsr.io/badges/@luca?color=blue&labelColor=121212&logoColor=red)](https://jsr.io/@luca)
+[![JSR Scope](https://jsr.io/badges/@luca?logoColor=f7fd1e&color=f7fd1e&labelColor=083344)](https://jsr.io/@luca)
 
 The supported style-related query parameters can be found in the
 [Shields.io documentation](https://shields.io/badges/endpoint-badge#:~:text=Query%20Parameters).
 
-> Note: `logoSize`, `logo`, `url` and `cacheSeconds` are not supported and if
-> provided, they will be ignored.
+> Note: `logoSize`, `logo`, `url`, `message` and `cacheSeconds` are not
+> supported and if provided, they will be ignored.


### PR DESCRIPTION
This polishes the example badge to give it a better visual.

I also added the `message` to the ignore list.