### PR TITLE
fix: specify the color-scheme for dark mode

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -81,6 +81,7 @@
 
     background-color: theme("colors.jsr-gray.950");
     color: theme("colors.jsr-gray.100");
+    color-scheme: only dark;
     --color-text-primary: theme("colors.jsr-gray.100");
     --color-text-secondary: theme("colors.jsr-gray.300");
     --color-text-tertiary: theme("colors.jsr-gray.400");


### PR DESCRIPTION
Fixes #1115 

### PR Checklist

- [x] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Is this closing an open issue? If so, link it, else include a proper
      description of the changes and rason behind them.
- [x] Does the PR have changes to the frontend? If so, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
- [ ] Does the PR have changes to the backend? If so, make sure tests are added.
      <br/>And if changing dababase queries, be sure you have ran `sqlx prepare`
      and committed the changes in the `.sqlx` directory.

### How to reproduce this issue

([Safari does not support this](https://bugs.webkit.org/show_bug.cgi?id=199134), you need to use Chrome or Firefox to reproduce this issue)

1. Switch to dark mode
1. Modify any img src to `https://cdn.simpleicons.org/jsr/yellow/blue` in your inspector 
1. The image color should be blue, but it's yellow on production

### Description

The package readme may include a dynamic color scheme style in the image, like this project's readme: https://github.com/LitoMore/simple-icons-cdn.

This PR fixes a display behavior when the remote image has a `prefers-color-scheme` inside for dark mode.

### Preview

|Before|After|
|:-:|:-:|
|![](https://github.com/user-attachments/assets/01a06939-6484-4d06-ad82-95355a3842ea)|![](https://github.com/user-attachments/assets/395b4c6b-0a21-4acf-ac6a-40f48308b124)|

