### PR TITLE
fix: allow publishing with no version in config file

### DIFF
--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -647,7 +647,7 @@ mod tests {
   ) -> Result<(), anyhow::Error> {
     let scope = spec.jsr_json.name.scope.clone();
     let package = spec.jsr_json.name.package.clone();
-    let version = spec.jsr_json.version.clone();
+    let version = spec.jsr_json.version.clone().unwrap();
 
     let exports = match exports_map_from_json(spec.jsr_json.exports.clone()) {
       Ok(exports) => exports,

--- a/api/src/publish.rs
+++ b/api/src/publish.rs
@@ -791,7 +791,7 @@ pub mod tests {
       .unwrap();
     let deno_json: ConfigFile = serde_json::from_slice(&json).unwrap();
     assert_eq!(deno_json.name.to_string(), "@scope/foo");
-    assert_eq!(deno_json.version.to_string(), "1.2.3");
+    assert_eq!(deno_json.version.unwrap().to_string(), "1.2.3");
     {
       let metadata_json = t
         .buckets

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -247,7 +247,6 @@ pub async fn process_tarball(
       publish_task_name: publishing_task_scoped_package_name,
     });
   }
-
   if let Some(config_file_version) = config_file.version {
     if config_file_version != publishing_task.package_version {
       return Err(PublishError::ConfigFileVersionMismatch {

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -247,12 +247,15 @@ pub async fn process_tarball(
       publish_task_name: publishing_task_scoped_package_name,
     });
   }
-  if config_file.version != publishing_task.package_version {
-    return Err(PublishError::ConfigFileVersionMismatch {
-      path: Box::new(publishing_task.config_file.clone()),
-      deno_json_version: Box::new(config_file.version),
-      publish_task_version: Box::new(publishing_task.package_version.clone()),
-    });
+
+  if let Some(config_file_version) = config_file.version {
+    if config_file_version != publishing_task.package_version {
+      return Err(PublishError::ConfigFileVersionMismatch {
+        path: Box::new(publishing_task.config_file.clone()),
+        deno_json_version: Box::new(config_file.version),
+        publish_task_version: Box::new(publishing_task.package_version.clone()),
+      });
+    }
   }
 
   let exports =
@@ -690,7 +693,7 @@ pub struct FileInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConfigFile {
   pub name: ScopedPackageName,
-  pub version: Version,
+  pub version: Option<Version>,
   pub exports: Option<serde_json::Value>,
 }
 

--- a/api/src/tarball.rs
+++ b/api/src/tarball.rs
@@ -251,7 +251,7 @@ pub async fn process_tarball(
     if config_file_version != publishing_task.package_version {
       return Err(PublishError::ConfigFileVersionMismatch {
         path: Box::new(publishing_task.config_file.clone()),
-        deno_json_version: Box::new(config_file.version),
+        deno_json_version: Box::new(config_file_version),
         publish_task_version: Box::new(publishing_task.package_version.clone()),
       });
     }

--- a/frontend/static/schema/config-file.v1.json
+++ b/frontend/static/schema/config-file.v1.json
@@ -4,7 +4,6 @@
   "description": "A JSON representation of a JSR configuration file.",
   "required": [
     "name",
-    "version",
     "exports"
   ],
   "title": "JSR configuration file Schema",


### PR DESCRIPTION
https://github.com/dsherret/jsr-publish-on-tag/actions/runs/12332179143/job/34419677355

```
$ deno publish --set-version 0.2.0
Download https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz
Check file:///home/runner/work/jsr-publish-on-tag/jsr-publish-on-tag/src/main.ts
Checking for slow types in the public API...
Check file:///home/runner/work/jsr-publish-on-tag/jsr-publish-on-tag/src/main.ts
Publishing @david/publish-on-tag@0.2.0 ...
error: Failed to publish @david/publish-on-tag@0.2.0
Caused by:
    Failed to publish @david/publish-on-tag at 0.2.0: invalid config file '/deno.json': missing field `version`
Error: Process completed with exit code 1.
```