### PR TITLE
fix(frontend): add license field to example config file

### DIFF
--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -58,6 +58,8 @@ export default define.page<typeof handler>(function PackagePage({
                   {"  "}
                   <span class="bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]">{`"version": "0.1.0",\n`}</span>
                   {"  "}
+                  <span class="bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]">{`"license": "MIT",\n`}</span>
+                  {"  "}
                   <span class="bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]">{`"exports": "./mod.ts"\n`}</span>
                   {`}`}
                 </code>


### PR DESCRIPTION
This PR add the `license` field to the `config file` example in **How to publish** page.

Closes #764 