### PR TITLE
fix: make the right side of package header visible

### DIFF
--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -74,7 +74,7 @@ export function PackageHeader(
         </div>
       )}
 
-      <div class="flex flex-col md:flex-row items-start justify-between gap-6">
+      <div class="flex flex-col flex-wrap md:flex-row items-start justify-between gap-6">
         <div class="space-y-3.5 flex-shrink">
           <div class="flex flex-row gap-x-3 gap-y-2 flex-wrap md:items-center">
             <h1 class="text-2xl md:text-3xl flex flex-wrap items-center font-sans gap-x-2">
@@ -155,7 +155,7 @@ export function PackageHeader(
           )}
         </div>
 
-        <div class="flex flex-none md:items-end flex-col gap-2 md:gap-4 text-right pb-4">
+        <div class="flex flex-none md:items-end flex-col gap-2 md:gap-4 text-right pb-4 md:ml-auto">
           <div class="flex flex-col md:flex-row gap-2 md:gap-8 items-between">
             {runtimeCompat &&
               (


### PR DESCRIPTION
If you try to access this package via the following URL: 
https://jsr.io/@planetarium/lib9c@0.3.0-dev.202409100854550774+2db5208d2bf73ba22624cdd8f2f7cf167097359e

you'll notice that the right side of the package header isn’t fully visible. This happens because the version string is unusually long.
![image](https://github.com/user-attachments/assets/d8aa0bfb-3be0-4762-b827-0fcf3923f22d)

While this issue is rare, I wanted to ensure that the package details are at least viewable. I considered implementing a more polished solution, but it impacted other parts of the UI and required more effort for something that doesn't occur often. So, I decided to go with a simpler, cleaner fix that achieves the primary goal which is making the information visible.

so now it looks like this:
![image](https://github.com/user-attachments/assets/fa57b3b9-659c-4a42-900c-8b98d793f212)