### PR TITLE
chore: optimized SVG logo

### DIFF
--- a/frontend/static/logo.svg
+++ b/frontend/static/logo.svg
@@ -1,8 +1,6 @@
-<svg width="100%" height="100%" viewBox="0 0 13 7" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <path d="M0,2h2v-2h7v1h4v4h-2v2h-7v-1h-4" fill="#083344" />
-  <g fill="#f7df1e" >
-    <path d="M1,3h1v1h1v-3h1v4h-3" />
-    <path d="M5,1h3v1h-2v1h2v3h-3v-1h2v-1h-2" />
-    <path d="M9,2h3v2h-1v-1h-1v3h-1" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 7">
+  <path fill="#083344" d="M0 6h4v1h7V5h2V1H9V0H2v2H0" />
+  <path
+    fill="#f7df1e"
+    d="M4 5V1H3v3H2V3H1v2h6V4H5V1h3v1h4v2h-1V3h-1v3H9V2H6v1h2v3H5V5" />
 </svg>


### PR DESCRIPTION
I saw [this post](https://deno.com/blog/designing-jsr) on social media and decided to check the SVG code of the logo, and I noticed it could be made smaller by manually tweaking the coordinates of the paths, so we get this for the background:

```diff
- M0,2h2v-2h7v1h4v4h-2v2h-7v-1h-4
+ M0 6h4v1h7V5h2V1H9V0H2v2H0
```

And this for the foreground:

```diff
- M1,3h1v1h1v-3h1v4h-3M5,1h3v1h-2v1h2v3h-3v-1h2v-1h-2M9,2h3v2h-1v-1h-1v3h-1
+ M4 5V1H3v3H2V3H1v2h6V4H5V1h3v1h4v2h-1V3h-1v3H9V2H6v1h2v3H5V5
```

It's a tiny improvement (18 less bytes), so feel free to reject this PR. I did the same thing in the past with the [NPM Logo](https://gist.github.com/loucyx/73a3b2a2db9d9b629a94) ... I just love to optimize SVGs manually 😅 