### PR TITLE
feat: allow cross-origin use of og images

### DIFF
--- a/frontend/routes/package/og.ts
+++ b/frontend/routes/package/og.ts
@@ -395,6 +395,7 @@ export const handler = define.handlers({
 
     return new Response(await ogpImage.encode(), {
       headers: {
+        "access-control-allow-origin": "*",
         "Content-Type": "image/png",
       },
     });


### PR DESCRIPTION
closes #801

> [!NOTE]
> The header name uses lowercase because the other `access-control-allow-origin` uses also lowercase.
> https://github.com/search?q=repo%3Ajsr-io%2Fjsr%20access-control-allow-origin&type=code