### PR TITLE
fix: hung publishes & frozen package metadata from lb cache key/poll caching

### DIFF
--- a/api/src/api/authorization.rs
+++ b/api/src/api/authorization.rs
@@ -32,7 +32,10 @@ pub fn authorization_router() -> Router<Body, ApiError> {
     .post("/", util::json(create_authorization))
     .post("/exchange", util::json(exchange_authorization))
     // Never cache: OAuth authorization details are dynamic and per-flow.
-    .get("/details/:code", util::no_store(util::json(get_authorization)))
+    .get(
+      "/details/:code",
+      util::no_store(util::json(get_authorization)),
+    )
     .post("/approve/:code", util::auth(approve_authorization))
     .post("/deny/:code", util::auth(decline_authorization))
     .build()

--- a/api/src/api/authorization.rs
+++ b/api/src/api/authorization.rs
@@ -31,7 +31,8 @@ pub fn authorization_router() -> Router<Body, ApiError> {
   Router::builder()
     .post("/", util::json(create_authorization))
     .post("/exchange", util::json(exchange_authorization))
-    .get("/details/:code", util::json(get_authorization))
+    // Never cache: OAuth authorization details are dynamic and per-flow.
+    .get("/details/:code", util::no_store(util::json(get_authorization)))
     .post("/approve/:code", util::auth(approve_authorization))
     .post("/deny/:code", util::auth(decline_authorization))
     .build()

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -58,8 +58,10 @@ pub fn api_router() -> Router<Body, ApiError> {
     )
     .get(
       // todo: remove once CLI uses the new endpoint
+      // Never cache: `deno publish` polls this for live status, and a cached
+      // non-terminal status would make it hang until the entry expired.
       "/publish_status/:publishing_task_id",
-      util::json(publishing_task::get_handler),
+      util::no_store(util::json(publishing_task::get_handler)),
     )
     .scope("/tickets", tickets_router())
     .get("/.well-known/openapi", openapi_handler)

--- a/api/src/api/publishing_task.rs
+++ b/api/src/api/publishing_task.rs
@@ -19,7 +19,10 @@ pub fn publishing_task_router() -> Router<Body, ApiError> {
   Router::builder()
     // Never cache: `deno publish` polls this for live status, and a cached
     // non-terminal status would make it hang until the entry expired.
-    .get("/:publishing_task_id", util::no_store(util::json(get_handler)))
+    .get(
+      "/:publishing_task_id",
+      util::no_store(util::json(get_handler)),
+    )
     .build()
     .unwrap()
 }

--- a/api/src/api/publishing_task.rs
+++ b/api/src/api/publishing_task.rs
@@ -17,7 +17,9 @@ use super::ApiPublishingTask;
 
 pub fn publishing_task_router() -> Router<Body, ApiError> {
   Router::builder()
-    .get("/:publishing_task_id", util::json(get_handler))
+    // Never cache: `deno publish` polls this for live status, and a cached
+    // non-terminal status would make it hang until the entry expired.
+    .get("/:publishing_task_id", util::no_store(util::json(get_handler)))
     .build()
     .unwrap()
 }

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -97,6 +97,37 @@ where
     .expect("expected to be able to create response")
 }
 
+/// Wrap a handler so its response is explicitly uncacheable
+/// (`Cache-Control: no-store`).
+///
+/// `json` sets no `Cache-Control`, and the lb caches such GET responses for
+/// anonymous callers. That must not happen for dynamic, not-behind-[`auth`]
+/// endpoints — most importantly the publish-status poll: a cached
+/// `pending`/`processing` status makes `deno publish` hang until the entry
+/// expires even though the task already finished. Stamping `no-store` keeps the
+/// lb (and any downstream cache) from ever storing the response.
+pub fn no_store<H, HF>(
+  handler: H,
+) -> impl Fn(Request<Body>) -> ApiHandlerFuture<Response<Body>>
+where
+  H: Send + Sync + Fn(Request<Body>) -> HF + Send + 'static,
+  HF: Future<Output = ApiResult<Response<Body>>> + Send + 'static,
+{
+  let handler = Arc::new(handler);
+  move |req: Request<Body>| {
+    let handler = handler.clone();
+    async move {
+      let mut res = handler(req).await?;
+      res.headers_mut().insert(
+        header::CACHE_CONTROL,
+        header::HeaderValue::from_static("no-store"),
+      );
+      Ok(res)
+    }
+    .boxed()
+  }
+}
+
 pub fn auth<H, HF>(
   handler: H,
 ) -> impl Fn(Request<Body>) -> ApiHandlerFuture<Response<Body>>

--- a/lb/proxy.ts
+++ b/lb/proxy.ts
@@ -90,6 +90,16 @@ export async function proxyToBackend(
     ? new URL(path + url.search, backend)
     : new URL(path + url.search, url.origin);
 
+  // Cache key is the PUBLIC URL (inbound origin + proxied path), never the
+  // backend origin. CDN purges target the public jsr.io / api.jsr.io URLs (see
+  // `package_api_cache_urls` in the API), so an entry keyed under the Cloud Run
+  // backend host could never be evicted on publish — which froze package
+  // metadata (`latestVersion`/version counts) for the full, now-30-day TTL. The
+  // proxied `path` already matches the purge URLs' path on both hosts, so this
+  // makes the existing purges land. For a service-binding (frontend) backend
+  // this equals `backendRequestUrl`, so frontend caching is unchanged.
+  const cacheKeyUrl = new URL(path + url.search, url.origin).toString();
+
   const headers = new Headers(request.headers);
   if (isUrlBackend) {
     headers.set("Host", new URL(backend).host);
@@ -138,6 +148,7 @@ export async function proxyToBackend(
         redirect: "manual",
       },
       ctx,
+      cacheKeyUrl,
     );
 
     const shared = isIdentityIndependent(response);
@@ -270,13 +281,17 @@ async function cachedFetch(
   restrictToShared: boolean,
   fetcher: (req: Request) => Promise<Response>,
   input: RequestInfo | URL,
-  init?: RequestInit,
-  ctx?: ExecutionCtx,
+  init: RequestInit | undefined,
+  ctx: ExecutionCtx | undefined,
+  // The PUBLIC URL to key the cache under (see proxyToBackend) — kept separate
+  // from the backend fetch URL so CDN purges, which target public URLs, can
+  // evict these entries.
+  cacheKeyUrl: string,
 ): Promise<Response> {
   const req = new Request(input, init);
+  const cacheKey = new Request(cacheKeyUrl, { method: "GET" });
 
   if (allowCache) {
-    const cacheKey = new Request(req.url, { method: "GET" });
     const cached = await caches.default?.match(cacheKey);
     if (cached && (!restrictToShared || isIdentityIndependent(cached))) {
       if (req.method === "HEAD") {
@@ -291,27 +306,27 @@ async function cachedFetch(
 
   const res = await fetcher(req);
 
-  // Cache 200s and (negatively) 404s. 200s keep the prior behaviour: cached
-  // unless explicitly `private`/`no-store` (even with no `Cache-Control`).
-  // 404s are only cached when the origin opted in with an explicit cacheable
-  // directive — the API stamps a short `public` TTL on 404s from cached routes
-  // (docs/diff for a missing symbol/version etc.); without storing them every
-  // repeat miss falls through to the origin. A 404 with no `Cache-Control`
-  // (uncached routes) is never stored.
+  // Only cache responses the origin explicitly marked cacheable: a `max-age` or
+  // `s-maxage` directive, and never `private`/`no-store`. This applies to both
+  // 200s and (negatively-cached) 404s. Previously an unmarked 200 was cached by
+  // default, which silently cached dynamic endpoints that forgot to opt out —
+  // e.g. the publish-status poll (`util::json`, no `Cache-Control`), pinning a
+  // stale "pending"/"processing" status so `deno publish` hung until the entry
+  // expired. Endpoints meant to be cached go through the API's `cache*`
+  // wrappers, which always set an explicit `public, max-age=…, s-maxage=…`.
   const cacheControl = res.headers.get("Cache-Control") ?? "";
   const explicitlyUncacheable = cacheControl.includes("private") ||
     cacheControl.includes("no-store");
-  const cacheable = res.ok
-    ? !explicitlyUncacheable
-    : res.status === 404 && !explicitlyUncacheable &&
-      (cacheControl.includes("max-age") || cacheControl.includes("s-maxage"));
+  const hasCacheableDirective = cacheControl.includes("max-age") ||
+    cacheControl.includes("s-maxage");
+  const cacheable = (res.ok || res.status === 404) &&
+    !explicitlyUncacheable && hasCacheableDirective;
   // An authenticated request may only write an identity-independent response —
   // a viewer-specific authed response must never land in the shared cache.
   const writable = cacheable &&
     (!restrictToShared || isIdentityIndependent(res));
   const cache = caches.default;
   if (cache && allowCache && req.method === "GET" && writable) {
-    const cacheKey = new Request(req.url, { method: "GET" });
     // `waitUntil` (or await in tests) so the write isn't dropped when the
     // invocation ends — the cause of the lb caching nothing in production.
     await persistCacheWrite(ctx, cache, cacheKey, res.clone());

--- a/lb/proxy_test.ts
+++ b/lb/proxy_test.ts
@@ -306,6 +306,42 @@ Deno.test("proxyToBackend caches anonymous GET with URL-only key", async () => {
   }
 });
 
+Deno.test("proxyToBackend caches a path-rewritten API request under the public URL package_api_cache_urls purges", async () => {
+  // api.jsr.io serves the API without the `/api` prefix; the lb re-adds it via
+  // pathRewrite before hitting the backend. The cache key must be the PUBLIC,
+  // rewritten URL — byte-for-byte the URL the API purges on publish via
+  // `package_api_cache_urls` (its api.jsr.io form is
+  // `https://api.jsr.io/api/scopes/<scope>/packages/<pkg>`). If the two diverge,
+  // publish purges silently miss and package metadata freezes (#1453). Uses the
+  // same std/fs example as that fn's Rust test so both ends stay pinned.
+  const cache = createFakeCache();
+  (globalThis as any).caches = { default: cache };
+
+  const restore = setupFetchStub(
+    new Response('{"latestVersion":"1.0.0"}', {
+      status: 200,
+      headers: { "Cache-Control": "public, max-age=30, s-maxage=2592000" },
+    }),
+  );
+
+  try {
+    // Inbound to api.jsr.io carries no `/api` prefix; the lb adds it.
+    const request = new Request("https://api.jsr.io/scopes/std/packages/fs", {
+      method: "GET",
+    });
+    await proxyToBackend(request, BACKEND_URL, (path) => `/api${path}`);
+
+    assertEquals(cache.putCalls.length, 1);
+    assertEquals(
+      cache.putCalls[0],
+      "https://api.jsr.io/api/scopes/std/packages/fs",
+    );
+  } finally {
+    restore();
+    (globalThis as any).caches = { default: undefined };
+  }
+});
+
 Deno.test("proxyToBackend does not cache a 200 without a cacheable directive", async () => {
   // A 200 with no Cache-Control must not be cached: dynamic endpoints like the
   // publish-status poll (`util::json`, no Cache-Control) were being cached by

--- a/lb/proxy_test.ts
+++ b/lb/proxy_test.ts
@@ -295,10 +295,37 @@ Deno.test("proxyToBackend caches anonymous GET with URL-only key", async () => {
 
     assertEquals(response.status, 200);
     assertEquals(cache.putCalls.length, 1);
-    // Cache key should be the backend URL, not include client headers
-    assertEquals(cache.putCalls[0], `${BACKEND_URL}/api/packages`);
+    // Cache key is the PUBLIC URL, not the backend URL — otherwise CDN purges
+    // (which target public URLs) could never evict it. See proxyToBackend.
+    assertEquals(cache.putCalls[0], "https://jsr.io/api/packages");
     // Vary is set on all responses so browsers re-fetch when auth changes
     assertEquals(response.headers.get("Vary"), "Cookie, Authorization");
+  } finally {
+    restore();
+    (globalThis as any).caches = { default: undefined };
+  }
+});
+
+Deno.test("proxyToBackend does not cache a 200 without a cacheable directive", async () => {
+  // A 200 with no Cache-Control must not be cached: dynamic endpoints like the
+  // publish-status poll (`util::json`, no Cache-Control) were being cached by
+  // default, pinning a stale status so `deno publish` hung until the entry
+  // expired. Only responses the origin explicitly marked cacheable are stored.
+  const cache = createFakeCache();
+  (globalThis as any).caches = { default: cache };
+
+  const restore = setupFetchStub(
+    new Response('{"status":"processing"}', { status: 200 }),
+  );
+
+  try {
+    const request = new Request("https://jsr.io/api/publishing_tasks/abc", {
+      method: "GET",
+    });
+    const response = await proxyToBackend(request, BACKEND_URL);
+
+    assertEquals(response.status, 200);
+    assertEquals(cache.putCalls.length, 0);
   } finally {
     restore();
     (globalThis as any).caches = { default: undefined };


### PR DESCRIPTION
This PR together with #1449 fixes the hang and stale/invisible metadata symptoms described in #1448