### PR TITLE
fix(frontend): displayed percentage of documented symbols

### DIFF
--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -157,9 +157,8 @@ function ScoreInfo(props: {
           <a class="link" href="/docs/writing-docs#symbol-documentation">
             symbol documentation
           </a>. Currently{" "}
-          {(score.percentageDocumentedSymbols * 100).toString().match(
-            /\d+/,
-          )?.[0]}% of exported symbols are documented.
+          {Math.floor(score.percentageDocumentedSymbols * 100)}% of exported
+          symbols are documented.
         </ScoreItem>
         <ScoreItem
           value={score.allFastCheck}

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -157,8 +157,9 @@ function ScoreInfo(props: {
           <a class="link" href="/docs/writing-docs#symbol-documentation">
             symbol documentation
           </a>. Currently{" "}
-          {(score.percentageDocumentedSymbols * 100).toFixed(0)}% of exported
-          symbols are documented.
+          {(score.percentageDocumentedSymbols * 100).toString().match(
+            /\d+/,
+          )?.[0]}% of exported symbols are documented.
         </ScoreItem>
         <ScoreItem
           value={score.allFastCheck}


### PR DESCRIPTION
closes https://github.com/jsr-io/jsr/issues/748.

as already expected in the issue there was some rounding happening, caused by `.toFixed(0)`:
![Bildschirmfoto 2024-10-28 um 16 24 54](https://github.com/user-attachments/assets/5d814788-ac8d-4cac-8d9e-3a86ab0d6f51)

changes the implementation to make use of `Math.floor`.