### PR TITLE
fix(ui): Drop shadow overlaped error text, now it doesn't

### DIFF
--- a/frontend/islands/new.tsx
+++ b/frontend/islands/new.tsx
@@ -188,7 +188,7 @@ function CreateScope(
 
   return (
     <>
-      <form class="flex flex-wrap gap-4 items-center" onSubmit={onSubmit}>
+      <form class="flex flex-wrap gap-4 items-center mb-2" onSubmit={onSubmit}>
         <label class="flex items-center w-full md:w-full input-container pl-4 py-[2px] pr-[2px]">
           <span>@</span>
           <input


### PR DESCRIPTION
Fixes #960

![image](https://github.com/user-attachments/assets/7684c891-b03f-4b9c-83f8-6d4f0f76328f)

Even with other error messages
![image](https://github.com/user-attachments/assets/01154a78-e57c-40f8-a523-1d15a4f82e0f)
