### PR TITLE
feat : Show dependencies dependents count #342

### DIFF
--- a/api/.sqlx/query-8433bacb42d0833b723781eff2467ab27542e94691c1a5626c3f3d8c090caa54.json
+++ b/api/.sqlx/query-8433bacb42d0833b723781eff2467ab27542e94691c1a5626c3f3d8c090caa54.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(DISTINCT dependency_name)\n      FROM package_version_dependencies\n      WHERE package_scope = $1 AND package_name = $2 AND package_version = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8433bacb42d0833b723781eff2467ab27542e94691c1a5626c3f3d8c090caa54"
+}

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -470,6 +470,8 @@ pub struct ApiPackage {
   pub updated_at: DateTime<Utc>,
   pub created_at: DateTime<Utc>,
   pub version_count: u64,
+  pub dependency_count: u64,
+  pub dependent_count: u64,
   pub score: Option<u32>,
   pub latest_version: Option<String>,
   pub when_featured: Option<DateTime<Utc>>,
@@ -491,6 +493,8 @@ impl From<PackageWithGitHubRepoAndMeta> for ApiPackage {
       updated_at: package.updated_at,
       created_at: package.created_at,
       version_count: package.version_count as u64,
+      dependency_count: 0,
+      dependent_count: 0,
       score: package
         .latest_version
         .as_ref()

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -2858,6 +2858,48 @@ impl Database {
     Ok((total_unique_package_dependents as usize, dependents))
   }
 
+  #[instrument(name = "Database::count_package_dependents", skip(self), err)]
+  pub async fn count_package_dependents(
+    &self,
+    kind: DependencyKind,
+    name: &str,
+  ) -> Result<usize> {
+    let total_unique_package_dependents = sqlx::query!(
+      r#"SELECT COUNT(DISTINCT (package_scope, package_name)) FROM package_version_dependencies
+      WHERE dependency_kind = $1 AND dependency_name = $2;"#,
+      kind as _,
+      name,
+    )
+    .map(|r| r.count.unwrap())
+    .fetch_one(&self.pool)
+    .await?;
+
+    Ok(total_unique_package_dependents as usize)
+  }
+
+  #[instrument(name = "Database::count_package_dependencies", skip(self), err)]
+  pub async fn count_package_dependencies(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+  ) -> Result<usize> {
+    let total_package_dependencies = sqlx::query!(
+      r#"SELECT COUNT(DISTINCT dependency_name)
+      FROM package_version_dependencies
+      WHERE package_scope = $1 AND package_name = $2 AND package_version = $3"#,
+      scope as _,
+      name as _,
+      version as _
+    )
+    .fetch_one(&self.pool)
+    .await?
+    .count
+    .unwrap();
+
+    Ok(total_package_dependencies as usize)
+  }
+
   #[instrument(name = "Database::check_bad_word", skip(self), err)]
   pub async fn check_is_bad_word(&self, word: &str) -> Result<bool> {
     let res = sqlx::query!("SELECT * FROM bad_words WHERE word = $1", word)

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -23,6 +23,8 @@ interface PackageNavProps {
   currentTab: Tab;
   params: Params;
   versionCount: number;
+  dependencyCount: number;
+  dependentCount: number;
   iam: ScopeIAM;
   latestVersion: string | null;
 }
@@ -32,6 +34,8 @@ export function PackageNav({
   params,
   iam,
   versionCount,
+  dependencyCount,
+  dependentCount,
   latestVersion,
 }: PackageNavProps) {
   const base = `/@${params.scope}/${params.package}`;
@@ -74,6 +78,9 @@ export function PackageNav({
           active={currentTab === "Dependencies"}
         >
           Dependencies
+          <span class="chip tabular-nums border-1 border-white bg-jsr-cyan-100 ml-2 flex items-center justify-center">
+            {dependencyCount}
+          </span>
         </NavItem>
       )}
       {versionCount > 0 && (
@@ -82,6 +89,9 @@ export function PackageNav({
           active={currentTab === "Dependents"}
         >
           Dependents
+          <span class="chip tabular-nums border-1 border-white bg-jsr-cyan-100 ml-2 flex items-center justify-center">
+            {dependentCount}
+          </span>
         </NavItem>
       )}
       {versionCount > 0 && (

--- a/frontend/routes/package/all_symbols.tsx
+++ b/frontend/routes/package/all_symbols.tsx
@@ -22,6 +22,8 @@ export default define.page<typeof handler>(function AllSymbols(
       <PackageNav
         currentTab="Docs"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependencies/graph.tsx
+++ b/frontend/routes/package/dependencies/graph.tsx
@@ -23,6 +23,8 @@ export default define.page<typeof handler>(
         <PackageNav
           currentTab="Dependencies"
           versionCount={data.package.versionCount}
+          dependencyCount={data.package.dependencyCount}
+          dependentCount={data.package.dependentCount}
           iam={iam}
           params={params as unknown as Params}
           latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependencies/index.tsx
+++ b/frontend/routes/package/dependencies/index.tsx
@@ -68,6 +68,8 @@ export default define.page<typeof handler>(function Deps(
       <PackageNav
         currentTab="Dependencies"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependents.tsx
+++ b/frontend/routes/package/dependents.tsx
@@ -21,6 +21,8 @@ export default define.page<typeof handler>(function Dep(
       <PackageNav
         currentTab="Dependents"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -24,6 +24,8 @@ export default define.page<typeof handler>(function File({
       <PackageNav
         currentTab="Docs"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -22,6 +22,8 @@ export default define.page<typeof handler>(function Symbol(
       <PackageNav
         currentTab="Docs"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -23,6 +23,8 @@ export default define.page<typeof handler>(function PackagePage(
       <PackageNav
         currentTab="Index"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -22,6 +22,8 @@ export default define.page<typeof handler>(function PackagePage({
       <PackageNav
         currentTab="Publish"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={data.iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -24,6 +24,8 @@ export default define.page<typeof handler>(function Score(
       <PackageNav
         currentTab="Score"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/settings.tsx
+++ b/frontend/routes/package/settings.tsx
@@ -19,6 +19,8 @@ export default define.page<typeof handler>(function Settings({ data, params }) {
       <PackageNav
         currentTab="Settings"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={data.iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -44,6 +44,8 @@ export default define.page<typeof handler>(function PackagePage(
       <PackageNav
         currentTab="Files"
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -97,6 +97,8 @@ export default define.page<typeof handler>(function Versions({
         params={params as unknown as Params}
         iam={iam}
         versionCount={data.package.versionCount}
+        dependencyCount={data.package.dependencyCount}
+        dependentCount={data.package.dependentCount}
         latestVersion={data.package.latestVersion}
       />
 

--- a/frontend/routes/status.tsx
+++ b/frontend/routes/status.tsx
@@ -28,6 +28,8 @@ export default define.page<typeof handler>(function PackageListPage({
         <PackageNav
           currentTab="Versions"
           versionCount={data.package.versionCount}
+          dependencyCount={data.package.dependencyCount}
+          dependentCount={data.package.dependentCount}
           iam={iam}
           params={{ scope: data.package.scope, package: data.package.name }}
           latestVersion={data.package.latestVersion}

--- a/frontend/utils/api_types.ts
+++ b/frontend/utils/api_types.ts
@@ -115,6 +115,8 @@ export interface Package {
   updatedAt: string;
   createdAt: string;
   versionCount: number;
+  dependencyCount: number;
+  dependentCount: number;
   score: number | null;
   latestVersion: string | null;
   whenFeatured: string | null;

--- a/frontend/utils/data.ts
+++ b/frontend/utils/data.ts
@@ -23,6 +23,7 @@ export async function packageData(
       ? state.api.get<ScopeMember>(path`/user/member/${scope}`)
       : Promise.resolve(null),
   ]);
+
   if (!pkgResp.ok) {
     if (pkgResp.code === "scopeNotFound") return null;
     if (pkgResp.code === "packageNotFound") return null;


### PR DESCRIPTION
Fixes https://github.com/jsr-io/jsr/issues/342.

I think a should export some code to improve visibility in of the `get_handler` function in `package.rs` into an other file but where ? `utils.rs` ?

Ready to read suggestions and make changes if needed !