### PR TITLE
fix: cap resolver staleness at s-maxage by dropping manifest SWR

### DIFF
--- a/api/src/s3.rs
+++ b/api/src/s3.rs
@@ -31,11 +31,14 @@ pub const CACHE_CONTROL_IMMUTABLE: &str = "public, max-age=31536000, immutable";
 /// re-fetches the regenerated `meta.json`; if the explicit purge call fails,
 /// `s-maxage` is the longest a just-published version can stay invisible to
 /// the resolver while the version page and immutable `_meta.json` already
-/// exist. `stale-while-revalidate` then lets the edge keep serving instantly
-/// while it refreshes in the background, so a short `s-maxage` does not add
-/// latency to resolver requests. `max-age` caps client-side staleness.
-pub const CACHE_CONTROL_MANIFEST: &str =
-  "public, max-age=60, s-maxage=60, stale-while-revalidate=86400";
+/// exist. We deliberately omit `stale-while-revalidate`: the lb serves a
+/// cached entry on a hit without re-fetching it (see `proxyToR2`), so SWR
+/// would only let the edge keep serving the *stale* manifest without ever
+/// producing fresh content until the entry fully expires — pure added
+/// staleness with no upside. Without it, a request past `s-maxage` is an
+/// unambiguous miss that forces an R2 re-fetch, capping resolver staleness at
+/// `s-maxage`. `max-age` caps client-side staleness.
+pub const CACHE_CONTROL_MANIFEST: &str = "public, max-age=60, s-maxage=60";
 
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
## What

Drops `stale-while-revalidate=86400` from `CACHE_CONTROL_MANIFEST` (the cache-control for package and npm version `meta.json` manifests):

```
- public, max-age=60, s-maxage=60, stale-while-revalidate=86400
+ public, max-age=60, s-maxage=60
```

## Why

After a publish, a new version only becomes visible to Deno's resolver once the edge re-fetches the regenerated `meta.json`. We explicitly purge Cloudflare on publish, but that purge is best-effort, so the cache-control is the durability net.

The SWR window was that net's weak point: it let an edge keep serving a **stale** manifest for up to 24h. And critically, SWR bought us nothing here — the lb serves a cached entry on a hit *without re-fetching* (see `proxyToR2`), so the background "revalidation" SWR implies never actually happens; it only extends the stale window.

Without SWR, a request past `s-maxage` is an unambiguous miss that forces an R2 re-fetch. This caps worst-case post-publish resolver staleness at **`s-maxage` (~60s)** instead of **up to 24h**.

## Trade-off to review

This slightly increases manifest re-fetches from R2 (the edge can no longer lean on a stale copy past `s-maxage`), but `s-maxage=60` still bounds that to roughly one R2 fetch per package per minute per PoP. Worth a sanity check.

## Not in scope

Eliminating the remaining ~60s floor (`s-maxage`) requires a purge-key redesign — the manifest is keyed under the synthetic `bucket-cache.jsr.internal` host (#1440), which isn't zone-purgeable by URL — and is intentionally left out of this change.