### PR TITLE
fix(docs): remove broken link to non-existent api-reference page

### DIFF
--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -248,9 +248,6 @@ specific package and version specified.
 An OpenAPI 3.0 specification for the management API is available at
 https://api.jsr.io/.well-known/openapi.
 
-A rendered version of the OpenAPI specification is available at
-[/docs/api-reference](/docs/api-reference).
-
 ### Usage restrictions
 
 The management API should not be used during registry operations. You should not


### PR DESCRIPTION
## Summary
Removes a broken link to `/docs/api-reference` which doesn't exist.

## Problem
The `api.md` file contained a reference to a rendered OpenAPI documentation page at `/docs/api-reference`, but this page doesn't exist in the docs, resulting in a 404 error.

## Solution
Removed the broken link. The OpenAPI specification URL (https://api.jsr.io/.well-known/openapi) is already provided on the preceding line, so users can still access the API documentation.

## PR Checklist
- [x] The PR title follows conventional commits
- [x] Closing issue: Fixes broken documentation link
- [ ] No frontend visual changes
- [ ] No backend changes