### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TypeScript/JavaScript (Deno default: 2 spaces)
+[*.{ts,tsx,js,jsx,json}]
+indent_style = space
+indent_size = 2
+
+# Rust (4 spaces)
+[*.rs]
+indent_style = space
+indent_size = 4
+
+# TOML (Cargo.toml, etc.)
+[*.toml]
+indent_style = space
+indent_size = 2
+
+# YAML
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+
+# SQL
+[*.sql]
+indent_style = space
+indent_size = 2
+
+# Docker
+[Dockerfile*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Summary
Added an `.editorconfig` file to help maintain consistent coding styles across different editors and IDEs.

## Configuration

- **TypeScript/JavaScript**: 2 spaces (Deno default)
- **Rust**: 4 spaces (Rust default)
- **TOML/YAML/JSON**: 2 spaces
- **Markdown**: 2 spaces, trailing whitespace preserved
- **All files**: UTF-8 encoding, LF line endings, final newline

## Benefits

- Editors that support EditorConfig will automatically use the right settings
- Reduces formatting inconsistencies in contributions
- Helps new contributors use correct settings immediately
- Works with VS Code, JetBrains IDEs, Vim, Sublime Text, and [many more](https://editorconfig.org/#pre-installed)