### PR TITLE
fix(ui): trunck instead of overflow in search box

### DIFF
--- a/frontend/islands/GlobalSearch.tsx
+++ b/frontend/islands/GlobalSearch.tsx
@@ -258,6 +258,7 @@ export function GlobalSearch(
     : "Search for documentation";
   const placeholder = kindPlaceholder +
     (macLike !== undefined ? ` (${macLike ? "⌘K" : "Ctrl+K"})` : "");
+
   return (
     <div ref={ref} class="pointer-events-auto">
       <form
@@ -273,7 +274,7 @@ export function GlobalSearch(
           <input
             type="search"
             name="search"
-            class={`w-full h-full search-input bg-white/90 ${
+            class={`w-full h-full search-input bg-white/90 truncate ${
               kind === "packages" ? "!text-transparent" : ""
             } !caret-black input rounded-r-none ${sizeClasses} relative`}
             placeholder={placeholder}


### PR DESCRIPTION
Before:
<img width="686" alt="Capture d’écran 2025-02-22 à 11 12 30" src="https://github.com/user-attachments/assets/9192f4b9-6a40-4a7c-b5ba-a0188cb00641" />
After:
<img width="686" alt="Capture d’écran 2025-02-22 à 11 13 42" src="https://github.com/user-attachments/assets/a5e3f886-776c-428e-8d99-e0e3407075f5" />
