### PR TITLE
perf: cache dependent count query to reduce database load

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -406,8 +406,11 @@ pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiPackage> {
     api_package.dependency_count = dependency_count as u64;
   }
 
-  let dependent_count = db
+  let dependent_count_cache =
+    req.data::<crate::db::DependentCountCache>().unwrap();
+  let dependent_count = dependent_count_cache
     .count_package_dependents(
+      db,
       crate::db::DependencyKind::Jsr,
       &format!("@{}/{}", scope, package),
     )

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -4713,3 +4713,38 @@ pub enum CreatePublishingTaskResult {
   Exists((PublishingTask, Option<UserPublic>)),
   WeeklyPublishAttemptsLimitExceeded(i32),
 }
+
+/// In-memory cache for `count_package_dependents` results. The dependent count
+/// for a package only changes when someone publishes a new version of a
+/// depending package, so a 15-minute TTL is safe and drastically reduces
+/// database load on package page views.
+#[derive(Clone)]
+pub struct DependentCountCache {
+  cache: moka::future::Cache<String, usize>,
+}
+
+impl DependentCountCache {
+  pub fn new() -> Self {
+    Self {
+      cache: moka::future::Cache::builder()
+        .max_capacity(2048)
+        .time_to_live(std::time::Duration::from_secs(900))
+        .build(),
+    }
+  }
+
+  pub async fn count_package_dependents(
+    &self,
+    db: &Database,
+    kind: DependencyKind,
+    name: &str,
+  ) -> Result<usize> {
+    let key = format!("{kind:?}:{name}");
+    if let Some(count) = self.cache.get(&key).await {
+      return Ok(count);
+    }
+    let count = db.count_package_dependents(kind, name).await?;
+    self.cache.insert(key, count).await;
+    Ok(count)
+  }
+}

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -4727,7 +4727,7 @@ impl DependentCountCache {
   pub fn new() -> Self {
     Self {
       cache: moka::future::Cache::builder()
-        .max_capacity(2048)
+        .max_capacity(65536)
         .time_to_live(std::time::Duration::from_secs(900))
         .build(),
     }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -117,6 +117,7 @@ pub(crate) fn main_router(
     .data(PublishQueue(publish_queue))
     .data(NpmTarballBuildQueue(npm_tarball_build_queue))
     .data(AnalyticsEngineConfig(analytics_engine_config))
+    .data(db::DependentCountCache::new())
     .middleware(routerify_query::query_parser())
     .err_handler_with_info(error_handler);
 


### PR DESCRIPTION
- Add a 15-minute in-memory cache (moka) for `count_package_dependents`
  query results
- This query runs on every package page view but the result only changes
  on publish events
- Under load, this single query was consuming 5.7x the Cloud SQL
  instance's CPU capacity (11.35 CPU-seconds vs 2 vCPU), causing
  connection pool starvation and timeouts across the site
- The delete-version path continues to use the uncached query for
  real-time accuracy