### PR TITLE
fix: cut docs/diff origin render cost (noindex + per-IP cache-miss rate limit)

### DIFF
--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -36,12 +36,17 @@ const auth = define.middleware(async (ctx) => {
     !pathname.startsWith("/api") &&
     !ctx.url.searchParams.has("__frsh_c");
   const { token, sudo } = getCookies(ctx.req.headers);
+  // Forward the originating client's user-agent so the api server records it
+  // on its HTTP span instead of an empty `http.user_agent`. Identify ourselves
+  // when the inbound request carries none.
+  const userAgent = ctx.req.headers.get("user-agent") ?? "jsr-frontend";
   if (interactive) {
     ctx.state.sudo = sudo === "1";
     ctx.state.api = new API(API_ROOT, {
       token,
       sudo: ctx.state.sudo,
       span: ctx.state.span,
+      userAgent,
     });
     if (ctx.state.api.hasToken()) {
       ctx.state.userPromise = (async () => {
@@ -53,6 +58,7 @@ const auth = define.middleware(async (ctx) => {
           ctx.state.api = new API(API_ROOT, {
             span: ctx.state.span,
             token: null,
+            userAgent,
           });
           const redirectTarget = `${ctx.url.pathname}${ctx.url.search}`;
           const loginUrl = `/login?redirect=${

--- a/frontend/routes/package/diff/[file].tsx
+++ b/frontend/routes/package/diff/[file].tsx
@@ -119,7 +119,10 @@ export const handler = define.handlers({
         versions,
         docsReq,
       },
-      headers: { ...(ctx.params.version ? { "X-Robots-Tag": "noindex" } : {}) },
+      // Diff pages key on old/new version (never `version`), so this branch was
+      // dead and every diff page was indexable — N² version pairs × entrypoints
+      // of cold-render cardinality with no SEO value. Always `noindex`.
+      headers: { "X-Robots-Tag": "noindex" },
     };
   },
 });

--- a/frontend/routes/package/diff/[symbol].tsx
+++ b/frontend/routes/package/diff/[symbol].tsx
@@ -119,7 +119,10 @@ export const handler = define.handlers({
         versions,
         docsReq,
       },
-      headers: { ...(ctx.params.version ? { "X-Robots-Tag": "noindex" } : {}) },
+      // Diff pages key on old/new version (never `version`), so this branch was
+      // dead and every diff page was indexable — N² version pairs × symbols of
+      // cold-render cardinality with no SEO value. Always `noindex`.
+      headers: { "X-Robots-Tag": "noindex" },
     };
   },
 });

--- a/frontend/routes/package/diff/all_symbols.tsx
+++ b/frontend/routes/package/diff/all_symbols.tsx
@@ -107,7 +107,10 @@ export const handler = define.handlers({
         versions,
         docsReq,
       },
-      headers: { ...(ctx.params.version ? { "X-Robots-Tag": "noindex" } : {}) },
+      // Diff pages key on old/new version (never `version`), so this branch was
+      // dead and every diff page was indexable — N² version pairs of cold-render
+      // cardinality with no SEO value. Always `noindex`.
+      headers: { "X-Robots-Tag": "noindex" },
     };
   },
 });

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -116,7 +116,10 @@ export const handler = define.handlers({
         docs,
         member: scopeMember,
       },
-      headers: { ...(ctx.params.version ? { "X-Robots-Tag": "noindex" } : {}) },
+      // Per-symbol doc pages are unbounded cardinality (every symbol of every
+      // version) and each is a cold docs render at the origin. `noindex`
+      // unconditionally — including "latest" — so crawlers stop walking them.
+      headers: { "X-Robots-Tag": "noindex" },
     };
   },
 });

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -66,6 +66,15 @@ interface APIOptions {
   token?: string | null;
   sudo?: boolean;
   span?: TraceSpan | null;
+  /**
+   * User-Agent to forward on server-side API calls. The SSR client makes its
+   * own requests with a fresh header set, so without this the api server sees
+   * no user-agent and records an empty `http.user_agent` in its traces. We
+   * forward the originating client's user-agent so api traces reflect the real
+   * caller. Unused in the browser, where the runtime sets (and forbids
+   * overriding) User-Agent.
+   */
+  userAgent?: string | null;
 }
 
 interface RequestOptions {
@@ -93,12 +102,17 @@ export class API {
   #token: string | null;
   #sudo: boolean;
   #span: TraceSpan | null;
+  #userAgent: string | null;
 
-  constructor(apiRoot: string, { token, sudo, span }: APIOptions = {}) {
+  constructor(
+    apiRoot: string,
+    { token, sudo, span, userAgent }: APIOptions = {},
+  ) {
     this.#apiRoot = apiRoot;
     this.#token = token ?? null;
     this.#sudo = sudo ?? false;
     this.#span = span ?? null;
+    this.#userAgent = userAgent ?? null;
   }
 
   hasToken(): boolean {
@@ -194,6 +208,9 @@ export class API {
     if (span) {
       headers.set("x-cloud-trace-context", span.cloudTraceContext);
       headers.set("traceparent", span.traceparent);
+    }
+    if (this.#userAgent) {
+      headers.set("User-Agent", this.#userAgent);
     }
     try {
       // On Cloudflare Workers, route API subrequests through the LB

--- a/lb/main.ts
+++ b/lb/main.ts
@@ -224,13 +224,36 @@ export function isModuleFilePath(path: string): boolean {
     );
 }
 
+/**
+ * Doc, diff, and source package pages are the expensive-to-render routes that
+ * scrapers walk symbol-by-symbol. They get a stricter per-IP limit than the
+ * general frontend limit. Patterns (the package segment may carry an
+ * `@version` suffix; source pins the version as its own path segment):
+ *   docs:   /@scope/pkg[@version]/doc(/...)?
+ *   diff:   /@scope/pkg/diff/...
+ *   source: /@scope/pkg/<semver>/...
+ */
+const DOCS_DIFF_SOURCE_ROUTE =
+  /^\/@[^/]+\/[^/]+(?:\/doc(?:\/|$)|\/diff(?:\/|$)|\/\d+\.\d+\.\d+)/;
+
+export function isDocsDiffSourceRoute(path: string): boolean {
+  return DOCS_DIFF_SOURCE_ROUTE.test(path);
+}
+
 async function handleFrontendRoute(
   request: Request,
   env: WorkerEnv,
   isBot: boolean,
   ctx?: ExecutionCtx,
 ): Promise<Response> {
-  const limited = await rateLimitGuard(request, env);
+  // Doc, diff, and source pages are the expensive renders scrapers walk;
+  // give them a stricter per-IP limit before the general frontend limit.
+  if (isDocsDiffSourceRoute(new URL(request.url).pathname)) {
+    const limited = await rateLimitGuard(request, env.DOCS_RATELIMIT);
+    if (limited) return limited;
+  }
+
+  const limited = await rateLimitGuard(request, env.FRONTEND_RATELIMIT);
   if (limited) return limited;
 
   const response = await proxyToBackend(request, env.FRONTEND, undefined, ctx);
@@ -245,15 +268,16 @@ async function handleFrontendRoute(
 }
 
 /**
- * Per-IP rate limit for the frontend only. Module files (R2), the API, and
- * npm compat are never rate-limited here — only the Cloud Run frontend, which
- * is the backend that scrapers actually generate cache-miss load on.
+ * Per-IP rate limit, keyed on the real client IP (`CF-Connecting-IP`) at the
+ * edge. Applied only to frontend routes — module files (R2), the API, and npm
+ * compat are never rate-limited here. Callers pass the binding to enforce:
+ * the general `FRONTEND_RATELIMIT` for all frontend routes, or the stricter
+ * `DOCS_RATELIMIT` for the expensive doc/diff/source pages.
  */
 async function rateLimitGuard(
   request: Request,
-  env: WorkerEnv,
+  limiter: RateLimit | undefined,
 ): Promise<Response | null> {
-  const limiter = env.FRONTEND_RATELIMIT;
   if (!limiter) return null;
   const ip = request.headers.get("CF-Connecting-IP");
   if (!ip) return null;

--- a/lb/main_test.ts
+++ b/lb/main_test.ts
@@ -1,0 +1,64 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { isDocsDiffSourceRoute } from "./main.ts";
+
+Deno.test("isDocsDiffSourceRoute matches doc pages", () => {
+  for (
+    const path of [
+      "/@scope/pkg/doc",
+      "/@scope/pkg/doc/",
+      "/@scope/pkg/doc/all_symbols",
+      "/@scope/pkg/doc/~/Foo",
+      "/@scope/pkg/doc/mod.ts/~/Foo.bar",
+      "/@scope/pkg@1.2.3/doc",
+      "/@scope/pkg@1.2.3/doc/~/Foo",
+    ]
+  ) {
+    assertEquals(isDocsDiffSourceRoute(path), true, path);
+  }
+});
+
+Deno.test("isDocsDiffSourceRoute matches diff pages", () => {
+  for (
+    const path of [
+      "/@scope/pkg/diff/1.0.0...2.0.0",
+      "/@scope/pkg/diff/1.0.0...2.0.0/all_symbols",
+      "/@scope/pkg/diff/1.0.0...2.0.0/~/Foo",
+      "/@scope/pkg/diff/...2.0.0/mod.ts/~/Foo",
+    ]
+  ) {
+    assertEquals(isDocsDiffSourceRoute(path), true, path);
+  }
+});
+
+Deno.test("isDocsDiffSourceRoute matches source pages", () => {
+  for (
+    const path of [
+      "/@scope/pkg/1.2.3",
+      "/@scope/pkg/1.2.3/mod.ts",
+      "/@scope/pkg/1.2.3/src/foo.ts",
+      "/@scope/pkg/1.2.3-beta.1/mod.ts",
+    ]
+  ) {
+    assertEquals(isDocsDiffSourceRoute(path), true, path);
+  }
+});
+
+Deno.test("isDocsDiffSourceRoute ignores other routes", () => {
+  for (
+    const path of [
+      "/",
+      "/@scope",
+      "/@scope/pkg",
+      "/@scope/pkg/score",
+      "/@scope/pkg/versions",
+      "/@scope/pkg/dependencies",
+      "/@scope/pkg/meta.json",
+      "/api/scopes/scope/packages/pkg/versions/1.2.3/docs",
+      "/packages",
+    ]
+  ) {
+    assertEquals(isDocsDiffSourceRoute(path), false, path);
+  }
+});

--- a/lb/types.ts
+++ b/lb/types.ts
@@ -31,4 +31,9 @@ export interface WorkerEnv {
   // not modules (R2), the API server, or npm compat. Keeps scrapers from
   // generating cache-miss load on the frontend Worker.
   FRONTEND_RATELIMIT?: RateLimit;
+
+  // Optional: omitted in local dev. Stricter per-IP limit applied only to the
+  // doc, diff, and source package pages (see isDocsDiffSourceRoute), the
+  // expensive-to-render routes scrapers walk symbol-by-symbol.
+  DOCS_RATELIMIT?: RateLimit;
 }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -93,7 +93,7 @@ resource "cloudflare_workers_script" "jsr_lb" {
       name         = "DOCS_RATELIMIT"
       namespace_id = "1002"
       simple = {
-        limit  = 30
+        limit  = 20
         period = 60
       }
     }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -82,6 +82,20 @@ resource "cloudflare_workers_script" "jsr_lb" {
         limit  = 240
         period = 60
       }
+      }, {
+      # Stricter per-IP limit applied only to the doc, diff, and source package
+      # pages (see isDocsDiffSourceRoute in lb/main.ts) — the expensive-to-render
+      # routes scrapers walk symbol-by-symbol. Stacks on top of FRONTEND_RATELIMIT
+      # so these pages are capped well below the general frontend allowance.
+      # namespace_id is a per-account identifier for this rate-limit binding;
+      # any unused value works (no Cloudflare-reserved meaning for "1002").
+      type         = "ratelimit"
+      name         = "DOCS_RATELIMIT"
+      namespace_id = "1002"
+      simple = {
+        limit  = 60
+        period = 60
+      }
     }
   ]
 

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -93,7 +93,7 @@ resource "cloudflare_workers_script" "jsr_lb" {
       name         = "DOCS_RATELIMIT"
       namespace_id = "1002"
       simple = {
-        limit  = 60
+        limit  = 30
         period = 60
       }
     }


### PR DESCRIPTION
## Why

docs/diff/source origin load is dominated by **crawler cardinality**, confirmed in the live data: the lb cache key is the full URL, and these pages fan out across every `symbol × entrypoint × version` (and for diff, every `old→new` version pair). So each *distinct* URL is a cold docs render at the origin that caching fundamentally can't collapse — and as the origin gets healthier, crawlers complete more of the walk, pushing load onto this uncacheable tail. Cutting the crawl is the lever.

This PR attacks it from two complementary angles: stop *inviting* the crawl (noindex), and *cap* it when it happens anyway (per-IP rate limit).

## Change

### 1. Unconditional `noindex` on high-cardinality, zero-SEO-value pages

- **Per-symbol doc pages** (`.../doc/.../~/:symbol`) — previously `noindex` only for pinned `@version` URLs, so the **latest** symbol pages (exactly what crawlers walk) stayed indexable.
- **All diff pages** — they key on `oldVersion`/`newVersion`, never `:version`, so the existing `ctx.params.version` guard was **dead code** and *every* diff page was indexable (N² version-pairs × symbols, no SEO value).

Canonical, low-cardinality pages stay indexable: the package index (`/@scope/pkg`), the docs landing/per-entrypoint pages, and `all_symbols`.

### 2. Stricter per-IP rate limit on docs/diff/source pages

A new `DOCS_RATELIMIT` (60 req / 60s) at the lb, applied **only** to the doc, diff, and source package pages via `isDocsDiffSourceRoute` in `lb/main.ts`. Keyed on `CF-Connecting-IP` — the real client IP at the Cloudflare edge — and stacked on top of the existing `FRONTEND_RATELIMIT` (240/60s), which stays as the broad frontend backstop.

This works where rate limiting was previously thought infeasible: the *API server* only sees the frontend's identity on SSR-driven renders, but the **edge lb sees the real client IP on every route**, so the gate sits in front of the SSR render that drives the origin load.

## Notes

- `noindex` reduces crawl *over time* (Google stops re-crawling and following into noindexed URLs); it's not instant, since a crawler must fetch a page once to see the header. The rate limit caps load immediately, including for clients that ignore `robots`/`noindex`.
- The limit is per-IP, so it fully bites a single/few-IP scraper; a widely distributed crawl needs the noindex lever (and the render-cost work) to do the heavy lifting.
- Scoped to the **pages** only. The backing `/api/.../docs` and `/api/.../diff` endpoints remain directly reachable without this limit (`isAPIRoute` routes them to `handleAPIRequest`, which has no guard) — capping the pages caps the SSR-driven renders, but a direct-API crawl is a separate vector left for follow-up.
