### PR TITLE
fix: resolve root-relative URLs in README to source repository

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -11,10 +11,8 @@ use comrak::nodes::Ast;
 use comrak::nodes::AstNode;
 use comrak::nodes::NodeValue;
 use deno_ast::ModuleSpecifier;
-use deno_doc::DeclarationDef;
-use deno_doc::Location;
-use deno_doc::ParseOutput;
-use deno_doc::Symbol;
+use deno_doc::html::pages::SymbolPage;
+use deno_doc::html::util::BreadcrumbsCtx;
 use deno_doc::html::DocNodeWithContext;
 use deno_doc::html::GenerateCtx;
 use deno_doc::html::HrefResolver;
@@ -22,12 +20,14 @@ use deno_doc::html::RenderContext;
 use deno_doc::html::ShortPath;
 use deno_doc::html::UrlResolveKind;
 use deno_doc::html::UsageComposerEntry;
-use deno_doc::html::pages::SymbolPage;
-use deno_doc::html::util::BreadcrumbsCtx;
+use deno_doc::DeclarationDef;
+use deno_doc::Location;
+use deno_doc::ParseOutput;
+use deno_doc::Symbol;
 use deno_semver::RangeSetOrTag;
-use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde::Serialize;
@@ -1759,7 +1759,8 @@ mod tests {
       "https://raw.githubusercontent.com/foo/bar/HEAD/assets/logo.png"
     );
 
-    let rewriter = get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
+    let rewriter =
+      get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
 
     assert_eq!(rewriter(None, "/docs/foo.md"), "/docs/foo.md");
   }

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -1759,7 +1759,8 @@ mod tests {
       "https://raw.githubusercontent.com/foo/bar/HEAD/assets/logo.png"
     );
 
-    let rewriter = get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
+    let rewriter =
+      get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
 
     assert_eq!(rewriter(None, "/docs/foo.md"), "/docs/foo.md");
   }

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -604,12 +604,12 @@ fn get_url_rewriter(
   is_readme: bool,
 ) -> URLRewriter {
   Arc::new(move |current_file, url| {
-    if url.starts_with('#') || url.starts_with('/') {
+    if url.starts_with('#') {
       return url.to_string();
     }
 
-    let base = if let Some(github_repository) = &github_repository {
-      if url.rsplit_once('.').is_some_and(|(_path, extension)| {
+    let is_media_url = |url: &str| {
+      url.rsplit_once('.').is_some_and(|(_path, extension)| {
         matches!(
           extension,
           "png"
@@ -624,7 +624,11 @@ fn get_url_rewriter(
             | "gif"
             | "ico"
         )
-      }) {
+      })
+    };
+
+    let base = if let Some(github_repository) = &github_repository {
+      if is_media_url(url) {
         format!(
           "https://raw.githubusercontent.com/{}/{}/HEAD",
           github_repository.owner, github_repository.name
@@ -638,6 +642,13 @@ fn get_url_rewriter(
     } else {
       base.clone()
     };
+
+    if url.starts_with('/') {
+      if github_repository.is_some() {
+        return format!("{base}{}", url);
+      }
+      return url.to_string();
+    }
 
     if !is_readme && let Some(current_file) = current_file {
       let (path, _file) = current_file
@@ -1737,5 +1748,19 @@ mod tests {
       ),
       "https://raw.githubusercontent.com/foo/bar/HEAD/./src/assets/logo.svg"
     );
+
+    assert_eq!(
+      rewriter(None, "/docs/getting-started.md"),
+      "https://github.com/foo/bar/blob/HEAD/docs/getting-started.md"
+    );
+
+    assert_eq!(
+      rewriter(None, "/assets/logo.png"),
+      "https://raw.githubusercontent.com/foo/bar/HEAD/assets/logo.png"
+    );
+
+    let rewriter = get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
+
+    assert_eq!(rewriter(None, "/docs/foo.md"), "/docs/foo.md");
   }
 }

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -11,8 +11,10 @@ use comrak::nodes::Ast;
 use comrak::nodes::AstNode;
 use comrak::nodes::NodeValue;
 use deno_ast::ModuleSpecifier;
-use deno_doc::html::pages::SymbolPage;
-use deno_doc::html::util::BreadcrumbsCtx;
+use deno_doc::DeclarationDef;
+use deno_doc::Location;
+use deno_doc::ParseOutput;
+use deno_doc::Symbol;
 use deno_doc::html::DocNodeWithContext;
 use deno_doc::html::GenerateCtx;
 use deno_doc::html::HrefResolver;
@@ -20,14 +22,12 @@ use deno_doc::html::RenderContext;
 use deno_doc::html::ShortPath;
 use deno_doc::html::UrlResolveKind;
 use deno_doc::html::UsageComposerEntry;
-use deno_doc::DeclarationDef;
-use deno_doc::Location;
-use deno_doc::ParseOutput;
-use deno_doc::Symbol;
+use deno_doc::html::pages::SymbolPage;
+use deno_doc::html::util::BreadcrumbsCtx;
 use deno_semver::RangeSetOrTag;
+use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde::Serialize;
@@ -1759,8 +1759,7 @@ mod tests {
       "https://raw.githubusercontent.com/foo/bar/HEAD/assets/logo.png"
     );
 
-    let rewriter =
-      get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
+    let rewriter = get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true);
 
     assert_eq!(rewriter(None, "/docs/foo.md"), "/docs/foo.md");
   }


### PR DESCRIPTION
## Summary

Root-relative URLs (starting with `/`) in package READMEs now resolve to the linked GitHub repository instead of jsr.io, matching the behavior npm and GitHub already provide.

## Why this matters

A README with `[Docs](/docs/getting-started.md)` would link to `jsr.io/docs/getting-started.md` and 404. Relative URLs without the leading slash (e.g. `docs/getting-started.md`) already resolved correctly to GitHub. This inconsistency confused package authors.

## Changes

In `api/src/docs.rs`, the `get_url_rewriter` function previously returned `/`-prefixed URLs unchanged:

```rust
if url.starts_with('#') || url.starts_with('/') {
    return url.to_string();
}
```

Now, only `#` fragment links pass through unchanged. Root-relative URLs are resolved against the GitHub repository URL when one is linked, using the same media-detection logic as relative URLs (images go to `raw.githubusercontent.com`, other files to `github.com/blob/HEAD`).

When no GitHub repository is linked, root-relative URLs are still returned as-is.

## Testing

Added three test cases to `test_url_rewriter`:
- `/docs/getting-started.md` with GitHub repo resolves to `https://github.com/foo/bar/blob/HEAD/docs/getting-started.md`
- `/assets/logo.png` with GitHub repo resolves to `https://raw.githubusercontent.com/foo/bar/HEAD/assets/logo.png`
- `/docs/foo.md` without GitHub repo stays as `/docs/foo.md`

All tests pass: `cargo test -p registry_api test_url_rewriter`

Fixes #768

This contribution was developed with AI assistance (Claude Code + Codex CLI).