### PR TITLE
fix(frontend): fix data point aggregation logic for download chart

### DIFF
--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -340,12 +340,12 @@
     "@isaacs/cliui@8.0.2": {
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dependencies": [
-        "string-width@5.1.2",
         "string-width-cjs@npm:string-width@4.2.3",
-        "strip-ansi@7.1.0",
+        "string-width@5.1.2",
         "strip-ansi-cjs@npm:strip-ansi@6.0.1",
-        "wrap-ansi@8.1.0",
-        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
+        "strip-ansi@7.1.0",
+        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0",
+        "wrap-ansi@8.1.0"
       ]
     },
     "@jridgewell/gen-mapping@0.3.5": {
@@ -627,8 +627,8 @@
         "fraction.js",
         "normalize-range",
         "picocolors",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "axios@1.8.4": {
@@ -774,7 +774,6 @@
         "browserslist",
         "css-declaration-sorter",
         "cssnano-utils",
-        "postcss@8.4.35",
         "postcss-calc",
         "postcss-colormin",
         "postcss-convert-values",
@@ -801,7 +800,8 @@
         "postcss-reduce-initial",
         "postcss-reduce-transforms",
         "postcss-svgo",
-        "postcss-unique-selectors"
+        "postcss-unique-selectors",
+        "postcss@8.4.35"
       ]
     },
     "cssnano-utils@4.0.2_postcss@8.4.35": {
@@ -1227,8 +1227,8 @@
     "openai@4.71.1": {
       "integrity": "sha512-C6JNMaQ1eijM0lrjiRUL3MgThVP5RdwNAghpbJFdW0t11LzmyqON8Eh8MuUuEZ+CeD6bgYl2Fkn2BoptVxv9Ug==",
       "dependencies": [
-        "@types/node@18.19.64",
         "@types/node-fetch",
+        "@types/node@18.19.64",
         "abort-controller",
         "agentkeepalive",
         "form-data-encoder",
@@ -1270,9 +1270,9 @@
     "postcss-calc@9.0.1_postcss@8.4.35": {
       "integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
       "dependencies": [
-        "postcss@8.4.35",
         "postcss-selector-parser",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-colormin@6.1.0_postcss@8.4.35": {
@@ -1281,16 +1281,16 @@
         "browserslist",
         "caniuse-api",
         "colord",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-convert-values@6.1.0_postcss@8.4.35": {
       "integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
       "dependencies": [
         "browserslist",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-discard-comments@6.0.2_postcss@8.4.35": {
@@ -1320,8 +1320,8 @@
     "postcss-import@15.1.0_postcss@8.4.47": {
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dependencies": [
-        "postcss@8.4.47",
         "postcss-value-parser",
+        "postcss@8.4.47",
         "read-cache",
         "resolve"
       ]
@@ -1344,8 +1344,8 @@
     "postcss-merge-longhand@6.0.5_postcss@8.4.35": {
       "integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
       "dependencies": [
-        "postcss@8.4.35",
         "postcss-value-parser",
+        "postcss@8.4.35",
         "stylehacks"
       ]
     },
@@ -1355,15 +1355,15 @@
         "browserslist",
         "caniuse-api",
         "cssnano-utils",
-        "postcss@8.4.35",
-        "postcss-selector-parser"
+        "postcss-selector-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-minify-font-values@6.1.0_postcss@8.4.35": {
       "integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-minify-gradients@6.0.3_postcss@8.4.35": {
@@ -1371,8 +1371,8 @@
       "dependencies": [
         "colord",
         "cssnano-utils",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-minify-params@6.1.0_postcss@8.4.35": {
@@ -1380,22 +1380,22 @@
       "dependencies": [
         "browserslist",
         "cssnano-utils",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-minify-selectors@6.0.4_postcss@8.4.35": {
       "integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-selector-parser"
+        "postcss-selector-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-nested@6.2.0_postcss@8.4.47": {
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "dependencies": [
-        "postcss@8.4.47",
-        "postcss-selector-parser"
+        "postcss-selector-parser",
+        "postcss@8.4.47"
       ]
     },
     "postcss-normalize-charset@6.0.2_postcss@8.4.35": {
@@ -1407,66 +1407,66 @@
     "postcss-normalize-display-values@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-positions@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-repeat-style@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-string@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-timing-functions@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-unicode@6.1.0_postcss@8.4.35": {
       "integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
       "dependencies": [
         "browserslist",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-url@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-normalize-whitespace@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-ordered-values@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
       "dependencies": [
         "cssnano-utils",
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-reduce-initial@6.1.0_postcss@8.4.35": {
@@ -1480,8 +1480,8 @@
     "postcss-reduce-transforms@6.0.2_postcss@8.4.35": {
       "integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-value-parser"
+        "postcss-value-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-selector-parser@6.1.2": {
@@ -1494,16 +1494,16 @@
     "postcss-svgo@6.0.3_postcss@8.4.35": {
       "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
       "dependencies": [
-        "postcss@8.4.35",
         "postcss-value-parser",
+        "postcss@8.4.35",
         "svgo"
       ]
     },
     "postcss-unique-selectors@6.0.4_postcss@8.4.35": {
       "integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
       "dependencies": [
-        "postcss@8.4.35",
-        "postcss-selector-parser"
+        "postcss-selector-parser",
+        "postcss@8.4.35"
       ]
     },
     "postcss-value-parser@4.2.0": {
@@ -1658,8 +1658,8 @@
       "integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
       "dependencies": [
         "browserslist",
-        "postcss@8.4.35",
-        "postcss-selector-parser"
+        "postcss-selector-parser",
+        "postcss@8.4.35"
       ]
     },
     "sucrase@3.35.0": {
@@ -1706,12 +1706,12 @@
         "normalize-path",
         "object-hash",
         "picocolors",
-        "postcss@8.4.47",
         "postcss-import",
         "postcss-js",
         "postcss-load-config",
         "postcss-nested",
         "postcss-selector-parser",
+        "postcss@8.4.47",
         "resolve",
         "sucrase"
       ]

--- a/frontend/routes/package/(_islands)/DownloadChart.tsx
+++ b/frontend/routes/package/(_islands)/DownloadChart.tsx
@@ -5,6 +5,7 @@ import type {
   DownloadDataPoint,
   PackageDownloadsRecentVersion,
 } from "../../../utils/api_types.ts";
+import type ApexCharts from "apexcharts";
 
 interface Props {
   downloads: PackageDownloadsRecentVersion[];
@@ -14,8 +15,7 @@ export type AggregationPeriod = "daily" | "weekly" | "monthly";
 
 export function DownloadChart(props: Props) {
   const chartDivRef = useRef<HTMLDivElement>(null);
-  // deno-lint-ignore no-explicit-any
-  const chartRef = useRef<any>(null);
+  const chartRef = useRef<ApexCharts>(null);
   const [graphRendered, setGraphRendered] = useState(false);
 
   useEffect(() => {
@@ -63,7 +63,7 @@ export function DownloadChart(props: Props) {
       setGraphRendered(true);
     })();
     return () => {
-      chartRef.current.destroy();
+      chartRef.current?.destroy();
       chartRef.current = null;
     };
   }, []);
@@ -78,7 +78,7 @@ export function DownloadChart(props: Props) {
           <select
             id="aggregationPeriod"
             onChange={(e) =>
-              chartRef.current.updateSeries(
+              chartRef.current?.updateSeries(
                 getSeries(
                   props.downloads,
                   e.currentTarget.value as AggregationPeriod,
@@ -158,7 +158,7 @@ export function normalize(
   dataPoints: DownloadDataPoint[],
   xValues: string[],
   aggregationPeriod: AggregationPeriod,
-): [Date, number][] {
+): [number, number][] {
   const normalized: { [key: string]: number } = {};
   for (const date of xValues) {
     normalized[date] = 0;
@@ -176,7 +176,7 @@ export function normalize(
 
   return Object.entries(normalized).map((
     [key, value],
-  ) => [new Date(key), value]);
+  ) => [new Date(key).getTime(), value]);
 }
 
 function getSeries(
@@ -193,7 +193,7 @@ function getSeries(
   ).flat();
 
   const xValues = collectX(
-    dataPointsToDisplay.map((version) => version.downloads).flat(),
+    dataPointsWithDownloads.map((version) => version.downloads).flat(),
     aggregationPeriod,
   );
 

--- a/frontend/routes/package/(_islands)/DownloadWidget.tsx
+++ b/frontend/routes/package/(_islands)/DownloadWidget.tsx
@@ -34,7 +34,7 @@ export function DownloadWidget(props: Props) {
   }
 
   const [hoveredDataPoint, setHoveredDataPoint] = useState<
-    { date: Date; data: number } | null
+    { date: number; data: number } | null
   >(null);
   const [graphRendered, setGraphRendered] = useState(false);
 
@@ -141,11 +141,11 @@ export function DownloadWidget(props: Props) {
             <div>
               {hoveredDataPoint
                 ? `${
-                  hoveredDataPoint.date.toISOString()
+                  new Date(hoveredDataPoint.date).toISOString()
                     .split("T")[0]
                 } to ${
                   new Date(
-                    hoveredDataPoint.date.getTime() + 6 * 24 * 60 * 60 * 1000,
+                    hoveredDataPoint.date + 6 * 24 * 60 * 60 * 1000,
                   ).toISOString()
                     .split("T")[0]
                 }`


### PR DESCRIPTION
This PR fixes the rendering of download chart when the recent 5 versions don't have enough x values in the chart.

This PR fixes the download chart of `@ecopages/lit` package:

BEFORE
<img width="1228" alt="Screenshot 2025-04-22 at 11 49 45" src="https://github.com/user-attachments/assets/e9536df1-ca96-4c8e-ae70-ca8d7fc75f36" />

AFTER
<img width="1242" alt="Screenshot 2025-04-22 at 11 49 31" src="https://github.com/user-attachments/assets/2c846670-9d46-4822-9472-07608b50d42f" />