### PR TITLE
Mark the page wrapper as a container only in the inline direction and not block

### DIFF
--- a/frontend/routes/_layout.tsx
+++ b/frontend/routes/_layout.tsx
@@ -11,7 +11,7 @@ export default function Layout(
     <>
       <div
         class="min-h-[calc(100vh-4rem)] md:min-h-[calc(100vh-4.5rem)]"
-        style="container: page / size"
+        style="container: page / inline-size"
         data-dark-theme="light"
       >
         <a


### PR DESCRIPTION
Fixes https://github.com/jsr-io/jsr/pull/945#issuecomment-2647716883. 

Only tested by changing the value in the browser devtools.