### PR TITLE
ci: bump actions/checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Deno
         uses: denoland/setup-deno@v2
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name != 'push'
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -102,7 +102,7 @@ jobs:
       frontend_image_id: ${{ steps.frontend_image_id.outputs.image_id }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Authenticate with GCP
         id: gcp_auth
@@ -165,7 +165,7 @@ jobs:
       id-token: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Deno
         uses: denoland/setup-deno@v2
@@ -222,7 +222,7 @@ jobs:
       id-token: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/orama_package_reindex.yml
+++ b/.github/workflows/orama_package_reindex.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
       - name: Deploy
         env:

--- a/.github/workflows/orama_symbols_reindex.yml
+++ b/.github/workflows/orama_symbols_reindex.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
       - name: Deploy
         env:

--- a/frontend/docs/publishing-packages.md
+++ b/frontend/docs/publishing-packages.md
@@ -340,7 +340,7 @@ jobs:
       contents: read
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: npx jsr publish
 ```
 

--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -175,7 +175,7 @@ jobs:
     <span class='bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]'>  contents: read</span>
     <span class='bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]'>  id-token: write</span>
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
     <span class='bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]'>  - name: Publish package</span>
     <span class='bg-[rgba(134,239,172,.25)] text-[rgba(190,242,100)]'>    run: npx jsr publish</span>
 `;


### PR DESCRIPTION
This PR bumps the version of `actions/checkout` from `v5` to `v6`. The corresponding changes can be found in [CHANGELOG.md](https://github.com/actions/checkout/blob/main/CHANGELOG.md).