### PR TITLE
fix: correct default dark-mode preference

### DIFF
--- a/frontend/islands/DarkModeToggle.tsx
+++ b/frontend/islands/DarkModeToggle.tsx
@@ -6,10 +6,11 @@ export default function DarkModeToggle() {
   const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
-    const isDarkStored = localStorage.getItem("darkMode") === "true";
+    const isDarkStored = localStorage.getItem("darkMode");
     const isDarkPreference =
       globalThis.matchMedia("(prefers-color-scheme: dark)").matches;
-    const initialDarkMode = isDarkStored ?? isDarkPreference;
+    const initialDarkMode = isDarkStored === "true" ||
+      isDarkStored === null && isDarkPreference;
 
     setIsDark(initialDarkMode);
     updateTheme(initialDarkMode);


### PR DESCRIPTION
Thanks for shipping Dark mode for JSR! (#1055) 🎉 

Though I noticed that the media `prefers-color-scheme` detection is not working correctly. During loading the correct theme will be applied (via `_app.tsx` script), but when Preact renders it will override with incorrect theme. This is because the `isDarkStored ?? isDarkPreference` expression basically always returning `isDarkStored` (`isDarkStored` is `boolean`, not `boolean | undefined | null`).

This PR attempts to fix the issue by ensuring the [logic is the same as for `_app.tsx`](https://github.com/jsr-io/jsr/blob/main/frontend/routes/_app.tsx#L74-L81) for when Dark mode should be applied, which avoids dark -> light flashing for when dark mode is preferred without any stored value.

## Current behavior

This is how it looks for me (3G throttled) when I have no `darkMode` localeStorage item.

https://github.com/user-attachments/assets/56ff105f-5a39-46ff-bf6c-40f518366ed2

