### PR TITLE
chore: add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Auto detect text files and normalize line endings
+* text=auto eol=lf
+
+# TypeScript/JavaScript
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+
+# Rust
+*.rs text eol=lf
+
+# Configuration files
+*.json text eol=lf
+*.toml text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# Web
+*.html text eol=lf
+*.css text eol=lf
+*.svg text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# SQL
+*.sql text eol=lf
+
+# Docker
+Dockerfile* text eol=lf
+
+# Lock files - don't diff (they're auto-generated)
+deno.lock -diff linguist-generated=true
+Cargo.lock -diff linguist-generated=true
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+
+# Fonts
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
## Summary
Added a `.gitattributes` file to ensure consistent file handling across different operating systems.

## Configuration

- **Line endings**: LF for all text files
- **Lock files**: `deno.lock` and `Cargo.lock` excluded from diffs (auto-generated)
- **File types**: TypeScript, Rust, JSON, YAML, Markdown, SQL, Docker files
- **Binary files**: Images and fonts marked as binary

## Benefits

- Prevents line ending issues when contributors work across Windows, macOS, and Linux
- Cleaner git diffs (no whitespace-only changes, no lock file noise)
- Proper linguist detection for GitHub statistics

## PR Checklist
- [x] The PR title follows conventional commits
- [ ] No visual changes
- [ ] No backend changes