### PR TITLE
feat(api): add package version visibility endpoint

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -901,7 +901,7 @@ pub async fn get_version_visibility_handler(
     .ok_or(ApiError::PackageNotFound)?;
 
   let task = db
-    .get_publishing_task_for_version(&scope, &package, &version)
+    .get_publishing_task_for_version_optional(&scope, &package, &version)
     .await?;
   let db_version = db
     .get_package_version(&scope, &package, &version)
@@ -930,7 +930,7 @@ pub async fn get_version_visibility_handler(
       let package_metadata =
         serde_json::from_slice::<PackageMetadata>(&package_metadata_bytes)?;
       let has_version = package_metadata.versions.contains_key(&version);
-      (true, Some(package_metadata.latest), has_version)
+      (true, package_metadata.latest, has_version)
     } else {
       (false, None, false)
     };
@@ -4799,7 +4799,7 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
 
   #[tokio::test]
   async fn package_version_visibility() {
-    let t = TestSetup::new().await;
+    let mut t = TestSetup::new().await;
 
     let mut resp = t
       .http()

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -106,6 +106,7 @@ use super::ApiPackageScore;
 use super::ApiPackageVersion;
 use super::ApiPackageVersionDocs;
 use super::ApiPackageVersionSource;
+use super::ApiPackageVersionVisibility;
 use super::ApiPackageVersionWithUser;
 use super::ApiProvenanceStatementRequest;
 use super::ApiPublishingTask;
@@ -168,6 +169,10 @@ pub fn package_router() -> Router<Body, ApiError> {
         CacheDuration::THIRTY_DAYS,
         util::json(get_version_handler),
       ),
+    )
+    .get(
+      "/:package/versions/:version/visibility",
+      util::json(get_version_visibility_handler),
     )
     .post(
       "/:package/versions/:version",
@@ -870,6 +875,93 @@ pub async fn get_version_handler(
   let version = maybe_version.ok_or(ApiError::PackageVersionNotFound)?;
 
   Ok(ApiPackageVersion::from(version))
+}
+
+#[instrument(
+  name = "GET /api/scopes/:scope/packages/:package/versions/:version/visibility",
+  skip(req),
+  fields(scope, package, version)
+)]
+pub async fn get_version_visibility_handler(
+  req: Request<Body>,
+) -> ApiResult<ApiPackageVersionVisibility> {
+  let scope = req.param_scope()?;
+  let package = req.param_package()?;
+  let version = req.param_version()?;
+  Span::current().record("scope", field::display(&scope));
+  Span::current().record("package", field::display(&package));
+  Span::current().record("version", field::display(&version));
+
+  let db = req.data::<Database>().unwrap();
+  let buckets = req.data::<Buckets>().unwrap();
+
+  let _ = db
+    .get_package(&scope, &package)
+    .await?
+    .ok_or(ApiError::PackageNotFound)?;
+
+  let task = db
+    .get_publishing_task_for_version(&scope, &package, &version)
+    .await?;
+  let db_version = db
+    .get_package_version(&scope, &package, &version)
+    .await?
+    .is_some();
+
+  let version_metadata_path =
+    crate::s3_paths::version_metadata(&scope, &package, &version);
+  let package_metadata_path =
+    crate::s3_paths::package_metadata(&scope, &package);
+  let npm_manifest_path =
+    crate::s3_paths::npm_version_manifest_path(&scope, &package);
+
+  let version_metadata = buckets
+    .modules_bucket
+    .download(version_metadata_path.into())
+    .await?
+    .is_some();
+
+  let package_metadata_bytes = buckets
+    .modules_bucket
+    .download(package_metadata_path.into())
+    .await?;
+  let (package_metadata, package_metadata_latest, package_metadata_has_version) =
+    if let Some(package_metadata_bytes) = package_metadata_bytes {
+      let package_metadata =
+        serde_json::from_slice::<PackageMetadata>(&package_metadata_bytes)?;
+      let has_version = package_metadata.versions.contains_key(&version);
+      (true, Some(package_metadata.latest), has_version)
+    } else {
+      (false, None, false)
+    };
+
+  let npm_manifest_bytes = buckets
+    .npm_bucket
+    .download(npm_manifest_path.into())
+    .await?;
+  let (npm_manifest, npm_manifest_has_version) =
+    if let Some(npm_manifest_bytes) = npm_manifest_bytes {
+      let npm_manifest =
+        serde_json::from_slice::<serde_json::Value>(&npm_manifest_bytes)?;
+      let has_version = npm_manifest
+        .get("versions")
+        .and_then(|versions| versions.as_object())
+        .is_some_and(|versions| versions.contains_key(&version.to_string()));
+      (true, has_version)
+    } else {
+      (false, false)
+    };
+
+  Ok(ApiPackageVersionVisibility {
+    task: task.map(|(task, _)| task.status.into()),
+    db_version,
+    version_metadata,
+    package_metadata,
+    package_metadata_latest,
+    package_metadata_has_version,
+    npm_manifest,
+    npm_manifest_has_version,
+  })
 }
 
 #[instrument(
@@ -2737,6 +2829,8 @@ mod test {
   use crate::api::ApiPackageVersion;
   use crate::api::ApiPackageVersionDocs;
   use crate::api::ApiPackageVersionSource;
+  use crate::api::ApiPackageVersionVisibility;
+  use crate::api::ApiPublishingTaskStatus;
   use crate::api::ApiSource;
   use crate::api::ApiSourceDirEntry;
   use crate::api::ApiSourceDirEntryKind;
@@ -4701,6 +4795,44 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
       .unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].0.id, task2.id);
+  }
+
+  #[tokio::test]
+  async fn package_version_visibility() {
+    let t = TestSetup::new().await;
+
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/1.2.3/visibility")
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "packageNotFound")
+      .await;
+
+    let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{task:?}");
+
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/1.2.3/visibility")
+      .call()
+      .await
+      .unwrap();
+    let visibility = resp.expect_ok::<ApiPackageVersionVisibility>().await;
+
+    assert_eq!(visibility.task, Some(ApiPublishingTaskStatus::Success));
+    assert!(visibility.db_version);
+    assert!(visibility.version_metadata);
+    assert!(visibility.package_metadata);
+    assert_eq!(
+      visibility.package_metadata_latest,
+      Some(Version::try_from("1.2.3").unwrap())
+    );
+    assert!(visibility.package_metadata_has_version);
+    assert!(visibility.npm_manifest);
+    assert!(visibility.npm_manifest_has_version);
   }
 
   #[tokio::test]

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -632,6 +632,19 @@ pub struct ApiPackageVersion {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiPackageVersionVisibility {
+  pub task: Option<ApiPublishingTaskStatus>,
+  pub db_version: bool,
+  pub version_metadata: bool,
+  pub package_metadata: bool,
+  pub package_metadata_latest: Option<Version>,
+  pub package_metadata_has_version: bool,
+  pub npm_manifest: bool,
+  pub npm_manifest_has_version: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 #[allow(clippy::large_enum_variant)]
 pub enum ApiPackageVersionDocs {

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -3182,6 +3182,63 @@ gitlab_id: r.user_gitlab_id,
   }
 
   #[instrument(
+    name = "Database::get_publishing_task_for_version_optional",
+    skip(self),
+    err
+  )]
+  pub async fn get_publishing_task_for_version_optional(
+    &self,
+    scope_name: &ScopeName,
+    package_name: &PackageName,
+    version: &Version,
+  ) -> Result<Option<(PublishingTask, Option<UserPublic>)>> {
+    query_concat!(
+      "SELECT
+        ", PUBLISHING_TASK_SELECT_JOINED, ",
+        ", USER_PUBLIC_SELECT_JOINED_OPTIONAL, "
+      FROM publishing_tasks
+      LEFT JOIN users on publishing_tasks.user_id = users.id
+      JOIN packages ON publishing_tasks.package_scope = packages.scope AND publishing_tasks.package_name = packages.name
+      WHERE publishing_tasks.package_scope = $1 AND publishing_tasks.package_name = $2 AND publishing_tasks.package_version = $3 AND publishing_tasks.created_at >= packages.created_at
+      ORDER BY publishing_tasks.created_at DESC
+      LIMIT 1";
+      scope_name as _,
+      package_name as _,
+      version as _,
+    )
+      .map(|r| {
+        let task = PublishingTask {
+          id: r.task_id,
+          status: r.task_status,
+          error: r.task_error,
+          package_scope: r.task_package_scope,
+          package_name: r.task_package_name,
+          package_version: r.task_package_version,
+          config_file: r.task_config_file,
+          user_id: r.task_user_id,
+          created_at: r.task_created_at,
+          updated_at: r.task_updated_at,
+        };
+
+        let user = task.user_id.map(|_| {
+          UserPublic {
+            id: r.user_id.unwrap(),
+            name: r.user_name.unwrap(),
+            avatar_url: r.user_avatar_url.unwrap(),
+            github_id: r.user_github_id,
+            gitlab_id: r.user_gitlab_id,
+            updated_at: r.user_updated_at.unwrap(),
+            created_at: r.user_created_at.unwrap(),
+          }
+        });
+
+        (task, user)
+      })
+      .fetch_optional(&self.pool)
+      .await
+  }
+
+  #[instrument(
     name = "Database::update_publishing_task_status",
     skip(self),
     err


### PR DESCRIPTION
## Summary

Adds a package-version visibility endpoint for debugging publish completion across the registry's separate consistency layers.

New endpoint:

```text
GET /api/scopes/:scope/packages/:package/versions/:version/visibility
```

The response reports whether the requested version is visible in:

- the publishing task state
- the database package version row
- the public version metadata object (`@scope/name/version_meta.json`)
- the public package metadata object (`@scope/name/meta.json`), including `latest` and whether the version is present
- the npm compatibility manifest, including whether the version is present

## Why

A publish can be partially visible while the CLI or downstream automation is still waiting. For example, `version_meta.json` can exist while package-level `meta.json`/`latest` or npm metadata are not yet updated. This endpoint gives clients and operators a stable way to identify which layer is lagging instead of treating publish as a black box.

## Verification

- `cargo fmt --check` passed.
- Added `api::package::test::package_version_visibility` covering:
  - missing package returns `packageNotFound`
  - successful publish reports all visibility layers as present
  - package metadata latest equals the published version

I attempted to run the targeted Rust test locally on Windows, but the repository currently does not build cleanly in this environment because the unconditional `tikv-jemallocator` dependency fails under `x86_64-pc-windows-msvc` native build setup. The Linux CI should exercise the Rust test normally.