### PR TITLE
refactor: Usage of @std/fmt instead of manual size calculation

### DIFF
--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -14,6 +14,7 @@
   },
   "imports": {
     "@preact-icons/tb": "jsr:@preact-icons/tb@^1.0.12",
+    "@std/fmt": "jsr:@std/fmt@^1.0.6",
     "fresh": "jsr:@fresh/core@^2.0.0-alpha.25",
     "@fresh/plugin-tailwind": "jsr:@fresh/plugin-tailwind@^0.0.1-alpha.7",
 

--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -17,8 +17,9 @@
     "jsr:@std/datetime@~0.225.2": "0.225.2",
     "jsr:@std/encoding@1": "1.0.5",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
-    "jsr:@std/fmt@1": "1.0.3",
-    "jsr:@std/fmt@^1.0.3": "1.0.3",
+    "jsr:@std/fmt@1": "1.0.6",
+    "jsr:@std/fmt@^1.0.3": "1.0.6",
+    "jsr:@std/fmt@^1.0.6": "1.0.6",
     "jsr:@std/front-matter@1": "1.0.5",
     "jsr:@std/fs@1": "1.0.5",
     "jsr:@std/html@1": "1.0.3",
@@ -167,6 +168,9 @@
     },
     "@std/fmt@1.0.3": {
       "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
+    },
+    "@std/fmt@1.0.6": {
+      "integrity": "a2c56a69a2369876ddb3ad6a500bb6501b5bad47bb3ea16bfb0c18974d2661fc"
     },
     "@std/front-matter@1.0.5": {
       "integrity": "abddc64030a33eb5bc524b8c73e7c417cea09177aaeb4abf75a56b540c4b6e60",
@@ -1876,6 +1880,7 @@
       "jsr:@fresh/core@^2.0.0-alpha.25",
       "jsr:@fresh/plugin-tailwind@^0.0.1-alpha.7",
       "jsr:@preact-icons/tb@^1.0.12",
+      "jsr:@std/fmt@^1.0.6",
       "jsr:@std/front-matter@1",
       "jsr:@std/http@1",
       "jsr:@std/path@1",

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -8,6 +8,7 @@ import { PackageHeader } from "./(_components)/PackageHeader.tsx";
 import { TbFolder, TbSourceCode } from "@preact-icons/tb";
 import { ListDisplay } from "../../components/List.tsx";
 import { scopeIAM } from "../../utils/iam.ts";
+import { format as formatBytes } from "@std/fmt/bytes";
 
 export default define.page<typeof handler>(function PackagePage(
   { data, params, state },
@@ -136,17 +137,10 @@ function DirEntry({ entry }: { entry: SourceDirEntry }) {
         </div>
       </div>
       <div class="text-sm text-jsr-gray-600">
-        {bytesToSize(entry.size)}
+        {formatBytes(entry.size, { maximumFractionDigits: 0 }).toUpperCase()}
       </div>
     </div>
   );
-}
-
-function bytesToSize(bytes: number) {
-  const sizes = ["B", "KB", "MB", "GB", "TB"];
-  if (bytes == 0) return "0 B";
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  return (bytes / Math.pow(1024, i)).toFixed(0) + " " + sizes[i];
 }
 
 const LINE_COL_REGEX = /(.*):(\d+):(\d+)$/;


### PR DESCRIPTION
Showcase of @std/fmt usage:

![image](https://github.com/user-attachments/assets/ee22ab56-8885-4c67-a222-678508789456)
