### PR TITLE
fix: add CORS headers to tarball endpoints

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -39,6 +39,7 @@ use crate::db::Database;
 use crate::emails::EmailSender;
 use crate::errors_internal::error_handler;
 use crate::gcp::Queue;
+use crate::npm::serve_npm_tarball;
 use crate::orama::OramaClient;
 use crate::sitemap::packages_sitemap_handler;
 use crate::sitemap::scopes_sitemap_handler;
@@ -75,6 +76,8 @@ pub struct MainRouterOptions {
 
 pub struct RegistryUrl(pub Url);
 pub struct NpmUrl(pub Url);
+
+
 
 pub(crate) fn main_router(
   MainRouterOptions {
@@ -115,6 +118,9 @@ pub(crate) fn main_router(
       .get("/login", auth::login_handler)
       .get("/login/callback", auth::login_callback_handler)
       .get("/logout", auth::logout_handler)
+      // Add CORS headers to tarball endpoints
+      .get("/~/:revision/*", serve_npm_tarball)
+      .options("/~/:revision/*", serve_npm_tarball)
   } else {
     builder
   };

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -27,6 +27,7 @@ pub use self::tarball::NpmTarball;
 pub use self::tarball::NpmTarballFiles;
 pub use self::tarball::NpmTarballOptions;
 pub use self::tarball::create_npm_tarball;
+pub use self::tarball::serve_npm_tarball;
 pub use self::types::NpmMappedJsrPackageName;
 use self::types::NpmVersionInfo;
 


### PR DESCRIPTION
Currently it's not possible to download JSR packages within browser environments (eg, in WebContainers). This fix adds CORS headers to prevent errors like this:

```
Access to fetch at
'https://npm.jsr.io/~/11/@jsr/nostrify__react/0.2.8.tgz' from origin 'https://h11gbxowc46vh5zy16u09l3mau3ohm-pock.w-corp-staticblitz.com' has been blocked by CORS policy: Request header
field npm-command is not allowed by Access-Control-Allow-Headers in preflight response.
```