### PR TITLE
fix: unescape quotes (#902)

### DIFF
--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -166,8 +166,8 @@ function ScoreInfo(props: {
           scoreValue={1}
           title="At least one runtime is marked as compatible"
         >
-          The package should be marked with at least one runtime as <span>"compatible"</span>
-          {" "} in {canAdmin
+          The package should be marked with at least one runtime as{" "}
+          <span>"compatible"</span>{" "}in {canAdmin
             ? (
               <a class="link" href="settings#runtime_compat">
                 the package settings

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -166,8 +166,8 @@ function ScoreInfo(props: {
           scoreValue={1}
           title="At least one runtime is marked as compatible"
         >
-          The package should be marked with at least one runtime as "compatible"
-          in {canAdmin
+          The package should be marked with at least one runtime as <span>"compatible"</span>
+          {" "} in {canAdmin
             ? (
               <a class="link" href="settings#runtime_compat">
                 the package settings

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -166,8 +166,8 @@ function ScoreInfo(props: {
           scoreValue={1}
           title="At least one runtime is marked as compatible"
         >
-          The package should be marked with at least one runtime as{" "}<span>"compatible"</span>
-          {" "}in {canAdmin
+          The package should be marked with at least one runtime as{" "}
+          <span>"compatible"</span> in {canAdmin
             ? (
               <a class="link" href="settings#runtime_compat">
                 the package settings

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -166,8 +166,8 @@ function ScoreInfo(props: {
           scoreValue={1}
           title="At least one runtime is marked as compatible"
         >
-          The package should be marked with at least one runtime as{" "}
-          <span>"compatible"</span>{" "}in {canAdmin
+          The package should be marked with at least one runtime as{" "}<span>"compatible"</span>
+          {" "}in {canAdmin
             ? (
               <a class="link" href="settings#runtime_compat">
                 the package settings


### PR DESCRIPTION
Fixes #902

fixes quote escaping by wrapping `"compatible"` as `<span>"compatible"</span>`