### PR TITLE
fix: increase frontend memory limit to 1Gi to prevent OOM crashes

### DIFF
--- a/terraform/cloud_run_frontend.tf
+++ b/terraform/cloud_run_frontend.tf
@@ -46,6 +46,12 @@ resource "google_cloud_run_v2_service" "registry_frontend" {
     containers {
       image = var.frontend_image_id
 
+      resources {
+        limits = {
+          memory = "1Gi"
+        }
+      }
+
       dynamic "env" {
         for_each = local.frontend_envs
         content {


### PR DESCRIPTION
Frontend containers were using the default 512Mi memory limit, causing repeated OOM kills under load and cascading into site-wide outages.
