### PR TITLE
chore: get ready for Deno 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           deno-version: 1.x
 
       - name: Check license headers
-        run: deno task lint:license
+        run: deno run lint:license
 
       - name: Format
         run: deno fmt --check
@@ -43,7 +43,7 @@ jobs:
         working-directory: frontend
 
       - name: Build Fresh
-        run: deno task build
+        run: deno run build
         working-directory: frontend
 
   test:
@@ -191,9 +191,9 @@ jobs:
       - name: terraform plan
         run: |
           touch terraform/staging.secret.tfvars
-          deno task tf:staging:init
+          deno run tf:staging:init
           terraform version
-          deno task tf:staging:plan
+          deno run tf:staging:plan
         env:
           API_IMAGE_ID: ${{ needs.docker-images.outputs.api_image_id }}
           FRONTEND_IMAGE_ID: ${{ needs.docker-images.outputs.frontend_image_id }}
@@ -203,16 +203,16 @@ jobs:
           TF_VAR_orama_package_private_api_key: ${{ secrets.ORAMA_PACKAGE_PRIVATE_API_KEY }}
 
       - name: terraform apply
-        run: deno task tf:staging:apply
+        run: deno run tf:staging:apply
 
       - name: Run e2e tests
-        run: deno task e2e:staging
+        run: deno run e2e:staging
 
       - name: Reindex orama docs search
         env:
           ORAMA_DOCS_INDEX_ID: ${{ secrets.ORAMA_DOCS_INDEX_ID }}
           ORAMA_DOCS_PRIVATE_API_KEY: ${{ secrets.ORAMA_DOCS_PRIVATE_API_KEY }}
-        run: deno task tools:orama:docs_reindex
+        run: deno run tools:orama:docs_reindex
 
   prod:
     if: github.event_name == 'push' || github.ref == 'refs/heads/main'
@@ -249,9 +249,9 @@ jobs:
       - name: terraform plan
         run: |
           touch terraform/prod.secret.tfvars
-          deno task tf:prod:init
+          deno run tf:prod:init
           terraform version
-          deno task tf:prod:plan
+          deno run tf:prod:plan
         env:
           API_IMAGE_ID: ${{ needs.docker-images.outputs.api_image_id }}
           FRONTEND_IMAGE_ID: ${{ needs.docker-images.outputs.frontend_image_id }}
@@ -261,13 +261,13 @@ jobs:
           TF_VAR_orama_package_private_api_key: ${{ secrets.ORAMA_PACKAGE_PRIVATE_API_KEY }}
 
       - name: terraform apply
-        run: deno task tf:prod:apply
+        run: deno run tf:prod:apply
 
       - name: Run e2e tests
-        run: deno task e2e:prod
+        run: deno run e2e:prod
 
       - name: Reindex orama docs search
         env:
           ORAMA_DOCS_INDEX_ID: ${{ secrets.ORAMA_DOCS_INDEX_ID }}
           ORAMA_DOCS_PRIVATE_API_KEY: ${{ secrets.ORAMA_DOCS_PRIVATE_API_KEY }}
-        run: deno task tools:orama:docs_reindex
+        run: deno run tools:orama:docs_reindex

--- a/.github/workflows/orama_package_reindex.yml
+++ b/.github/workflows/orama_package_reindex.yml
@@ -24,4 +24,4 @@ jobs:
           ORAMA_PACKAGE_INDEX_ID: ${{ secrets.ORAMA_PACKAGE_INDEX_ID }}
           ORAMA_PACKAGE_PRIVATE_API_KEY: ${{ secrets.ORAMA_PACKAGE_PRIVATE_API_KEY }}
           JSR_URL: ${{ vars.ENVIRONMENT_URL }}
-        run: deno task tools:orama:package_reindex
+        run: deno run tools:orama:package_reindex

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ frontend in a development mode that connects to the production API.
 
 ### Running jsr
 
-1. `deno task prod:frontend`
+1. `deno run prod:frontend`
 
 You can view the registry at `http://jsr.test`. This frontend is connected to
 the production API - use it with the same care that you would use the live
@@ -114,9 +114,9 @@ making changes to the API.
 
 ### Running jsr
 
-1. `deno task services:macos` or `deno task services:linux` in one terminal
-2. `deno task dev:api` in another terminal
-3. `deno task dev:frontend` in another terminal
+1. `deno run services:macos` or `deno run services:linux` in one terminal
+2. `deno run dev:api` in another terminal
+3. `deno run dev:frontend` in another terminal
 
 You can view the registry at `http://jsr.test`. The API can be found at
 `http://api.jsr.test`.

--- a/deno.json
+++ b/deno.json
@@ -4,16 +4,16 @@
     "services:linux": "docker compose up & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
     "services:linux-no-postgres": "docker compose up jaeger & ./tools/bin/linux-amd64/fake-gcs-server -scheme http -port 4080 -filesystem-root=.gcs & ./tools/server.ts",
     "dev:api": "cd api && cargo run",
-    "dev:frontend": "cd frontend && OLTP_ENDPOINT=http://localhost:4318 deno task start",
-    "prod:frontend": "deno run -A --watch ./tools/prod_proxy.ts & cd frontend && API_ROOT=https://api.jsr.io deno task start",
-    "lint": "deno task lint:frontend && deno task lint:license",
+    "dev:frontend": "cd frontend && OLTP_ENDPOINT=http://localhost:4318 deno run start",
+    "prod:frontend": "deno -A --watch ./tools/prod_proxy.ts & cd frontend && API_ROOT=https://api.jsr.io deno run start",
+    "lint": "deno run lint:frontend && deno run lint:license",
     "lint:frontend": "cd frontend && deno lint && deno check main.ts",
-    "lint:license": "deno run --allow-read jsr:@kt3k/license-checker@3.2.11/main -q",
-    "lint:license:fix": "deno run --allow-read --allow-write jsr:@kt3k/license-checker@3.2.11/main -q --inject",
-    "tools:orama:package_reindex": "deno run --allow-env --allow-net tools/orama_package_reindex.ts",
-    "tools:orama:docs_reindex": "deno run --allow-env --allow-net --allow-read tools/orama_docs_reindex.ts",
-    "tools:deno_symbols": "deno run --allow-run --allow-read --allow-env --allow-net --allow-write tools/generate_global_symbols.ts",
-    "tools:web_symbols": "deno run --allow-write tools/generate_web_symbols.ts",
+    "lint:license": "deno --allow-read jsr:@kt3k/license-checker@3.2.11/main -q",
+    "lint:license:fix": "deno --allow-read --allow-write jsr:@kt3k/license-checker@3.2.11/main -q --inject",
+    "tools:orama:package_reindex": "deno --allow-env --allow-net tools/orama_package_reindex.ts",
+    "tools:orama:docs_reindex": "deno --allow-env --allow-net --allow-read tools/orama_docs_reindex.ts",
+    "tools:deno_symbols": "deno --allow-run --allow-read --allow-env --allow-net --allow-write tools/generate_global_symbols.ts",
+    "tools:web_symbols": "deno --allow-write tools/generate_web_symbols.ts",
 
     "tf:infra:init": "gcloud config set project deno-registry3-infra && cd terraform_infra && terraform init -backend-config bucket=deno-registry3-infra-terraform",
     "tf:infra:plan": "cd terraform_infra && terraform plan -var-file=infra.tfvars -out=infra.tfplan -input=false",
@@ -28,12 +28,7 @@
     "e2e:staging": "cd e2e && JSR_URL=https://deno-registry-staging.net/ JSR_API_URL=https://api.deno-registry-staging.net/ deno test -A",
     "e2e:prod": "cd e2e && JSR_URL=https://jsr.io/ JSR_API_URL=https://api.jsr.io/ deno test -A"
   },
-  "exclude": [
-    "target/",
-    "api/testdata/",
-    ".gcs/",
-    "frontend/_fresh"
-  ],
+  "exclude": ["target/", "api/testdata/", ".gcs/", "frontend/_fresh"],
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "npm:preact"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN deno task build
+RUN deno run build
 RUN deno cache main.ts
 
 CMD ["run", "-A", "--cached-only", "main.ts"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,7 +10,7 @@ Make sure to install Deno: https://deno.land/manual/getting_started/installation
 Then start the project:
 
 ```
-deno task start
+deno run start
 ```
 
 This will watch the project directory and restart as necessary.

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -3,10 +3,10 @@
   "nodeModulesDir": true,
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx",
-    "start": "deno run -A --watch=static/,routes/ dev.ts",
-    "build": "deno run -A dev.ts build",
-    "preview": "deno run -A main.ts",
-    "update": "deno run -A -r https://fresh.deno.dev/update ."
+    "start": "deno -A --watch=static/,routes/ dev.ts",
+    "build": "deno -A dev.ts build",
+    "preview": "deno -A main.ts",
+    "update": "deno -A -r https://fresh.deno.dev/update ."
   },
   "lint": {
     "rules": {

--- a/frontend/dev.ts
+++ b/frontend/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/
+#!/usr/bin/env -S deno -A --watch=static/,routes/
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 
 import dev from "$fresh/dev.ts";

--- a/frontend/docs/migrate-x-to-jsr.md
+++ b/frontend/docs/migrate-x-to-jsr.md
@@ -54,7 +54,7 @@ Then, from within your package folder (probably the one with your `deno.json` or
 `mod.ts`), execute the following command:
 
 ```bash
-deno run -Ar jsr:@deno/x-to-jsr
+deno -Ar jsr:@deno/x-to-jsr
 ```
 
 This will automatically refactor code where possible, and provide instructions

--- a/tools/prod_proxy.ts
+++ b/tools/prod_proxy.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch
+#!/usr/bin/env -S deno -A --watch
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 
 import { isCDNRequest, proxy } from "./server.ts";

--- a/tools/server.ts
+++ b/tools/server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch
+#!/usr/bin/env -S deno -A --watch
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 
 const FRONTEND_SERVER = "http://localhost:8000";


### PR DESCRIPTION
According to https://deno.com/blog/v1.46, we can use a simpler CLI for `deno run` and `deno task`.

### Changes

- Update all `deno run` to `deno`
- Update all `deno task` to `deno run`

Some `deno run` commands fail because of:

- https://github.com/denoland/deno/issues/25232

Now the issue has been fixed.