### PR TITLE
feat: add minimal implementation of changesStream for registry mirroring

### DIFF
--- a/api/migrations/20250402143550_create_changes.sql
+++ b/api/migrations/20250402143550_create_changes.sql
@@ -1,0 +1,16 @@
+CREATE TYPE change_type AS ENUM (
+    'PACKAGE_VERSION_ADDED',
+    'PACKAGE_TAG_ADDED'
+);
+
+CREATE TABLE changes (
+    seq BIGSERIAL PRIMARY KEY,
+    change_type change_type NOT NULL,
+    package_id VARCHAR(255) NOT NULL,
+    data TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 创建索引
+CREATE INDEX changes_package_id_idx ON changes (package_id);
+CREATE INDEX changes_created_at_idx ON changes (created_at);

--- a/api/migrations/20250402143550_create_changes.sql
+++ b/api/migrations/20250402143550_create_changes.sql
@@ -11,6 +11,5 @@ CREATE TABLE changes (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- 创建索引
 CREATE INDEX changes_package_id_idx ON changes (package_id);
 CREATE INDEX changes_created_at_idx ON changes (created_at);

--- a/api/src/api/changes.rs
+++ b/api/src/api/changes.rs
@@ -1,12 +1,10 @@
-use crate::api::ApiError;
 use hyper::{Body, Request};
-use routerify::Router;
 use routerify::prelude::*;
 use serde::Serialize;
 
 use crate::{
     db::{Change, Database},
-    util::{self, pagination, ApiResult},
+    util::{pagination, ApiResult},
 };
 
 
@@ -29,14 +27,7 @@ impl From<Change> for ApiChange {
     }
 }
 
-pub fn changes_router() -> Router<Body, ApiError> {
-    Router::builder()
-        .get("/_changes", util::json(list_changes))
-        .build()
-        .unwrap()
-}
-
-async fn list_changes(req: Request<Body>) -> ApiResult<Vec<ApiChange>> {
+pub async fn list_changes(req: Request<Body>) -> ApiResult<Vec<ApiChange>> {
     let db = req.data::<Database>().unwrap();
     let (start, limit) = pagination(&req);
     let changes = db.list_changes(start, limit).await?;

--- a/api/src/api/changes.rs
+++ b/api/src/api/changes.rs
@@ -1,0 +1,44 @@
+use crate::api::ApiError;
+use hyper::{Body, Request};
+use routerify::Router;
+use routerify::prelude::*;
+use serde::Serialize;
+
+use crate::{
+    db::{Change, Database},
+    util::{self, pagination, ApiResult},
+};
+
+
+#[derive(Serialize)]
+pub struct ApiChange {
+    pub seq: i64,
+    pub r#type: String,
+    pub id: String,
+    pub changes: serde_json::Value,
+}
+
+impl From<Change> for ApiChange {
+    fn from(change: Change) -> Self {
+        Self {
+            seq: change.seq,
+            r#type: change.change_type.to_string(),
+            id: change.package_id,
+            changes: serde_json::from_str(&change.data).unwrap(),
+        }
+    }
+}
+
+pub fn changes_router() -> Router<Body, ApiError> {
+    Router::builder()
+        .get("/_changes", util::json(list_changes))
+        .build()
+        .unwrap()
+}
+
+async fn list_changes(req: Request<Body>) -> ApiResult<Vec<ApiChange>> {
+    let db = req.data::<Database>().unwrap();
+    let (start, limit) = pagination(&req);
+    let changes = db.list_changes(start, limit).await?;
+    Ok(changes.into_iter().map(ApiChange::from).collect())
+}

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -16,6 +16,7 @@ use hyper::Response;
 use package::global_list_handler;
 use package::global_metrics_handler;
 use package::global_stats_handler;
+use changes::list_changes;
 use routerify::Middleware;
 use routerify::Router;
 
@@ -29,7 +30,6 @@ use self::admin::admin_router;
 use self::authorization::authorization_router;
 use self::scope::scope_router;
 use self::users::users_router;
-use self::changes::changes_router;
 
 use crate::util;
 use crate::util::CacheDuration;
@@ -43,10 +43,10 @@ pub fn api_router() -> Router<Body, ApiError> {
         util::json(global_metrics_handler),
       ),
     )
+    .get("/_changes", util::json(list_changes))
     .middleware(Middleware::pre(util::auth_middleware))
     .scope("/admin", admin_router())
     .scope("/scopes", scope_router())
-    .scope("/changes", changes_router())
     .scope("/user", self_user_router())
     .scope("/users", users_router())
     .scope("/authorizations", authorization_router())

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -8,6 +8,8 @@ mod scope;
 mod self_user;
 mod types;
 mod users;
+mod changes;
+
 
 use hyper::Body;
 use hyper::Response;
@@ -27,6 +29,7 @@ use self::admin::admin_router;
 use self::authorization::authorization_router;
 use self::scope::scope_router;
 use self::users::users_router;
+use self::changes::changes_router;
 
 use crate::util;
 use crate::util::CacheDuration;
@@ -43,6 +46,7 @@ pub fn api_router() -> Router<Body, ApiError> {
     .middleware(Middleware::pre(util::auth_middleware))
     .scope("/admin", admin_router())
     .scope("/scopes", scope_router())
+    .scope("/changes", changes_router())
     .scope("/user", self_user_router())
     .scope("/users", users_router())
     .scope("/authorizations", authorization_router())

--- a/api/src/db/models.rs
+++ b/api/src/db/models.rs
@@ -824,3 +824,37 @@ impl sqlx::postgres::PgHasArrayType for DownloadKind {
     sqlx::postgres::PgTypeInfo::with_name("_download_kind")
   }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "change_type", rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeType {
+
+    PackageVersionAdded,
+    PackageTagAdded,
+}
+
+impl std::fmt::Display for ChangeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PackageVersionAdded => write!(f, "PACKAGE_VERSION_ADDED"),
+            Self::PackageTagAdded => write!(f, "PACKAGE_TAG_ADDED"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Change {
+    pub seq: i64,
+    pub change_type: ChangeType,
+    pub package_id: String,
+    pub data: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub struct NewChange<'s> {
+    pub change_type: ChangeType,
+    pub package_id: &'s str,
+    pub data: &'s str,
+}

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -283,13 +283,17 @@ pub fn pagination(req: &Request<Body>) -> (i64, i64) {
     .and_then(|page| page.parse::<i64>().ok())
     .unwrap_or(100)
     .clamp(1, 100);
-  let page = req
-    .query("page")
-    .and_then(|page| page.parse::<i64>().ok())
-    .unwrap_or(1)
-    .max(1);
 
-  let start = (page * limit) - limit;
+  let start = if let Some(since) = req.query("since").and_then(|s| s.parse::<i64>().ok()) {
+    since
+  } else {
+    let page = req
+      .query("page")
+      .and_then(|page| page.parse::<i64>().ok())
+      .unwrap_or(1)
+      .max(1);
+    (page * limit) - limit
+  };
 
   (start, limit)
 }


### PR DESCRIPTION
Hi, jsr team 

This PR introduces a minimal implementation of the changesStream interface (#110) to enable registry mirroring capabilities. Given that `11 months` have passed since our initial discussion and the feature remains unscheduled, I've taken the liberty to propose this implementation based on our proven approach in npmmirror.

## Key implementation notes:
1. Implements simple polling mechanism via `application/json` endpoint
2. Follows npmmirror pattern (compared to npm's heavier stream interface)
3. Maintains backward compatibility with existing infrastructure

## For maintainers:
- This implementation prioritizes simplicity and maintainability
- Being new to Rust, I welcome guidance on code quality and best practices 😋

**Context**:
As developers in mainland China experience consistent network challenges accessing the JSR registry directly, this feature would significantly improve developer experience for one of the world's largest developer communities.

Thanks for building this vital infrastructure for the JavaScript ecosystem. 
Looking forward to your feedback! 🙏🏻