### PR TITLE
fix: selection highlight is offset in global search

### DIFF
--- a/frontend/islands/GlobalSearch.tsx
+++ b/frontend/islands/GlobalSearch.tsx
@@ -314,7 +314,7 @@ export function GlobalSearch(
           )}
           {kind === "packages" && (
             <div
-              class={`search-input !bg-transparent !border-transparent select-none pointer-events-none inset-0 absolute ${sizeClasses} `}
+              class={`search-input !bg-transparent !border-transparent select-none pointer-events-none inset-0 absolute inline-flex items-center ${sizeClasses} `}
             >
               <div class="whitespace-nowrap overflow-hidden">
                 <div ref={inputOverlayContent2Ref}>


### PR DESCRIPTION
Fixes: #819 

<details>
<summary>Before (Click to open)</summary>

![image](https://github.com/user-attachments/assets/1f0a10cc-1a7f-486b-a048-9975da96f554)


</details>

<details>
<summary>After (Click to open)</summary>

![image](https://github.com/user-attachments/assets/d4f60e37-e956-4113-bc3a-f22c265131b2)

</details>

### PR Checklist

- [x] The PR title follows
     [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Is this closing an open issue? If so, link it, else include a proper
      description of the changes and rason behind them.
- [x] Does the PR have changes to the frontend? If so, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
