### PR TITLE
fix: increase API memory limit to 2Gi

### DIFF
--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_v2_service" "registry_api" {
       resources {
         limits = {
           cpu    = "1"
-          memory = "1.5Gi"
+          memory = "2Gi"
         }
       }
 


### PR DESCRIPTION
- Increase API server memory limit from 1.5Gi to 2Gi
- API instances were OOMing at 1.5Gi (~1600-1658 MiB observed), causing 500 errors on package pages
- Already applied via gcloud as a hotfix; this makes it permanent in terraform
