### PR TITLE
chore(og): use summary large image

### DIFF
--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -52,6 +52,7 @@ export default function PackagePage(
           property="og:image"
           content={`${FRONTEND_ROOT}/@${params.scope}/${params.package}/og`}
         />
+        <meta name="twitter:card" content="summary_large_image" />
       </Head>
 
       <PackageHeader


### PR DESCRIPTION
jsr's og image is currently displayed small and the text is unreadable.
This RP display the image larger on X, Discord and so on.

Now
![image](https://github.com/user-attachments/assets/499d6aec-c8df-4d64-95a7-9e50e9813360)

Ideal
![image](https://github.com/user-attachments/assets/65e684b1-6724-4ee2-8c07-5268f8b2f77c)
