### PR TITLE
docs: mention deno.json(c) in publishing from GitHub

### DIFF
--- a/frontend/docs/publishing-packages.md
+++ b/frontend/docs/publishing-packages.md
@@ -346,9 +346,9 @@ jobs:
 
 This workflow will run every time you push to the `main` branch of your
 repository. It will publish your package to JSR, and will automatically use the
-correct version number based on the version in your `jsr.json` file.
-`jsr publish` will not attempt to publish if the version specified in your
-`jsr.json` file is already published to JSR.
+correct version number based on the version in your `jsr.json`/`deno.json(c)`
+file. `jsr publish` will not attempt to publish if the version specified in your
+`jsr.json`/`deno.json(c)` file is already published to JSR.
 
 ## Filtering files
 


### PR DESCRIPTION
When [publishing from GitHub Actions](https://jsr.io/docs/publishing-packages#publishing-from-github-actions), `deno.json(c)` is used if `jsr.json` doesn't exist.