### PR TITLE
chore: use deno 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.0.0-rc.1
+          deno-version: v2.x
 
       - name: Check license headers
         run: deno task lint:license
@@ -39,7 +39,7 @@ jobs:
         working-directory: frontend
 
       - name: Typecheck
-        run: deno check main.ts
+        run: deno check --allow-import main.ts
         working-directory: frontend
 
       - name: Build Fresh
@@ -173,7 +173,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.0.0-rc.1
+          deno-version: v2.x
 
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
@@ -231,7 +231,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.0.0-rc.1
+          deno-version: v2.x
 
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/orama_package_reindex.yml
+++ b/.github/workflows/orama_package_reindex.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 2.0.0-rc.1
+          deno-version: v2.x
       - name: Deploy
         env:
           ORAMA_PACKAGE_INDEX_ID: ${{ secrets.ORAMA_PACKAGE_INDEX_ID }}

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
     "dev:frontend": "cd frontend && OLTP_ENDPOINT=http://localhost:4318 deno task start",
     "prod:frontend": "deno run -A --watch ./tools/prod_proxy.ts & cd frontend && API_ROOT=https://api.jsr.io deno task start",
     "lint": "deno task lint:frontend && deno task lint:license",
-    "lint:frontend": "cd frontend && deno lint && deno check main.ts",
+    "lint:frontend": "cd frontend && deno lint && deno check --allow-import main.ts",
     "lint:license": "deno run --allow-read jsr:@kt3k/license-checker@3.2.11/main -q",
     "lint:license:fix": "deno run --allow-read --allow-write jsr:@kt3k/license-checker@3.2.11/main -q --inject",
     "tools:orama:package_reindex": "deno run --allow-env --allow-net tools/orama_package_reindex.ts",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-2.0.0-rc.1
+FROM denoland/deno:alpine-v2.x
 WORKDIR /app
 RUN mkdir /deno_dir
 ENV DENO_DIR /deno_dir

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-v2.x
+FROM denoland/deno:alpine-2.0.0
 WORKDIR /app
 RUN mkdir /deno_dir
 ENV DENO_DIR /deno_dir

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-2.0.0
+FROM denoland/deno:alpine-2.0.1
 WORKDIR /app
 RUN mkdir /deno_dir
 ENV DENO_DIR /deno_dir

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -326,7 +326,8 @@ body .ddoc {
     @apply rounded no-underline !important;
   }
 
-  code ~ .context_button:hover, code:hover ~ .context_button {
+  code ~ .context_button:hover,
+  code:hover ~ .context_button {
     @apply md:visible;
   }
 

--- a/tools/generate_global_symbols.ts
+++ b/tools/generate_global_symbols.ts
@@ -9,12 +9,12 @@ const output = await (new Deno.Command(Deno.execPath(), {
 })).output();
 
 const docNodes = await doc("asset:types.ts", {
-  async load(specifier) {
-    return {
+  load(specifier) {
+    return Promise.resolve({
       kind: "module",
       specifier,
       content: output.stdout,
-    };
+    });
   },
 });
 


### PR DESCRIPTION
This changed the runtime version from `2.0.0-rc.1` to the ~~latest canary~~ `2` version.

It also fixed some errors from `deno lint` and `deno fmt`.