### PR TITLE
fix(schema): add license field

### DIFF
--- a/frontend/static/schema/config-file.v1.json
+++ b/frontend/static/schema/config-file.v1.json
@@ -24,6 +24,13 @@
         "1.0.0"
       ]
     },
+    "license": {
+      "type": "string",
+      "description": "The license of this JSR package.",
+      "examples": [
+        "MIT"
+      ]
+    },
     "exports": {
       "oneOf": [
         {


### PR DESCRIPTION
License field or license file has required but JSON schema of jsr.json doesn't has a field of this. So I added it.

### PR Checklist

- [x] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Is this closing an open issue? If so, link it, else include a proper
      description of the changes and rason behind them.
- [ ] Does the PR have changes to the frontend? If so, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
- [ ] Does the PR have changes to the backend? If so, make sure tests are added.
      <br/>And if changing dababase queries, be sure you have ran `sqlx prepare`
      and committed the changes in the `.sqlx` directory.
