### PR TITLE
update docs about migrating from HTTP specifiers

### DIFF
--- a/frontend/docs/migrate-x-to-jsr.md
+++ b/frontend/docs/migrate-x-to-jsr.md
@@ -80,16 +80,28 @@ If you are using HTTPS modules from the standard library, we recommend updating
 those dependencies to use the newer [@std scope on JSR](https://jsr.io/@std).
 This will be the place to get the latest version of these modules going forward.
 
-_Use `deno vendor` for other dependencies on deno.land/x_
+```diff
+- import { copy } from "https://deno.land/std@0.224.0/fs/copy.ts";
++ import { copy } from "jsr:@std/fs@1/copy";
+```
+
+_Replace dependencies with equivalent npm or JSR ones_
 
 For other dependencies in your project, you can also replace them one by one
 with equivalent dependencies on npm or JSR as described above.
 
-If you find that this process would be prohibitively difficult, you also have
-the option of using the
-[`deno vendor`](https://docs.deno.com/runtime/manual/tools/vendor) command to
-download local versions of all your HTTPS dependencies, and store them alongside
-your package in source control.
+```diff
+- import * as Hono from "https://deno.land/x/hono@v4.3.11/mod.ts";
++ import { Hono } from "npm:hono";
+```
+
+_Vendor dependencies_
+
+You can also
+[vendor your dependencies](https://docs.deno.com/runtime/manual/basics/vendoring/)
+by adding `"vendor": true` to your `deno.json` file. This will download local
+versions of your HTTPS dependencies to a `vendor` directory when the project is
+ran.
 
 #### 2.) Ensure your library does not contain slow types
 


### PR DESCRIPTION
i wasn't able to find code diff example for the third "vendoring dependencies" section, so i'm open to suggestions there