### PR TITLE
fix: update SVG background URLs in styles.css for proper encoding

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -282,14 +282,14 @@
 
   .select {
     @apply appearance-none outline-hidden opacity-100 pl-1;
-    background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2014%22%3E%3Cpath%20fill%3D%22currentColor%22%20fill-rule%3D%22evenodd%22%20d%3D%22M.47%203.97a.75.75%200%200%201%201.06%200L6%208.44l4.47-4.47a.75.75%200%200%201%201.06%201.06l-5%205a.75.75%200%200%201-1.06%200l-5-5a.75.75%200%200%201%200-1.06Z%22%20clip-rule%3D%22evenodd%22/%3E%3C/svg%3E')
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2014%22%3E%3Cpath%20fill%3D%22currentColor%22%20fill-rule%3D%22evenodd%22%20d%3D%22M.47%203.97a.75.75%200%200%201%201.06%200L6%208.44l4.47-4.47a.75.75%200%200%201%201.06%201.06l-5%205a.75.75%200%200%201-1.06%200l-5-5a.75.75%200%200%201%200-1.06Z%22%20clip-rule%3D%22evenodd%22/%3E%3C/svg%3E")
       no-repeat;
     /* 0.25 = pl-1 */
     background-position: center right 0.25rem;
   }
 
   .dark .select {
-    background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2014%22%3E%3Cpath%20fill%3D%22white%22%20fill-rule%3D%22evenodd%22%20d%3D%22M.47%203.97a.75.75%200%200%201%201.06%200L6%208.44l4.47-4.47a.75.75%200%200%201%201.06%201.06l-5%205a.75.75%200%200%201-1.06%200l-5-5a.75.75%200%200%201%200-1.06Z%22%20clip-rule%3D%22evenodd%22/%3E%3C/svg%3E')
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2014%22%3E%3Cpath%20fill%3D%22white%22%20fill-rule%3D%22evenodd%22%20d%3D%22M.47%203.97a.75.75%200%200%201%201.06%200L6%208.44l4.47-4.47a.75.75%200%200%201%201.06%201.06l-5%205a.75.75%200%200%201-1.06%200l-5-5a.75.75%200%200%201%200-1.06Z%22%20clip-rule%3D%22evenodd%22/%3E%3C/svg%3E")
       no-repeat;
     /* 0.25 = pl-1 */
     background-position: center right 0.25rem;


### PR DESCRIPTION
### PR Checklist

- [x] The PR title follows
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Is this closing an open issue? If so, link it, else include a proper
      description of the changes and reason behind them.
- [x] Does the PR have changes to the frontend? If so, include screenshots or a
      recording of the changes.
      <br/>If it affect colors, please include screenshots/recording in both
      light and dark mode.
- [ ] Does the PR have changes to the backend? If so, make sure tests are added.
      <br/>And if changing dababase queries, be sure you have ran `sqlx prepare`
      and committed the changes in the `.sqlx` directory.

Tailwind 4 escapes special characters in the URL, so it's now http-encoded.

<img width="739" height="434" alt="image" src="https://github.com/user-attachments/assets/eaa503fc-f1f8-4142-b8f3-e36472360700" />

<img width="1122" height="424" alt="image" src="https://github.com/user-attachments/assets/6848f026-c6d5-49d6-9f8e-e3af9f5a5120" />
