### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: docker
+    directory: /api
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: docker
+    directory: /frontend
+    schedule:
+      interval: monthly


### PR DESCRIPTION
### Description

Adding dependabot to track update on our dependency. Sadly dependabot didn't track changes on deno

Action is weekly check to unsure there are no vulnerabilities on supply chain. But rest in montly do reduce noice and maintenance.

### PR Checklist

- [X] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
