### PR TITLE
docs: add exports object syntax example to publishing packages page

### DIFF
--- a/frontend/docs/publishing-packages.md
+++ b/frontend/docs/publishing-packages.md
@@ -203,6 +203,8 @@ This file contains package metadata like the name, version, and entrypoint(s).
 This file should be named `jsr.json`. Deno users can also include the required
 JSR properties in their `deno.json(c)` to avoid having to create another file.
 
+For packages with a single entrypoint, you can use the shorthand string syntax:
+
 ```json
 // jsr.json / deno.json(c)
 {
@@ -211,6 +213,28 @@ JSR properties in their `deno.json(c)` to avoid having to create another file.
   "exports": "./mod.ts"
 }
 ```
+
+For packages with multiple entrypoints, use the object syntax:
+
+```json
+// jsr.json / deno.json(c)
+{
+  "name": "@luca/greet",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./greet": "./greet.ts",
+    "./farewell": "./farewell.ts"
+  }
+}
+```
+
+With the object syntax:
+
+- The `.` key defines the default entrypoint, imported as
+  `import { greet } from "@luca/greet";`
+- Named entrypoints like `./greet` are imported as
+  `import { greet } from "@luca/greet/greet";`
 
 Read more about the [configuring JSR packages.](/docs/package-configuration)
 


### PR DESCRIPTION
## Summary

Add documentation showing how to use the object syntax for the `exports` field when publishing packages with multiple entrypoints.

## Context

As noted in #767, the publishing packages page only showed the shorthand string syntax:

```json
"exports": "./mod.ts"
```

Users were confused about how to export multiple entrypoints using the object syntax.

## Changes

Updated the "Package config file" section in `frontend/docs/publishing-packages.md` to include:

1. **Clarification** that the string syntax is shorthand for single-entrypoint packages
2. **Object syntax example** showing multiple entrypoints:
   ```json
   "exports": {
     ".": "./mod.ts",
     "./greet": "./greet.ts",
     "./farewell": "./farewell.ts"
   }
   ```
3. **Explanation** of how the `.` key works as the default entrypoint
4. **Import examples** showing how each entrypoint is imported

This provides users with a clear reference on the publishing packages page itself, while still linking to the full package configuration documentation for more details.

Fixes #767