### PR TITLE
fix: more accurately report errors in otel

### DIFF
--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -54,7 +54,7 @@ pub fn admin_router() -> Router<Body, ApiError> {
     .unwrap()
 }
 
-#[instrument(name = "GET /api/admin/users", skip(req), err)]
+#[instrument(name = "GET /api/admin/users", skip(req))]
 pub async fn list_users(req: Request<Body>) -> ApiResult<ApiList<ApiFullUser>> {
   let iam = req.iam();
   iam.check_admin_access()?;
@@ -76,7 +76,6 @@ pub async fn list_users(req: Request<Body>) -> ApiResult<ApiList<ApiFullUser>> {
 #[instrument(
   name = "PATCH /api/admin/users/:user_id",
   skip(req),
-  err,
   fields(user_id)
 )]
 pub async fn update_user(mut req: Request<Body>) -> ApiResult<ApiFullUser> {
@@ -117,7 +116,7 @@ pub async fn update_user(mut req: Request<Body>) -> ApiResult<ApiFullUser> {
   }
 }
 
-#[instrument(name = "GET /api/admin/scopes", skip(req), err)]
+#[instrument(name = "GET /api/admin/scopes", skip(req))]
 pub async fn list_scopes(
   req: Request<Body>,
 ) -> ApiResult<ApiList<ApiFullScope>> {
@@ -138,12 +137,7 @@ pub async fn list_scopes(
   })
 }
 
-#[instrument(
-  name = "PATCH /api/admin/scopes/:scope",
-  skip(req),
-  err,
-  fields(scope)
-)]
+#[instrument(name = "PATCH /api/admin/scopes/:scope", skip(req), fields(scope))]
 pub async fn patch_scopes(mut req: Request<Body>) -> ApiResult<ApiFullScope> {
   let scope = req.param_scope()?;
   Span::current().record("scope", field::display(&scope));
@@ -184,7 +178,6 @@ pub async fn patch_scopes(mut req: Request<Body>) -> ApiResult<ApiFullScope> {
 #[instrument(
   name = "POST /api/admin/scopes",
   skip(req),
-  err,
   fields(scope, user_id)
 )]
 pub async fn assign_scope(mut req: Request<Body>) -> ApiResult<ApiScope> {
@@ -217,7 +210,7 @@ pub async fn assign_scope(mut req: Request<Body>) -> ApiResult<ApiScope> {
   Ok(scope.into())
 }
 
-#[instrument(name = "GET /api/admin/packages", skip(req), err)]
+#[instrument(name = "GET /api/admin/packages", skip(req))]
 pub async fn list_packages(
   req: Request<Body>,
 ) -> ApiResult<ApiList<ApiPackage>> {
@@ -240,7 +233,7 @@ pub async fn list_packages(
   })
 }
 
-#[instrument(name = "GET /api/admin/publishing_tasks", skip(req), err)]
+#[instrument(name = "GET /api/admin/publishing_tasks", skip(req))]
 pub async fn list_publishing_tasks(
   req: Request<Body>,
 ) -> ApiResult<ApiList<ApiPublishingTask>> {
@@ -268,7 +261,6 @@ pub async fn list_publishing_tasks(
 #[instrument(
   name = "POST /api/admin/publishing_tasks/:publishing_task/requeue",
   skip(req),
-  err
   fields(publishing_task)
 )]
 pub async fn requeue_publishing_tasks(req: Request<Body>) -> ApiResult<()> {
@@ -330,7 +322,7 @@ pub async fn requeue_publishing_tasks(req: Request<Body>) -> ApiResult<()> {
   Ok(())
 }
 
-#[instrument(name = "GET /api/admin/tickets", skip(req), err)]
+#[instrument(name = "GET /api/admin/tickets", skip(req))]
 pub async fn list_tickets(req: Request<Body>) -> ApiResult<ApiList<ApiTicket>> {
   let iam = req.iam();
   iam.check_admin_access()?;
@@ -349,7 +341,7 @@ pub async fn list_tickets(req: Request<Body>) -> ApiResult<ApiList<ApiTicket>> {
   })
 }
 
-#[instrument(name = "PATCH /api/admin/tickets/:id", skip(req), err)]
+#[instrument(name = "PATCH /api/admin/tickets/:id", skip(req))]
 pub async fn patch_ticket(mut req: Request<Body>) -> ApiResult<ApiTicket> {
   let id = req.param_uuid("id")?;
   Span::current().record("id", field::display(id));
@@ -372,7 +364,7 @@ pub async fn patch_ticket(mut req: Request<Body>) -> ApiResult<ApiTicket> {
   Ok(ticket.into())
 }
 
-#[instrument(name = "GET /api/admin/audit_logs", skip(req), err)]
+#[instrument(name = "GET /api/admin/audit_logs", skip(req))]
 pub async fn list_audit_logs(
   req: Request<Body>,
 ) -> ApiResult<ApiList<ApiAuditLog>> {

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -267,7 +267,7 @@ pub fn package_router() -> Router<Body, ApiError> {
     .unwrap()
 }
 
-#[instrument(name = "GET /api/packages", skip(req), err, fields(query))]
+#[instrument(name = "GET /api/packages", skip(req), fields(query))]
 pub async fn global_list_handler(
   req: Request<Body>,
 ) -> ApiResult<ApiList<ApiPackage>> {
@@ -299,7 +299,7 @@ pub async fn global_list_handler(
   })
 }
 
-#[instrument(name = "GET /api/stats", skip(req), err)]
+#[instrument(name = "GET /api/stats", skip(req))]
 pub async fn global_stats_handler(req: Request<Body>) -> ApiResult<ApiStats> {
   let db = req.data::<Database>().unwrap();
 
@@ -315,7 +315,7 @@ pub async fn global_stats_handler(req: Request<Body>) -> ApiResult<ApiStats> {
   })
 }
 
-#[instrument(name = "GET /api/metrics", skip(req), err)]
+#[instrument(name = "GET /api/metrics", skip(req))]
 pub async fn global_metrics_handler(
   req: Request<Body>,
 ) -> ApiResult<ApiMetrics> {
@@ -327,7 +327,6 @@ pub async fn global_metrics_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages",
   skip(req),
-  err,
   fields(scope)
 )]
 pub async fn list_handler(
@@ -356,7 +355,6 @@ pub async fn list_handler(
 #[instrument(
   name = "POST /api/scopes/:scope/packages",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn create_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
@@ -409,7 +407,6 @@ pub async fn create_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiPackage> {
@@ -452,7 +449,6 @@ pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiPackage> {
 #[instrument(
   name = "PATCH /api/scopes/:scope/packages/:package",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn update_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
@@ -757,7 +753,6 @@ async fn update_github_repository(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn list_versions_handler(
@@ -793,7 +788,6 @@ pub async fn list_versions_handler(
 #[instrument(
   name = "DELETE /api/scopes/:scope/packages/:package",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn delete_handler(req: Request<Body>) -> ApiResult<Response<Body>> {
@@ -840,7 +834,6 @@ pub async fn delete_handler(req: Request<Body>) -> ApiResult<Response<Body>> {
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn get_version_handler(
@@ -882,7 +875,6 @@ pub async fn get_version_handler(
 #[instrument(
   name = "POST /api/scopes/:scope/packages/:package/versions/:version",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn version_publish_handler(
@@ -1053,7 +1045,6 @@ pub async fn version_publish_handler(
 #[instrument(
   name = "POST /api/scopes/:scope/packages/:package/versions/:version/provenance",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn version_provenance_statements_handler(
@@ -1101,7 +1092,6 @@ pub async fn version_provenance_statements_handler(
 #[instrument(
   name = "PATCH /api/scopes/:scope/packages/:package/versions/:version",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn version_update_handler(
@@ -1194,7 +1184,6 @@ pub async fn version_update_handler(
 #[instrument(
   name = "DELETE /api/scopes/:scope/packages/:package/versions/:version",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn version_delete_handler(
@@ -1300,7 +1289,6 @@ pub async fn version_delete_handler(
 #[instrument(
   name = "POST /api/scopes/:scope/packages/:package/versions/:version/tarball",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn version_tarball_handler(
@@ -1345,7 +1333,6 @@ pub async fn version_tarball_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/docs",
   skip(req),
-  err,
   fields(scope, package, version, all_symbols, entrypoint, symbol)
 )]
 pub async fn get_docs_handler(
@@ -1489,7 +1476,6 @@ pub async fn get_docs_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/docs/search",
   skip(req),
-  err,
   fields(scope, package, version, all_symbols, entrypoint, symbol)
 )]
 pub async fn get_docs_search_handler(
@@ -1556,7 +1542,6 @@ pub async fn get_docs_search_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/docs/search_structured",
   skip(req),
-  err,
   fields(scope, package, version, all_symbols, entrypoint, symbol)
 )]
 pub async fn get_docs_search_structured_handler(
@@ -1641,7 +1626,6 @@ pub async fn get_docs_search_structured_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/source",
   skip(req),
-  err,
   fields(scope, package, version, path)
 )]
 pub async fn get_source_handler(
@@ -1805,7 +1789,6 @@ pub async fn get_source_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/diff/:old_version/:new_version",
   skip(req),
-  err,
   fields(scope, package, version, all_symbols, entrypoint, symbol)
 )]
 pub async fn get_diff_handler(
@@ -1968,7 +1951,6 @@ pub async fn get_diff_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/dependents",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn list_dependents_handler(
@@ -2013,7 +1995,6 @@ pub async fn list_dependents_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/downloads",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn get_downloads_handler(
@@ -2087,7 +2068,6 @@ pub async fn get_downloads_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/dependencies",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn list_dependencies_handler(
@@ -2642,7 +2622,6 @@ pub struct DependencyInfo {
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/versions/:version/dependencies/graph",
   skip(req),
-  err,
   fields(scope, package, version)
 )]
 pub async fn get_dependencies_graph_handler(
@@ -2692,7 +2671,6 @@ pub async fn get_dependencies_graph_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/publishing_tasks",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn list_publishing_tasks_handler(
@@ -2723,7 +2701,6 @@ pub async fn list_publishing_tasks_handler(
 #[instrument(
   name = "GET /api/scopes/:scope/packages/:package/score",
   skip(req),
-  err,
   fields(scope, package)
 )]
 pub async fn get_score_handler(

--- a/api/src/api/publishing_task.rs
+++ b/api/src/api/publishing_task.rs
@@ -25,7 +25,6 @@ pub fn publishing_task_router() -> Router<Body, ApiError> {
 #[instrument(
   name = "GET /api/publishing_tasks/:publishing_task_id",
   skip(req),
-  err,
   fields(publishing_task_id)
 )]
 pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiPublishingTask> {

--- a/api/src/api/scope.rs
+++ b/api/src/api/scope.rs
@@ -70,7 +70,7 @@ pub fn scope_router() -> Router<Body, ApiError> {
 static RESERVED_SCOPES: OnceLock<std::collections::HashSet<String>> =
   OnceLock::new();
 
-#[instrument(name = "POST /api/scopes", skip(req), err, fields(scope))]
+#[instrument(name = "POST /api/scopes", skip(req), fields(scope))]
 async fn create_handler(mut req: Request<Body>) -> ApiResult<ApiScope> {
   let ApiCreateScopeRequest { scope, description } =
     decode_json(&mut req).await?;
@@ -112,7 +112,7 @@ async fn create_handler(mut req: Request<Body>) -> ApiResult<ApiScope> {
   Ok(scope.into())
 }
 
-#[instrument(name = "GET /api/scopes/:scope", skip(req), err, fields(scope))]
+#[instrument(name = "GET /api/scopes/:scope", skip(req), fields(scope))]
 async fn get_handler(req: Request<Body>) -> ApiResult<ApiScopeOrFullScope> {
   let scope_name = req.param_scope()?;
   Span::current().record("scope", field::display(&scope_name));
@@ -136,7 +136,7 @@ async fn get_handler(req: Request<Body>) -> ApiResult<ApiScopeOrFullScope> {
   }
 }
 
-#[instrument(name = "PATCH /api/scopes/:scope", skip(req), err, fields(scope))]
+#[instrument(name = "PATCH /api/scopes/:scope", skip(req), fields(scope))]
 async fn update_handler(
   mut req: Request<Body>,
 ) -> ApiResult<ApiScopeOrFullScope> {
@@ -192,7 +192,7 @@ async fn update_handler(
   ))
 }
 
-#[instrument(name = "DELETE /api/scopes/:scope", skip(req), err, fields(scop))]
+#[instrument(name = "DELETE /api/scopes/:scope", skip(req), fields(scop))]
 pub async fn delete_handler(req: Request<Body>) -> ApiResult<Response<Body>> {
   let scope = req.param_scope()?;
 
@@ -215,12 +215,7 @@ pub async fn delete_handler(req: Request<Body>) -> ApiResult<Response<Body>> {
   Ok(res)
 }
 
-#[instrument(
-  name = "GET /api/scopes/:scope/members",
-  skip(req),
-  err,
-  fields(scope)
-)]
+#[instrument(name = "GET /api/scopes/:scope/members", skip(req), fields(scope))]
 async fn list_members_handler(
   req: Request<Body>,
 ) -> ApiResult<Vec<ApiScopeMember>> {
@@ -244,7 +239,6 @@ async fn list_members_handler(
 #[instrument(
   name = "POST /api/scopes/:scope/members",
   skip(req),
-  err,
   fields(scope, github_login)
 )]
 async fn invite_member_handler(
@@ -344,7 +338,6 @@ async fn invite_member_handler(
 #[instrument(
   name = "PATCH /api/scopes/:scope/members/:member",
   skip(req),
-  err,
   fields(scope, member)
 )]
 async fn update_member_handler(
@@ -395,7 +388,6 @@ async fn update_member_handler(
 #[instrument(
   name = "DELETE /api/scopes/:scope/members/:member",
   skip(req),
-  err,
   fields(scope, member)
 )]
 pub async fn delete_member_handler(
@@ -436,12 +428,7 @@ pub async fn delete_member_handler(
   Ok(resp)
 }
 
-#[instrument(
-  name = "GET /api/scopes/:scope/invites",
-  skip(req),
-  err,
-  fields(scope)
-)]
+#[instrument(name = "GET /api/scopes/:scope/invites", skip(req), fields(scope))]
 pub async fn list_invites_handler(
   req: Request<Body>,
 ) -> ApiResult<Vec<ApiScopeInvite>> {
@@ -468,7 +455,6 @@ pub async fn list_invites_handler(
 #[instrument(
   name = "DELETE /api/scopes/:scope/invites/:user_id",
   skip(req),
-  err,
   fields(scope, user_id)
 )]
 pub async fn delete_invite_handler(

--- a/api/src/api/self_user.rs
+++ b/api/src/api/self_user.rs
@@ -54,14 +54,14 @@ pub fn self_user_router() -> Router<Body, ApiError> {
     .unwrap()
 }
 
-#[instrument(name = "GET /api/user", skip(req), err)]
+#[instrument(name = "GET /api/user", skip(req))]
 pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiFullUser> {
   let iam = req.iam();
   let current_user = iam.check_current_user_access()?.to_owned();
   Ok(current_user.into())
 }
 
-#[instrument(name = "GET /api/user/scopes", skip(req), err)]
+#[instrument(name = "GET /api/user/scopes", skip(req))]
 pub async fn list_scopes_handler(
   req: Request<Body>,
 ) -> ApiResult<Vec<ApiScope>> {
@@ -74,12 +74,7 @@ pub async fn list_scopes_handler(
   Ok(scopes.into_iter().map(ApiScope::from).collect())
 }
 
-#[instrument(
-  name = "GET /api/user/member/:scope",
-  skip(req),
-  err,
-  fields(scope)
-)]
+#[instrument(name = "GET /api/user/member/:scope", skip(req), fields(scope))]
 pub async fn get_member_handler(
   req: Request<Body>,
 ) -> ApiResult<ApiScopeMember> {
@@ -99,7 +94,7 @@ pub async fn get_member_handler(
   Ok((scope_member, UserPublic::from(current_user.clone())).into())
 }
 
-#[instrument(name = "GET /api/user/invites", skip(req), err)]
+#[instrument(name = "GET /api/user/invites", skip(req))]
 pub async fn list_invites_handler(
   req: Request<Body>,
 ) -> ApiResult<Vec<ApiScopeInvite>> {
@@ -118,12 +113,7 @@ pub async fn list_invites_handler(
   Ok(scope_invites)
 }
 
-#[instrument(
-  name = "POST /api/user/invites/:scope",
-  skip(req),
-  err,
-  fields(scope)
-)]
+#[instrument(name = "POST /api/user/invites/:scope", skip(req), fields(scope))]
 pub async fn accept_invite_handler(
   req: Request<Body>,
 ) -> ApiResult<ApiScopeMember> {
@@ -146,7 +136,6 @@ pub async fn accept_invite_handler(
 #[instrument(
   name = "DELETE /api/user/invites/:scope",
   skip(req),
-  err,
   fields(scope)
 )]
 pub async fn decline_invite_handler(
@@ -318,7 +307,7 @@ async fn delete_token(req: Request<Body>) -> Result<Response<Body>, ApiError> {
   Ok(resp)
 }
 
-#[instrument(name = "GET /api/user/tickets", skip(req), err)]
+#[instrument(name = "GET /api/user/tickets", skip(req))]
 pub async fn list_tickets(req: Request<Body>) -> ApiResult<Vec<ApiTicket>> {
   let iam = req.iam();
   let current_user = iam.check_current_user_access()?;

--- a/api/src/api/tickets.rs
+++ b/api/src/api/tickets.rs
@@ -36,7 +36,7 @@ pub fn tickets_router() -> Router<Body, ApiError> {
     .unwrap()
 }
 
-#[instrument(name = "GET /api/tickets/:id", skip(req), err, fields(id))]
+#[instrument(name = "GET /api/tickets/:id", skip(req), fields(id))]
 pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiTicketOverview> {
   let id = req.param_uuid("id")?;
 
@@ -84,7 +84,7 @@ pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiTicketOverview> {
   }
 }
 
-#[instrument(name = "POST /api/tickets", skip(req), err)]
+#[instrument(name = "POST /api/tickets", skip(req))]
 pub async fn post_handler(mut req: Request<Body>) -> ApiResult<ApiTicket> {
   let new_ticket: NewTicket = decode_json(&mut req).await?;
   let db = req.data::<Database>().unwrap();

--- a/api/src/api/users.rs
+++ b/api/src/api/users.rs
@@ -31,7 +31,7 @@ pub fn users_router() -> Router<Body, ApiError> {
     .unwrap()
 }
 
-#[instrument(name = "GET /api/users/:id", skip(req), err, fields(id))]
+#[instrument(name = "GET /api/users/:id", skip(req), fields(id))]
 pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiUser> {
   let id = req.param_uuid("id")?;
   Span::current().record("id", field::display(id));
@@ -45,7 +45,7 @@ pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiUser> {
   Ok(user.into())
 }
 
-#[instrument(name = "GET /api/users/:id/scopes", skip(req), err, fields(id))]
+#[instrument(name = "GET /api/users/:id/scopes", skip(req), fields(id))]
 pub async fn get_scopes_handler(
   req: Request<Body>,
 ) -> ApiResult<Vec<ApiScope>> {

--- a/api/src/errors_internal.rs
+++ b/api/src/errors_internal.rs
@@ -7,6 +7,7 @@ use routerify::RequestInfo;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::Span;
+use tracing::error;
 
 use crate::api::ApiError;
 
@@ -133,14 +134,20 @@ pub async fn error_handler(
   // Because `routerify::RouteError` is a boxed error, it must be downcast
   // first. Unwrap for simplicity.
   let api_err = err.downcast::<ApiError>().unwrap();
+  let is_server_error = api_err.status_code().is_server_error();
   let span = Span::current();
   span.record(
     "otel.status_code",
-    if api_err.status_code().is_server_error() {
-      "error"
-    } else {
-      "ok"
-    },
+    if is_server_error { "error" } else { "ok" },
   );
+  // Only server errors (5xx) are logged. Client errors (4xx, e.g. 404s) are
+  // expected and would otherwise pollute error logs and trace error rates. The
+  // route handlers no longer carry `err` on their `#[instrument]`, so this is
+  // the single place a directly-constructed 5xx `ApiError` gets surfaced;
+  // anyhow-backed 5xx are additionally logged at their origin (leaf spans keep
+  // `err`).
+  if is_server_error {
+    error!(error = %api_err, status = api_err.status_code().as_u16());
+  }
   api_err.json_response()
 }


### PR DESCRIPTION
The `err` attribute would mark spans as errors even if they actually returned 400s.