### PR TITLE
fix: prevent layout shift when hovering over doc header

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -475,7 +475,7 @@ body .ddoc {
 
   .symbolGroup article > div:hover > div + a.context_button:before {
     content: "View code";
-    @apply hidden md:block text-xs;
+    @apply hidden md:block text-xs leading-none;
   }
 
   .docEntryHeader:hover > .context_button {


### PR DESCRIPTION
This closes #866, see issue for video of original issue. Resolves the shift caused by mismatch in the SVG and text heights.

https://github.com/user-attachments/assets/1b533313-60bc-4637-97d9-f0b51c4f4106
