### PR TITLE
fix(docs): more flexible local symbol search

### DIFF
--- a/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
+++ b/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
@@ -48,6 +48,10 @@ async function createOrama(): Promise<Orama<any>> {
         ) {
           if (prop === "name") {
             const tokens = raw.split(/(?=[A-Z])/).map((s) => s.toLowerCase());
+            tokens.forEach((token, index) =>
+              tokens[index + 1] &&
+              tokens.push(token + tokens[index + 1])
+            );
             tokens.push(raw.toLowerCase());
             return tokens;
           }


### PR DESCRIPTION
closes https://github.com/jsr-io/jsr/issues/775.

this extends the local symbol search by generating more tokens for the `name` prop, thus improving the overall search ux.

the output for `tokenize` is changed from this:
```ts
["assert", "almost", "equals", "assertalmostequals"]
```
to this:
```ts
["assert", "almost", "equals", "assertalmost", "almostequals" ,"assertalmostequals"]
```

![Bildschirmfoto 2024-10-28 um 12 48 50](https://github.com/user-attachments/assets/4ec598f8-2085-4547-987d-de2147182e98)
