### PR TITLE
fix: frontend cold start crash loop due to uncached deps

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,10 +6,9 @@ COPY . .
 
 RUN deno task build
 RUN rm -rf $DENO_DIR
-RUN deno install --allow-import -e main.ts
-
-RUN timeout 2s deno run -A --cached-only main.ts || true
+RUN deno install
+RUN deno install --allow-import -e _fresh/server.js
 
 ENV PORT=8000
 
-CMD deno serve -A --port=$PORT _fresh/server.js
+CMD deno serve -A --cached-only --port=$PORT _fresh/server.js

--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -86,7 +86,7 @@ const auth = define.middleware(async (ctx) => {
 
 const cache = define.middleware(async (ctx) => {
   const resp = await ctx.next();
-  if (!ctx.state.api.hasToken() && ctx.state.cacheControl) {
+  if (ctx.state.api && !ctx.state.api.hasToken() && ctx.state.cacheControl) {
     resp.headers.set("cache-control", ctx.state.cacheControl);
   }
   return resp;


### PR DESCRIPTION
## Summary
- **Dockerfile**: Cache deps for `_fresh/server.js` (the actual entrypoint) instead of `main.ts`. The generated Fresh server has different imports that weren't being cached, causing Deno to download hundreds of deps from jsr.io/npm at runtime on every cold start.
- **Dockerfile**: Add `--cached-only` to the CMD so Deno fails fast instead of silently downloading at runtime.
- **Middleware**: Guard `ctx.state.api` access in the `cache` middleware for non-interactive requests (e.g. `/_fresh/*`), preventing `TypeError: Cannot read properties of undefined (reading 'get')`.

## Context
Frontend containers were crash-looping: Cloud Run routed requests as soon as the TCP probe passed, but Deno was still lazily downloading modules. Requests hit route handlers before middleware had initialized `state.api`, causing an uncaught TypeError that killed the process. New instances would start and immediately crash on the same backed-up requests.

## Test plan
- [ ] CI passes (frontend lint, API tests)
- [ ] Docker image builds successfully with deps cached for `_fresh/server.js`
- [ ] Cold start serves requests without downloading deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)