### PR TITLE
fix: unifed size for report package button

### DIFF
--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -227,10 +227,10 @@ I would like to report a package for the following reason:
 
           <div class="flex flex-row items-center gap-2">
             <a
-              class="inline-flex items-center gap-1.5 md:gap-1 text-md md:text-xs bg-red-50 border-1 border-red-300/30 rounded-md p-1.5 md:p-1 text-red-500 font-semibold hover:bg-red-100 focus:outline-none focus:border-1 focus:border-red-300 focus:ring-1 focus:ring-red-300 focus:ring-opacity-50"
+              class="inline-flex items-center gap-1.5 text-sm bg-red-50 border border-red-300/30 rounded-md p-1.5 text-red-500 font-semibold hover:bg-red-100 focus:outline-none focus:border focus:border-red-300 focus:ring-1 focus:ring-red-300 focus:ring-opacity-50"
               href={mailLink}
             >
-              <TbFlag class="size-6 md:size-4" /> Report package
+              <TbFlag class="size-4" /> Report package
             </a>
           </div>
         </div>


### PR DESCRIPTION
Fullscreen view (almost) unchanged
Button was oversized on smaller screen

Before :
![image](https://github.com/user-attachments/assets/37f2d218-9c12-4175-a4c9-365ff9c76d33)

After :
![image](https://github.com/user-attachments/assets/ea90eb91-15ce-4a64-8beb-6f964544c85e)
