### PR TITLE
feat: add report package button

### DIFF
--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -5,6 +5,7 @@ import { RuntimeCompatIndicator } from "../../../components/RuntimeCompatIndicat
 import { getScoreTextColorClass } from "../../../utils/score_ring_color.ts";
 import {
   TbAlertTriangleFilled,
+  TbBug,
   TbExternalLink,
   TbRosetteDiscountCheck,
 } from "@preact-icons/tb";
@@ -32,6 +33,9 @@ export function PackageHeader({
     selectedVersionSemver.prerelease.length !== 0 &&
     (pkg.latestVersion === null ||
       greaterThan(selectedVersionSemver, parse(pkg.latestVersion)));
+
+  const mailLink =
+    `mailto:report@jsr.io?subject=Report%20${pkg.scope}/${pkg.name}%20${selectedVersion?.version}`;
 
   return (
     <div class="space-y-6 mt-0 md:mt-4">
@@ -212,6 +216,15 @@ export function PackageHeader({
                 </div>
               </div>
             )}
+          </div>
+
+          <div class="flex flex-row items-center gap-2">
+            <a
+              class="inline-flex items-center gap-1.5 md:gap-1 text-md md:text-xs bg-red-50 border-1 border-red-300/30 rounded-md p-1.5 md:p-1 text-red-500 font-semibold hover:bg-red-100 focus:outline-none focus:border-1 focus:border-red-300 focus:ring-1 focus:ring-red-300 focus:ring-opacity-50"
+              href={mailLink}
+            >
+              <TbBug class="size-6 md:size-4" /> Report an issue
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -35,9 +35,7 @@ export function PackageHeader({
       greaterThan(selectedVersionSemver, parse(pkg.latestVersion)));
 
   const reportPackageBody = `Hello JSR team,
-I would like to report a package.
-
-For the reason;
+I would like to report a package for the following reason:
 `;
 
   const mailLink = `mailto:report@jsr.io?subject=${

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -5,8 +5,8 @@ import { RuntimeCompatIndicator } from "../../../components/RuntimeCompatIndicat
 import { getScoreTextColorClass } from "../../../utils/score_ring_color.ts";
 import {
   TbAlertTriangleFilled,
-  TbBug,
   TbExternalLink,
+  TbFlag,
   TbRosetteDiscountCheck,
 } from "@preact-icons/tb";
 import { Tooltip } from "../../../components/Tooltip.tsx";
@@ -34,8 +34,17 @@ export function PackageHeader({
     (pkg.latestVersion === null ||
       greaterThan(selectedVersionSemver, parse(pkg.latestVersion)));
 
-  const mailLink =
-    `mailto:report@jsr.io?subject=Report%20${pkg.scope}/${pkg.name}%20${selectedVersion?.version}`;
+  const reportPackageBody = `Hello JSR team,
+I would like to report a package.
+
+For the reason;
+`;
+
+  const mailLink = `mailto:report@jsr.io?subject=${
+    encodeURIComponent(
+      `Report package: ${pkg.scope}/${pkg.name}@${selectedVersion?.version}`,
+    )
+  }&body=${encodeURIComponent(reportPackageBody)}`;
 
   return (
     <div class="space-y-6 mt-0 md:mt-4">
@@ -223,7 +232,7 @@ export function PackageHeader({
               class="inline-flex items-center gap-1.5 md:gap-1 text-md md:text-xs bg-red-50 border-1 border-red-300/30 rounded-md p-1.5 md:p-1 text-red-500 font-semibold hover:bg-red-100 focus:outline-none focus:border-1 focus:border-red-300 focus:ring-1 focus:ring-red-300 focus:ring-opacity-50"
               href={mailLink}
             >
-              <TbBug class="size-6 md:size-4" /> Report an issue
+              <TbFlag class="size-6 md:size-4" /> Report package
             </a>
           </div>
         </div>


### PR DESCRIPTION
#925 

Adding button to report malware.

Desktop: 
<img width="1551" alt="Capture d’écran 2025-02-22 à 11 07 43" src="https://github.com/user-attachments/assets/67c7079b-2f04-4256-80b7-bfb0354098b1" />
Mobile:
<img width="686" alt="Capture d’écran 2025-02-22 à 11 09 46" src="https://github.com/user-attachments/assets/d676f9a8-99d4-42e6-8c0c-7e499e3be0db" />
