### PR TITLE
fix: dark mode colors on /new page

### DIFF
--- a/frontend/routes/new.tsx
+++ b/frontend/routes/new.tsx
@@ -61,7 +61,7 @@ export default define.page<typeof handler>(function New(props) {
                   />
                 )
                 : (
-                  <div class="space-y-4 bg-jsr-gray-50 border-jsr-gray-100 p-4 rounded-xl">
+                  <div class="space-y-4 bg-jsr-gray-50 dark:bg-jsr-gray-900 border-jsr-gray-900 dark:border-jsr-gray-50 p-4 rounded-xl">
                     <p class="text-jsr-gray-700 dark:text-white">
                       You must be logged in to publish a package.
                     </p>


### PR DESCRIPTION
Fixes the dark mode colors for the "You must be logged in" box.

I also added a border color in case that is ever used/wanted.

### PR Checklist

- [x] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Does the PR have changes to the frontend? If so, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
      
 Before: 
![image](https://github.com/user-attachments/assets/e256d45d-5a29-464d-9c92-d17a064a71a4)

After:
![image](https://github.com/user-attachments/assets/8f4782e1-d636-45f8-81ac-b2c2782dddb7)
