### PR TITLE
fix: auto-fail stranded processing tasks on new publish

### DIFF
--- a/api/.sqlx/query-2bfcf9b00a00dcb339e78971a2ec1fdbaa3c8f23f639e2f9fc246526a799c63a.json
+++ b/api/.sqlx/query-2bfcf9b00a00dcb339e78971a2ec1fdbaa3c8f23f639e2f9fc246526a799c63a.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE publishing_tasks\n       SET updated_at = now() - ($1::bigint * interval '1 second')\n       WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2bfcf9b00a00dcb339e78971a2ec1fdbaa3c8f23f639e2f9fc246526a799c63a"
+}

--- a/api/.sqlx/query-a697c10a8e2aac6caab5130d5e382b22a79182b5ee824d714d468e23e0977eff.json
+++ b/api/.sqlx/query-a697c10a8e2aac6caab5130d5e382b22a79182b5ee824d714d468e23e0977eff.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE publishing_tasks\n         SET status = $1, error = $2\n         WHERE id = $3 AND status = $4",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "task_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "processing",
+                "processed",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        },
+        "Jsonb",
+        "Uuid",
+        {
+          "Custom": {
+            "name": "task_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "processing",
+                "processed",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a697c10a8e2aac6caab5130d5e382b22a79182b5ee824d714d468e23e0977eff"
+}

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -6,6 +6,7 @@ use crate::ids::ScopeDescription;
 use crate::ids::ScopeName;
 use crate::ids::Version;
 use chrono::DateTime;
+use chrono::Duration;
 use chrono::Utc;
 use registry_api_macros::query_concat;
 use registry_api_macros::query_concat_as;
@@ -2852,8 +2853,38 @@ gitlab_id: r.user_gitlab_id,
 
       .fetch_optional(&mut *tx)
       .await?;
-    if let Some(already_processing) = already_processing {
-      return Ok(CreatePublishingTaskResult::Exists(already_processing));
+    if let Some((existing_task, existing_user)) = already_processing {
+      let stale_threshold = Utc::now()
+        - Duration::seconds(crate::tasks::STALE_PUBLISHING_TASK_SECS);
+      let is_stale_processing = existing_task.status
+        == PublishingTaskStatus::Processing
+        && existing_task.updated_at < stale_threshold;
+
+      if !is_stale_processing {
+        return Ok(CreatePublishingTaskResult::Exists((
+          existing_task,
+          existing_user,
+        )));
+      }
+
+      // Failing a stranded `processing` task is safe: its version row never
+      // committed (the finalize transaction is atomic). `processed` tasks
+      // have committed data and are left for the requeue reaper.
+      let stale_error = PublishingTaskError {
+        code: "stale".to_string(),
+        message: "task stranded in processing".to_string(),
+      };
+      sqlx::query!(
+        "UPDATE publishing_tasks
+         SET status = $1, error = $2
+         WHERE id = $3 AND status = $4",
+        PublishingTaskStatus::Failure as _,
+        stale_error as _,
+        existing_task.id,
+        PublishingTaskStatus::Processing as _,
+      )
+      .execute(&mut *tx)
+      .await?;
     }
 
     let task = query_concat!(
@@ -2959,6 +2990,24 @@ gitlab_id: r.user_gitlab_id,
     tx.commit().await?;
 
     Ok(CreatePublishingTaskResult::Created(task))
+  }
+
+  #[cfg(test)]
+  pub async fn backdate_publishing_task_updated_at(
+    &self,
+    id: Uuid,
+    secs_ago: i64,
+  ) -> Result<()> {
+    sqlx::query!(
+      "UPDATE publishing_tasks
+       SET updated_at = now() - ($1::bigint * interval '1 second')
+       WHERE id = $2",
+      secs_ago,
+      id,
+    )
+    .execute(&self.pool)
+    .await?;
+    Ok(())
   }
 
   #[instrument(name = "Database::get_publishing_task", skip(self), err)]

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -53,6 +53,15 @@ macro_rules! sort_by {
   (@expand $key:expr) => { $key };
 }
 
+/// How long a publishing task may stay in a non-terminal state
+/// (`processing`/`processed`) before it is considered stranded. The publish
+/// queue normally finishes a task in seconds, and Cloud Run caps a single
+/// request well under this, so a task older than this is not actively being
+/// processed. Stranded tasks are re-driven by the reaper in `tasks.rs`, and
+/// `create_publishing_task` fails a stranded `processing` task inline when a
+/// new publish for the same version arrives.
+pub const STALE_PUBLISHING_TASK_SECS: i64 = 30 * 60;
+
 #[derive(Debug, Clone)]
 pub struct Database {
   pool: sqlx::PgPool,
@@ -2854,8 +2863,8 @@ gitlab_id: r.user_gitlab_id,
       .fetch_optional(&mut *tx)
       .await?;
     if let Some((existing_task, existing_user)) = already_processing {
-      let stale_threshold = Utc::now()
-        - Duration::seconds(crate::tasks::STALE_PUBLISHING_TASK_SECS);
+      let stale_threshold =
+        Utc::now() - Duration::seconds(STALE_PUBLISHING_TASK_SECS);
       let is_stale_processing = existing_task.status
         == PublishingTaskStatus::Processing
         && existing_task.updated_at < stale_threshold;
@@ -2874,7 +2883,7 @@ gitlab_id: r.user_gitlab_id,
         code: "stale".to_string(),
         message: "task stranded in processing".to_string(),
       };
-      sqlx::query!(
+      let res = sqlx::query!(
         "UPDATE publishing_tasks
          SET status = $1, error = $2
          WHERE id = $3 AND status = $4",
@@ -2885,6 +2894,15 @@ gitlab_id: r.user_gitlab_id,
       )
       .execute(&mut *tx)
       .await?;
+      // Lost a race: the reaper requeued the task (or a worker advanced it)
+      // between our read and this update. The task is active again, so hand
+      // it back instead of creating a duplicate.
+      if res.rows_affected() == 0 {
+        return Ok(CreatePublishingTaskResult::Exists((
+          existing_task,
+          existing_user,
+        )));
+      }
     }
 
     let task = query_concat!(

--- a/api/src/db/tests.rs
+++ b/api/src/db/tests.rs
@@ -309,7 +309,9 @@ async fn create_publishing_task_auto_fails_stranded_processing() {
     .await
     .unwrap();
   let CreatePublishingTaskResult::Created((new_task, _)) = res else {
-    panic!("stranded processing task should be auto-failed and new task created")
+    panic!(
+      "stranded processing task should be auto-failed and new task created"
+    )
   };
   assert_ne!(new_task.id, stranded_id);
   assert_eq!(new_task.status, PublishingTaskStatus::Pending);
@@ -334,7 +336,9 @@ async fn create_publishing_task_auto_fails_stranded_processing() {
     .await
     .unwrap();
   let CreatePublishingTaskResult::Exists((reused, _)) = res else {
-    panic!("stranded processed task is the reaper's responsibility, not this path")
+    panic!(
+      "stranded processed task is the reaper's responsibility, not this path"
+    )
   };
   assert_eq!(reused.id, processed_id);
   assert_eq!(reused.status, PublishingTaskStatus::Processed);

--- a/api/src/db/tests.rs
+++ b/api/src/db/tests.rs
@@ -219,6 +219,128 @@ async fn list_stale_publishing_tasks() {
 }
 
 #[tokio::test]
+async fn create_publishing_task_auto_fails_stranded_processing() {
+  let db = EphemeralDatabase::create().await;
+
+  let user_id = uuid::Uuid::default();
+  let scope_name: ScopeName = "scope".try_into().unwrap();
+  let package_name: PackageName = "package".try_into().unwrap();
+  let config_file: PackagePath = "/jsr.json".try_into().unwrap();
+
+  db.create_scope(
+    &user_id,
+    false,
+    &scope_name,
+    user_id,
+    &ScopeDescription::default(),
+  )
+  .await
+  .unwrap();
+  db.create_package(&scope_name, &package_name).await.unwrap();
+
+  // Helper: create a task on `version_str` and walk it up to `target`.
+  let make_task = async |version_str: &str, target: PublishingTaskStatus| {
+    let version: Version = version_str.try_into().unwrap();
+    let CreatePublishingTaskResult::Created((pt, _)) = db
+      .create_publishing_task(NewPublishingTask {
+        user_id: Some(user_id),
+        package_scope: &scope_name,
+        package_name: &package_name,
+        package_version: &version,
+        config_file: &config_file,
+      })
+      .await
+      .unwrap()
+    else {
+      unreachable!()
+    };
+    let path: &[PublishingTaskStatus] = match target {
+      PublishingTaskStatus::Pending => &[],
+      PublishingTaskStatus::Processing => &[PublishingTaskStatus::Processing],
+      PublishingTaskStatus::Processed => &[
+        PublishingTaskStatus::Processing,
+        PublishingTaskStatus::Processed,
+      ],
+      _ => unreachable!(),
+    };
+    let mut prev = PublishingTaskStatus::Pending;
+    for next in path {
+      db.update_publishing_task_status(None, pt.id, prev, next.clone(), None)
+        .await
+        .unwrap();
+      prev = next.clone();
+    }
+    pt.id
+  };
+
+  // 1. Fresh `processing` task: a duplicate publish gets the existing task back.
+  let fresh_id = make_task("1.0.0", PublishingTaskStatus::Processing).await;
+  let v1: Version = "1.0.0".try_into().unwrap();
+  let res = db
+    .create_publishing_task(NewPublishingTask {
+      user_id: Some(user_id),
+      package_scope: &scope_name,
+      package_name: &package_name,
+      package_version: &v1,
+      config_file: &config_file,
+    })
+    .await
+    .unwrap();
+  let CreatePublishingTaskResult::Exists((reused, _)) = res else {
+    panic!("fresh processing task should return Exists")
+  };
+  assert_eq!(reused.id, fresh_id);
+  assert_eq!(reused.status, PublishingTaskStatus::Processing);
+
+  // 2. Stranded `processing` task (>30 min old): inline auto-fail, new task created.
+  let stranded_id = make_task("2.0.0", PublishingTaskStatus::Processing).await;
+  db.backdate_publishing_task_updated_at(stranded_id, 31 * 60)
+    .await
+    .unwrap();
+  let v2: Version = "2.0.0".try_into().unwrap();
+  let res = db
+    .create_publishing_task(NewPublishingTask {
+      user_id: Some(user_id),
+      package_scope: &scope_name,
+      package_name: &package_name,
+      package_version: &v2,
+      config_file: &config_file,
+    })
+    .await
+    .unwrap();
+  let CreatePublishingTaskResult::Created((new_task, _)) = res else {
+    panic!("stranded processing task should be auto-failed and new task created")
+  };
+  assert_ne!(new_task.id, stranded_id);
+  assert_eq!(new_task.status, PublishingTaskStatus::Pending);
+  let (old, _) = db.get_publishing_task(stranded_id).await.unwrap().unwrap();
+  assert_eq!(old.status, PublishingTaskStatus::Failure);
+  assert_eq!(old.error.unwrap().code, "stale");
+
+  // 3. Stranded `processed` task: still returns Exists (left to the reaper).
+  let processed_id = make_task("3.0.0", PublishingTaskStatus::Processed).await;
+  db.backdate_publishing_task_updated_at(processed_id, 31 * 60)
+    .await
+    .unwrap();
+  let v3: Version = "3.0.0".try_into().unwrap();
+  let res = db
+    .create_publishing_task(NewPublishingTask {
+      user_id: Some(user_id),
+      package_scope: &scope_name,
+      package_name: &package_name,
+      package_version: &v3,
+      config_file: &config_file,
+    })
+    .await
+    .unwrap();
+  let CreatePublishingTaskResult::Exists((reused, _)) = res else {
+    panic!("stranded processed task is the reaper's responsibility, not this path")
+  };
+  assert_eq!(reused.id, processed_id);
+  assert_eq!(reused.status, PublishingTaskStatus::Processed);
+}
+
+#[tokio::test]
 async fn users() {
   let db = EphemeralDatabase::create().await;
 

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -94,7 +94,7 @@ pub fn tasks_router() -> Router<Body, ApiError> {
 /// re-drives it. The publish queue normally finishes a task in seconds, and
 /// Cloud Run caps a single request well under this, so a task older than this
 /// is not actively being processed and is safe to requeue.
-const STALE_PUBLISHING_TASK_SECS: i64 = 30 * 60;
+pub(crate) const STALE_PUBLISHING_TASK_SECS: i64 = 30 * 60;
 
 /// Re-drive publishing tasks that got stranded in a non-terminal state.
 ///

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -33,6 +33,7 @@ use crate::db::Database;
 use crate::db::DownloadKind;
 use crate::db::NewNpmTarball;
 use crate::db::PublishingTaskStatus;
+use crate::db::STALE_PUBLISHING_TASK_SECS;
 use crate::db::VersionDownloadCount;
 use crate::external::cloudflare;
 use crate::external::cloudflare::CachePurge;
@@ -88,13 +89,6 @@ pub fn tasks_router() -> Router<Body, ApiError> {
     .build()
     .unwrap()
 }
-
-/// How long a publishing task may stay in a non-terminal state
-/// (`processing`/`processed`) before the reaper treats it as stranded and
-/// re-drives it. The publish queue normally finishes a task in seconds, and
-/// Cloud Run caps a single request well under this, so a task older than this
-/// is not actively being processed and is safe to requeue.
-pub(crate) const STALE_PUBLISHING_TASK_SECS: i64 = 30 * 60;
 
 /// Re-drive publishing tasks that got stranded in a non-terminal state.
 ///


### PR DESCRIPTION
Closes the gap between worker death and the periodic reaper from #1449. When a new publish arrives for a version whose existing task has been in `processing` past `STALE_PUBLISHING_TASK_SECS`, the task is transitioned to `failure` in the same DB transaction so the new publish proceeds immediately, rather than waiting up to 30 minutes for the next reaper cycle. `processed` tasks remain handled by the reaper, since they have committed data and need requeue rather than fail.

Refs #1448.