### PR TITLE
fix: add npm-* headers to CORS

### DIFF
--- a/terraform/https.tf
+++ b/terraform/https.tf
@@ -98,7 +98,7 @@ resource "google_compute_url_map" "frontend_https" {
         allow_credentials = false
         expose_headers    = ["*"]
         allow_origins     = ["*"]
-        allow_headers     = ["Authorization", "X-Cloud-Trace-Context"]
+        allow_headers     = ["Authorization", "X-Cloud-Trace-Context", "npm-command", "npm-scope", "npm-session", "user-agent"]
         max_age           = 3600
       }
     }


### PR DESCRIPTION
Currently it's not possible to download JSR packages within browser environments (eg, in WebContainers). This fix adds CORS headers to prevent errors like this:

```
Access to fetch at
'https://npm.jsr.io/~/11/@jsr/nostrify__react/0.2.8.tgz' from origin 'https://h11gbxowc46vh5zy16u09l3mau3ohm-pock.w-corp-staticblitz.com' has been blocked by CORS policy: Request header
field npm-command is not allowed by Access-Control-Allow-Headers in preflight response.
```