### PR TITLE
fix(frontend): fix up line highlight width in source view

### DIFF
--- a/api/src/tree_sitter.rs
+++ b/api/src/tree_sitter.rs
@@ -58,7 +58,7 @@ impl comrak::adapters::SyntaxHighlighterAdapter for ComrakAdapter {
 
               let html = if self.show_line_numbers {
                 format!(
-                  r##"<div class="lineNumbers">{line_numbers}</div><div class="grow overflow-x-auto lineNumbersHighlight">{lines}</div>"##
+                  r##"<div class="lineNumbers">{line_numbers}</div><div class="grow overflow-x-auto"><div class="w-max lineNumbersHighlight">{lines}</div></div>"##
                 )
               } else {
                 lines

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -268,7 +268,7 @@ body .ddoc {
 
       .lineNumbersHighlight {
         > span {
-          @apply block target:bg-yellow-200;
+          @apply block target:bg-yellow-200 target:w-fit;
         }
       }
 

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -268,7 +268,7 @@ body .ddoc {
 
       .lineNumbersHighlight {
         > span {
-          @apply block target:bg-yellow-200 target:w-fit;
+          @apply block target:bg-yellow-200;
         }
       }
 


### PR DESCRIPTION
Fixes #31 

The width of the line highlight takes up the entire content

![image](https://github.com/user-attachments/assets/4df7e3c0-9436-4cf3-946c-1c65a285ce07)
