### PR TITLE
fix: dark mode member link color

### DIFF
--- a/frontend/routes/@[scope]/~/members.tsx
+++ b/frontend/routes/@[scope]/~/members.tsx
@@ -94,7 +94,7 @@ export function MemberItem(props: MemberItemProps) {
     <TableRow key={member.user.id}>
       <TableData>
         <a
-          class="text-jsr-cyan-700 hover:text-jsr-cyan-400 hover:underline"
+          class="text-jsr-cyan-700 dark:text-cyan-400 hover:text-jsr-cyan-400 hover:underline"
           href={`/user/${member.user.id}`}
         >
           {member.user.name}


### PR DESCRIPTION
### PR Checklist

- [x] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Is this closing an open issue? If so, link it, else include a proper
      description of the changes and rason behind them.
- [x] Does the PR have changes to the frontend? If xo, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
- [ ] Does the PR have changes to the backend? If so, make sure tests are added.
      <br/>And if changing dababase queries, be sure you have ran `sqlx prepare`
      and committed the changes in the `.sqlx` directory.

Before:

<img width="291" alt="Screenshot 2025-06-12 at 13 42 48" src="https://github.com/user-attachments/assets/50280c12-5681-492d-9102-04e3db428b27" />

After:

<img width="354" alt="Screenshot 2025-06-12 at 13 42 44" src="https://github.com/user-attachments/assets/f04163ab-13dd-4e49-8ced-e56031ec43ff" />

