### PR TITLE
feat: managed challenge for non-module endpoints

### DIFF
--- a/lb/main.ts
+++ b/lb/main.ts
@@ -158,7 +158,15 @@ export async function handleRootRequest(
   const url = new URL(request.url);
   const path = url.pathname;
 
+  if (path === "/__challenge") {
+    const returnPath = url.searchParams.get("return") || "/";
+    const safeReturn = returnPath.startsWith("/") ? returnPath : "/";
+    return Response.redirect(new URL(safeReturn, url.origin).toString(), 302);
+  }
+
   if (isAPIRoute(path)) {
+    const challenge = requireChallenge(request);
+    if (challenge) return challenge;
     return await handleAPIRequest(request, env, false);
   } else if (isBot(request)) {
     return await handleFrontendRoute(request, env, true);
@@ -166,11 +174,31 @@ export async function handleRootRequest(
     if (canAccessModuleFile(request) && isModuleFilePath(path)) {
       return await handleModuleFileRoute(request, env);
     } else {
+      const challenge = requireChallenge(request);
+      if (challenge) return challenge;
       return await handleFrontendRoute(request, env, false);
     }
   } else {
+    const challenge = requireChallenge(request);
+    if (challenge) return challenge;
     return await handleFrontendRoute(request, env, false);
   }
+}
+
+function requireChallenge(request: Request): Response | null {
+  // Only require a challenge for requests that actually came through
+  // Cloudflare — otherwise (local dev, direct Cloud Run access) we'd create
+  // an infinite redirect loop because there's no WAF to serve the challenge.
+  if (!request.headers.get("CF-Ray")) {
+    return null;
+  }
+  if (request.headers.get("Cookie")?.includes("cf_clearance=")) {
+    return null;
+  }
+  const url = new URL(request.url);
+  const challengeUrl = new URL("/__challenge", url.origin);
+  challengeUrl.searchParams.set("return", url.pathname + url.search);
+  return Response.redirect(challengeUrl.toString(), 302);
 }
 
 export function canAccessModuleFile(request: Request): boolean {

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -11,7 +11,7 @@ resource "cloudflare_workers_script" "jsr_lb" {
   main_module = "worker.js"
 
   observability = {
-    enabled            = true
+    enabled = true
     logs = {
       enabled            = true
       invocation_logs    = true
@@ -29,7 +29,7 @@ resource "cloudflare_workers_script" "jsr_lb" {
       type        = "r2_bucket"
       name        = "MODULES_BUCKET"
       bucket_name = cloudflare_r2_bucket.modules.name
-    }, {
+      }, {
       type        = "r2_bucket"
       name        = "NPM_BUCKET"
       bucket_name = cloudflare_r2_bucket.npm.name
@@ -83,4 +83,25 @@ resource "cloudflare_workers_route" "jsr_npm" {
   script  = cloudflare_workers_script.jsr_lb.script_name
 
   depends_on = [cloudflare_workers_script.jsr_lb]
+}
+
+# Managed challenge endpoint for bot protection.
+#
+# The Worker (lb/main.ts) uses exact isModuleFilePath() + canAccessModuleFile()
+# logic to determine which requests need a challenge. Non-module requests
+# without a cf_clearance cookie are redirected to /__challenge, which triggers
+# this WAF rule. After solving, CF sets cf_clearance and all subsequent
+# requests pass through.
+resource "cloudflare_ruleset" "jsr_waf" {
+  zone_id = var.cloudflare_zone_id
+  name    = "JSR managed challenge endpoint"
+  kind    = "zone"
+  phase   = "http_request_firewall_custom"
+
+  rules = [{
+    action      = "managed_challenge"
+    expression  = "http.host eq \"${var.domain_name}\" and http.request.uri.path eq \"/__challenge\""
+    description = "Managed challenge for bot protection"
+    enabled     = true
+  }]
 }


### PR DESCRIPTION
## Summary
- Adds a Cloudflare managed challenge for bot protection on non-module endpoints (frontend + API) while leaving the module-file path untouched, so package clients (`deno add`, `npm install`, etc.) are unaffected.
- The Worker uses the exact `isModuleFilePath()` / `canAccessModuleFile()` routing logic to decide who needs a challenge, then redirects to `/__challenge`, where a WAF rule serves the managed challenge. After solving, the `cf_clearance` cookie lets subsequent requests pass.
- Requests without a `CF-Ray` header (local dev, direct Cloud Run) skip the challenge so we don't create an infinite redirect loop outside of Cloudflare.

## Tradeoffs
- One extra round-trip per `cf_clearance` lifetime (~30 min) for unchallenged visitors. The alternative (WAF-only matching) wasn't viable: WAF `matches` (regex) is Enterprise-only, and approximations don't cover every module path variant.

## Test plan
- [ ] Verify first visit to `jsr.io/` triggers the managed challenge and then loads normally
- [ ] Verify module fetches (`/@scope/pkg/x.y.z/mod.ts`, `meta.json`, `x.y.z_meta.json`) bypass the challenge
- [ ] Verify `npm.jsr.io` and `api.jsr.io` are unaffected (they don't route through `handleRootRequest`)
- [ ] Verify bots (Googlebot) still reach the frontend without a challenge
- [ ] Verify local dev (`jsr.test`) no longer hits a redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)