### PR TITLE
fix(docs): fixes href for "Learn more about scope and package names"

### DIFF
--- a/frontend/docs/package-configuration.md
+++ b/frontend/docs/package-configuration.md
@@ -20,7 +20,7 @@ file can instead be placed in the
 ### `name`
 
 The `name` field is the name of your package, prefixed with a JSR scope.
-[Learn more about scope and package names](#creating-a-scope-and-package).
+[Learn more about scope and package names](/docs/publishing-packages#creating-a-scope-and-package).
 
 ### `version`
 


### PR DESCRIPTION
Current link isn't valid, I'm guessing this was the intended target.