### PR TITLE
fix(frontend): unstack download charts

### DIFF
--- a/frontend/routes/package/(_islands)/DownloadChart.tsx
+++ b/frontend/routes/package/(_islands)/DownloadChart.tsx
@@ -24,7 +24,6 @@ export function DownloadChart(props: Props) {
   ) => ({
     chart: {
       type: "area",
-      stacked: true,
       animations: {
         enabled: false,
       },


### PR DESCRIPTION
This fixes what appears to be a visual bug that causes the downloads to aggregate across versions in a strange way. 

Maybe this is intentional? Though my guess is that it is just a small mistake that got left in the chart options.

**before:** 

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/35322a6e-84ca-4966-a476-12711ba60f4e" />

**after:**

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/fcccf921-fee0-4cce-86dc-8fedd1ffd4d6" />

screenshots from: https://jsr.io/@tyler/duckhawk/versions