### PR TITLE
Fix cross-package links in docs

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -1126,7 +1126,23 @@ impl HrefResolver for DocResolver {
             deno_semver::jsr::JsrPackageReqReference::from_str(src).ok()?;
           let req = jsr_package_req.req();
 
-          Some(format!("/{}/~/{symbol}", req.name))
+          let mut version_path = Cow::Borrowed("");
+          if let Some(range) = req.version_req.range() {
+            if let Ok(version) = Version::new(&range.to_string()) {
+              // If using a specific version, link to it (e.g. prerelease)
+              version_path = Cow::Owned(format!("@{}", version));
+            }
+          }
+
+          let mut internal_path = Cow::Borrowed("");
+          if let Some(path) = jsr_package_req.sub_path() {
+            internal_path = Cow::Owned(format!("/{path}"));
+          }
+
+          Some(format!(
+            "/{}{version_path}/doc{internal_path}/~/{symbol}",
+            req.name
+          ))
         }
         _ => None,
       }
@@ -1415,6 +1431,28 @@ mod tests {
           }
         ),
         "/@foo/bar@0.0.1/doc/mod/~/bar"
+      );
+    }
+
+    {
+      assert_eq!(
+        resolver
+          .resolve_import_href(
+            &["Expression".to_string()],
+            "jsr:@babel/types@0.0.0-beta.1"
+          )
+          .as_deref(),
+        Some("/@babel/types@0.0.0-beta.1/doc/~/Expression")
+      );
+
+      assert_eq!(
+        resolver
+          .resolve_import_href(
+            &["version".to_string()],
+            "jsr:@babel/core/package.json"
+          )
+          .as_deref(),
+        Some("/@babel/core/doc/package.json/~/version")
       );
     }
   }


### PR DESCRIPTION
Trying to get the "Expression" link at https://jsr.io/@babel-test-6ae45912/parser@0.0.7-8.0.0-alpha.15/doc/~/parseExpression to work:
- it's missing the `/doc` in the URL
- if the type is imported from a non-default entrypoint, it should link to it
- if it's imported from a specific version, it should link to that version (this makes it work with pre-releases)