### PR TITLE
fix: (potential) workaround for transpiler's error

### DIFF
--- a/frontend/islands/CopyButton.tsx
+++ b/frontend/islands/CopyButton.tsx
@@ -13,7 +13,7 @@ export function CopyButton(props: CopyButtonProps) {
   const timer = useRef<number | null>(null);
   const copied = useSignal(false);
 
-  const { text } = props;
+  const text = props.text;
 
   const copy = useCallback(() => {
     navigator.clipboard.writeText(text).then(() => {


### PR DESCRIPTION
Currently the below part:

```js
const { text } = props;
...
navigator.clipboard.writeText(text)
```

is transpiled like the below (`props.value` is used instead of `props.text`)
<img width="768" height="319" alt="Screenshot 2025-10-31 at 10 46 46" src="https://github.com/user-attachments/assets/22a870f1-c547-4aa1-ab14-3f6bcb84bbc9" />

and it causes copying of 'undefined' text (ref https://x.com/JLarky/status/1984050194896580874 )

This PR tries to fix it by avoiding using destructuring syntax.