### PR TITLE
fix: make links relative to github for readme if github repo is present

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -934,7 +934,7 @@ pub async fn get_docs_handler(
 
   let db = req.data::<Database>().unwrap();
   let buckets = req.data::<Buckets>().unwrap();
-  let (package, _, _) = db
+  let (package, repo, _) = db
     .get_package(&scope, &package_name)
     .await?
     .ok_or(ApiError::PackageNotFound)?;
@@ -1019,6 +1019,7 @@ pub async fn get_docs_handler(
     package_name.clone(),
     version.version.clone(),
     version_or_latest == VersionOrLatest::Latest,
+    repo,
     readme,
     package.runtime_compat,
     registry_url,
@@ -1062,7 +1063,7 @@ pub async fn get_docs_search_handler(
 
   let db = req.data::<Database>().unwrap();
   let buckets = req.data::<Buckets>().unwrap();
-  let (package, _, _) = db
+  let (package, repo, _) = db
     .get_package(&scope, &package_name)
     .await?
     .ok_or(ApiError::PackageNotFound)?;
@@ -1104,6 +1105,7 @@ pub async fn get_docs_search_handler(
     package_name.clone(),
     version.version.clone(),
     version_or_latest == VersionOrLatest::Latest,
+    repo,
     false,
     package.runtime_compat,
     registry_url,
@@ -1132,7 +1134,7 @@ pub async fn get_docs_search_html_handler(
 
   let db = req.data::<Database>().unwrap();
   let buckets = req.data::<Buckets>().unwrap();
-  let (package, _, _) = db
+  let (package, repo, _) = db
     .get_package(&scope, &package_name)
     .await?
     .ok_or(ApiError::PackageNotFound)?;
@@ -1175,6 +1177,7 @@ pub async fn get_docs_search_html_handler(
     package_name.clone(),
     version.version.clone(),
     version_or_latest == VersionOrLatest::Latest,
+    repo,
     None,
     package.runtime_compat,
     registry_url,

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -565,6 +565,12 @@ pub struct GithubRepository {
   pub created_at: DateTime<Utc>,
 }
 
+impl GithubRepository {
+  pub fn get_head_url(&self) -> String {
+    format!("https://github.com/{}/{}/blob/HEAD", self.owner, self.name)
+  }
+}
+
 pub struct NewGithubRepository<'s> {
   pub id: i64,
   pub owner: &'s str,

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -565,12 +565,6 @@ pub struct GithubRepository {
   pub created_at: DateTime<Utc>,
 }
 
-impl GithubRepository {
-  pub fn get_head_url(&self) -> String {
-    format!("https://github.com/{}/{}/blob/HEAD", self.owner, self.name)
-  }
-}
-
 pub struct NewGithubRepository<'s> {
   pub id: i64,
   pub owner: &'s str,


### PR DESCRIPTION
For https://github.com/jsr-io/jsr/issues/717

> We could do a fallback mechanism though: either we link to JSR source if the file exists, or to GitHub if that is specified, or it is a dead link.

_Originally posted by @lucacasonato in https://github.com/jsr-io/jsr/issues/717#issuecomment-2343859084_
            