### PR TITLE
fix(search): rank scope above name and normalize scope:@ filter

### DIFF
--- a/frontend/islands/GlobalSearch.tsx
+++ b/frontend/islands/GlobalSearch.tsx
@@ -546,7 +546,13 @@ function tokenizeFilter(search: string): Token[] {
 
   for (const part of search.split(" ")) {
     if (part.startsWith("scope:") && part.slice(6).length > 0) {
-      tokens.push({ kind: "scope", value: part.slice(6), raw: part });
+      // Scopes are stored without the leading "@", so `scope:@std` and
+      // `scope:std` should filter the same. Keep `raw` as typed for display.
+      tokens.push({
+        kind: "scope",
+        value: part.slice(6).replace(/^@/, ""),
+        raw: part,
+      });
       continue;
     } else if (part.startsWith("runtime:")) {
       const runtime = part.slice(8);

--- a/terraform/algolia.tf
+++ b/terraform/algolia.tf
@@ -18,7 +18,9 @@ resource "algolia_index" "packages" {
   name = local.algolia_packages_index
 
   attributes_config {
-    searchable_attributes = ["name", "scope", "description"]
+    # Order is priority: scope ranks above name so e.g. "std" surfaces @std/*
+    # packages ahead of packages that merely contain "std" in their name.
+    searchable_attributes = ["scope", "name", "description"]
     attributes_for_faceting = [
       "filterOnly(scope)",
       "filterOnly(runtimeCompat.browser)",


### PR DESCRIPTION
Follow-up tweaks to the Algolia search migration (#1461):

- Ranking: searchable_attributes lists scope before name so a query like `std` surfaces @std/* packages ahead of packages that merely contain "std" in their name/description (restores the old Orama ordering where scope outranked name).
- Filter parsing: strip a leading @ from the scope: filter value so `scope:@std` and `scope:std` behave identically.

The ranking change is an index setting, so it takes effect on terraform apply (or can be set in the Algolia dashboard immediately).