### PR TITLE
chore: add per-branch database switching tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,23 @@ locally work on it, please see the
 [HTML development section](https://github.com/denoland/deno_doc?tab=readme-ov-file#html-generation)
 of `deno_doc`.
 
+### Per-branch databases
+
+The `db:switch` tool lets you work on multiple branches without clobbering your
+main development database. Each branch gets its own PostgreSQL database.
+
+```sh
+deno task db:switch switch     # switch to branch db copied from main
+deno task db:switch empty      # switch to an empty branch db
+deno task db:switch main       # switch back to the main database
+deno task db:switch current    # show which database is active
+deno task db:switch list       # list all branch databases
+deno task db:switch clean      # drop all branch databases
+```
+
+The `switch` and `empty` commands write an `api/.env.local` override file. Use
+`--method=export` to print an `export` command instead.
+
 ### Other
 
 During local dev, traces are sent to Jaeger. You can view them at

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -153,6 +153,7 @@ pub(crate) fn main_router(
 
 #[tokio::main]
 async fn main() {
+  dotenvy::from_filename(".env.local").ok();
   dotenvy::dotenv().ok();
   let config = Config::parse();
   println!("{config:?}");

--- a/architecture.md
+++ b/architecture.md
@@ -302,6 +302,7 @@ Local hostnames (`jsr.test`, `api.jsr.test`, `npm.jsr.test`) are configured in
 | `generate_web_symbols.ts`    | Generate web API type definitions                              |
 | `clone_dependency.ts`        | Clone dependencies for offline development                     |
 | `migrate_package_meta.ts`    | Database migration utilities                                   |
+| `db-switch.ts`               | Per-branch database management (copy, create empty, clean up)  |
 
 ## E2E Tests (`e2e/`)
 

--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
 
     "db:prepare": "cd api && cargo sqlx prepare -- --all-targets",
     "db:migrate": "cd api && sqlx migrate run",
+    "db:switch": "deno run --allow-read --allow-write --allow-run --allow-env ./tools/db-switch.ts",
 
     "lint": "deno task lint:frontend && deno task lint:tools && deno task lint:license && deno task lint:lb",
     "lint:frontend": "cd frontend && deno lint && deno check --allow-import=googleapis.deno.dev,deno.land,jsr.io dev.ts main.ts routes/**/*.tsx routes/**/*.ts",

--- a/tools/db-switch.ts
+++ b/tools/db-switch.ts
@@ -1,0 +1,393 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+
+import { parseArgs } from "jsr:@std/cli@^1";
+import { load } from "jsr:@std/dotenv@^0.225";
+import { exists } from "jsr:@std/fs@^1";
+
+const ENV_FILE = "api/.env";
+const ENV_LOCAL_FILE = "api/.env.local";
+
+interface DatabaseConfig {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+  name: string;
+}
+
+async function getCurrentBranch(): Promise<string> {
+  try {
+    const cmd = new Deno.Command("git", {
+      args: ["rev-parse", "--abbrev-ref", "HEAD"],
+      stdout: "piped",
+    });
+    const { stdout } = await cmd.output();
+    return new TextDecoder().decode(stdout).trim().replace(
+      /[^a-zA-Z0-9_]/g,
+      "_",
+    );
+  } catch {
+    return "unknown";
+  }
+}
+
+async function getMainDbName(): Promise<string> {
+  const env = await load({ envPath: ENV_FILE });
+  return env.MAIN_DB_NAME || "registry";
+}
+
+async function parseCurrentConfig(): Promise<DatabaseConfig> {
+  const env = await load({ envPath: ENV_FILE });
+  const databaseUrl = env.DATABASE_URL || "";
+
+  try {
+    const url = new URL(databaseUrl);
+    if (url.protocol !== "postgres:") throw new Error("Invalid protocol");
+
+    return {
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+      host: url.hostname,
+      port: url.port || "5432",
+      name: url.pathname.slice(1),
+    };
+  } catch {
+    const mainDb = await getMainDbName();
+    return {
+      host: "localhost",
+      port: "5432",
+      user: "user",
+      password: "password",
+      name: mainDb,
+    };
+  }
+}
+
+function buildDatabaseUrl(config: DatabaseConfig, dbName: string): string {
+  return `postgres://${config.user}:${config.password}@${config.host}:${config.port}/${dbName}`;
+}
+
+async function dbExists(
+  config: DatabaseConfig,
+  dbName: string,
+): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("psql", {
+      args: ["-h", config.host, "-p", config.port, "-U", config.user, "-lqt"],
+      env: { PGPASSWORD: config.password },
+      stdout: "piped",
+    });
+    const { stdout } = await cmd.output();
+    return new TextDecoder().decode(stdout).includes(dbName);
+  } catch {
+    return false;
+  }
+}
+
+async function createDatabase(
+  config: DatabaseConfig,
+  sourceDb: string,
+  targetDb: string,
+): Promise<void> {
+  console.log(`Creating database copy from ${sourceDb} to ${targetDb}...`);
+
+  const cmd = new Deno.Command("psql", {
+    args: [
+      "-h",
+      config.host,
+      "-p",
+      config.port,
+      "-U",
+      config.user,
+      "-c",
+      `CREATE DATABASE "${targetDb}" WITH TEMPLATE "${sourceDb}";`,
+    ],
+    env: { PGPASSWORD: config.password },
+  });
+
+  const output = await cmd.output();
+  if (!output.success) {
+    const errorMessage = new TextDecoder().decode(output.stderr);
+    throw new Error(
+      `Failed to create database: ${errorMessage || "Unknown error"}`,
+    );
+  }
+
+  console.log(`Database created successfully!`);
+}
+
+async function copyFromMain(
+  method: "env-local" | "export" = "env-local",
+): Promise<void> {
+  const branch = await getCurrentBranch();
+  const config = await parseCurrentConfig();
+  const mainDb = await getMainDbName();
+  const branchDb = `${mainDb}_${branch}`;
+
+  console.log(`Switching to branch database: ${branchDb}`);
+
+  if (!await dbExists(config, branchDb)) {
+    console.log(`Branch database does not exist. Creating...`);
+    await createDatabase(config, mainDb, branchDb);
+  }
+
+  const databaseUrl = buildDatabaseUrl(config, branchDb);
+
+  switch (method) {
+    case "env-local":
+      await Deno.writeTextFile(
+        ENV_LOCAL_FILE,
+        `DATABASE_URL=${databaseUrl}\n`,
+      );
+      console.log(
+        `Created ${ENV_LOCAL_FILE} - restart your app to use branch database`,
+      );
+      break;
+    case "export":
+      console.log(`\nexport DATABASE_URL="${databaseUrl}"`);
+      break;
+  }
+}
+
+async function switchToMain(): Promise<void> {
+  const mainDb = await getMainDbName();
+  console.log(`Switching to main database: ${mainDb}`);
+
+  if (await exists(ENV_LOCAL_FILE)) {
+    await Deno.remove(ENV_LOCAL_FILE);
+    console.log(`Removed ${ENV_LOCAL_FILE}`);
+  }
+}
+
+async function showCurrent(): Promise<void> {
+  const config = await parseCurrentConfig();
+  const mainDb = await getMainDbName();
+  const hasEnvLocal = await exists(ENV_LOCAL_FILE);
+
+  console.log(`Current database: ${config.name}`);
+
+  if (hasEnvLocal) {
+    const envLocal = await load({ envPath: ENV_LOCAL_FILE });
+    console.log(`Override active via ${ENV_LOCAL_FILE}: ${envLocal.DATABASE_URL}`);
+  } else if (config.name === mainDb) {
+    console.log(`Using main database`);
+  } else {
+    console.log(`Using branch database`);
+  }
+}
+
+async function listDatabases(): Promise<void> {
+  const config = await parseCurrentConfig();
+  const mainDb = await getMainDbName();
+  const currentDb = config.name;
+
+  const cmd = new Deno.Command("psql", {
+    args: [
+      "-h",
+      config.host,
+      "-p",
+      config.port,
+      "-U",
+      config.user,
+      "-t",
+      "-c",
+      `SELECT datname FROM pg_database WHERE datname = '${mainDb}' OR datname LIKE '${mainDb}_%' ORDER BY datname;`,
+    ],
+    env: { PGPASSWORD: config.password },
+    stdout: "piped",
+  });
+
+  const output = await cmd.output();
+  if (!output.success) {
+    throw new Error("Failed to list databases");
+  }
+
+  const databases = new TextDecoder().decode(output.stdout)
+    .split("\n")
+    .map((db) => db.trim())
+    .filter((db) => db.length > 0);
+
+  console.log("Branch databases:");
+  for (const db of databases) {
+    const marker = db === currentDb ? " <- (current)" : "";
+    const icon = db === mainDb ? "[main]" : "[branch]";
+    console.log(`${icon} ${db}${marker}`);
+  }
+}
+
+async function createEmpty(
+  method: "env-local" | "export" = "env-local",
+): Promise<void> {
+  const branch = await getCurrentBranch();
+  const config = await parseCurrentConfig();
+  const mainDb = await getMainDbName();
+  const blankDb = `${mainDb}_${branch}`;
+
+  console.log(`Creating blank database: ${blankDb}`);
+
+  if (await dbExists(config, blankDb)) {
+    console.log(`Database ${blankDb} already exists`);
+  } else {
+    const cmd = new Deno.Command("psql", {
+      args: [
+        "-h",
+        config.host,
+        "-p",
+        config.port,
+        "-U",
+        config.user,
+        "-c",
+        `CREATE DATABASE "${blankDb}";`,
+      ],
+      env: { PGPASSWORD: config.password },
+    });
+
+    const output = await cmd.output();
+    if (!output.success) {
+      const errorMessage = new TextDecoder().decode(output.stderr);
+      throw new Error(
+        `Failed to create blank database: ${errorMessage || "Unknown error"}`,
+      );
+    }
+
+    console.log(`Blank database created successfully!`);
+  }
+
+  const databaseUrl = buildDatabaseUrl(config, blankDb);
+
+  switch (method) {
+    case "env-local":
+      await Deno.writeTextFile(
+        ENV_LOCAL_FILE,
+        `DATABASE_URL=${databaseUrl}\n`,
+      );
+      console.log(
+        `Created ${ENV_LOCAL_FILE} - restart your app to use blank database`,
+      );
+      break;
+    case "export":
+      console.log(`\nexport DATABASE_URL="${databaseUrl}"`);
+      break;
+  }
+}
+
+async function cleanDatabases(): Promise<void> {
+  const config = await parseCurrentConfig();
+  const mainDb = await getMainDbName();
+
+  const cmd = new Deno.Command("psql", {
+    args: [
+      "-h",
+      config.host,
+      "-p",
+      config.port,
+      "-U",
+      config.user,
+      "-t",
+      "-c",
+      `SELECT datname FROM pg_database WHERE datname LIKE '${mainDb}_%' ORDER BY datname;`,
+    ],
+    env: { PGPASSWORD: config.password },
+    stdout: "piped",
+  });
+
+  const output = await cmd.output();
+  if (!output.success) {
+    throw new Error("Failed to list databases");
+  }
+
+  const databases = new TextDecoder().decode(output.stdout)
+    .split("\n")
+    .map((db) => db.trim())
+    .filter((db) => db.length > 0);
+
+  if (databases.length === 0) {
+    console.log("No branch databases to clean up.");
+    return;
+  }
+
+  console.log(`Dropping ${databases.length} branch database(s)...`);
+  for (const db of databases) {
+    const dropCmd = new Deno.Command("psql", {
+      args: [
+        "-h",
+        config.host,
+        "-p",
+        config.port,
+        "-U",
+        config.user,
+        "-c",
+        `DROP DATABASE "${db}";`,
+      ],
+      env: { PGPASSWORD: config.password },
+    });
+
+    const dropOutput = await dropCmd.output();
+    if (!dropOutput.success) {
+      const errorMessage = new TextDecoder().decode(dropOutput.stderr);
+      console.error(`Failed to drop ${db}: ${errorMessage}`);
+    } else {
+      console.log(`Dropped ${db}`);
+    }
+  }
+
+  if (await exists(ENV_LOCAL_FILE)) {
+    await Deno.remove(ENV_LOCAL_FILE);
+    console.log(`Removed ${ENV_LOCAL_FILE}`);
+  }
+}
+
+function showHelp(): void {
+  console.log(`Database Switch Helper
+
+Usage: deno task db:switch [command] [options]
+
+Commands:
+  switch    - Switch to a branch database copied from main (creates if needed)
+  empty     - Switch to an empty branch database (creates if needed)
+  main      - Switch back to main database
+  current   - Show current database
+  list      - List branch databases
+  clean     - Drop all branch databases
+
+Options:
+  --method=env-local   - Use api/.env.local (default)
+  --method=export      - Print export command`);
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Deno.args);
+  const command = args._[0] as string || "help";
+  const method = args.method as "env-local" | "export" || "env-local";
+
+  try {
+    switch (command) {
+      case "switch":
+        await copyFromMain(method);
+        break;
+      case "empty":
+        await createEmpty(method);
+        break;
+      case "main":
+        await switchToMain();
+        break;
+      case "current":
+        await showCurrent();
+        break;
+      case "list":
+        await listDatabases();
+        break;
+      case "clean":
+        await cleanDatabases();
+        break;
+      default:
+        showHelp();
+    }
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    Deno.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `tools/db-switch.ts` for managing per-branch PostgreSQL databases during local development
- Loads `api/.env.local` with priority over `api/.env` in the Rust API so the override takes effect
- Documents the tool in README.md and architecture.md

## Commands
```sh
deno task db:switch switch   # switch to branch db copied from main
deno task db:switch empty    # switch to an empty branch db
deno task db:switch main     # switch back to the main database
deno task db:switch current  # show which database is active
deno task db:switch list     # list all branch databases
deno task db:switch clean    # drop all branch databases
```

## Test plan
- [x] Run `deno task db:switch switch` and verify a branch database is created
- [x] Run `deno task db:switch current` and verify it reports the branch db
- [x] Run `deno task db:switch main` and verify it removes `api/.env.local`
- [x] Run `deno task db:switch clean` and verify branch databases are dropped
- [x] Start the API with `api/.env.local` present and verify it picks up the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)