### PR TITLE
feat: disable diff pages and serve docs only for the latest version

### DIFF
--- a/api/.sqlx/query-3019429dc85e4e9cf860c11760074cea191570f860c9b7da1caf4d1e7c001384.json
+++ b/api/.sqlx/query-3019429dc85e4e9cf860c11760074cea191570f860c9b7da1caf4d1e7c001384.json
@@ -1,0 +1,95 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scope as \"scope: ScopeName\", name as \"name: PackageName\", version as \"version: Version\", user_id, readme_path as \"readme_path: PackagePath\", exports as \"exports: ExportsMap\", is_yanked, uses_npm, meta as \"meta: PackageVersionMeta\", updated_at, created_at, rekor_log_id, license\n      FROM package_versions\n      WHERE scope = $1 AND name = $2 AND is_yanked = false\n      ORDER BY (version NOT LIKE '%-%') DESC, version DESC\n      LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scope: ScopeName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name: PackageName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "readme_path: PackagePath",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "exports: ExportsMap",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_yanked",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "uses_npm",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "meta: PackageVersionMeta",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "rekor_log_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "license",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "3019429dc85e4e9cf860c11760074cea191570f860c9b7da1caf4d1e7c001384"
+}

--- a/api/src/api/errors.rs
+++ b/api/src/api/errors.rs
@@ -47,6 +47,14 @@ errors!(
     status: NOT_FOUND,
     "Diffs do not have an index.",
   },
+  DiffDisabled {
+    status: NOT_FOUND,
+    "The diff view is currently disabled.",
+  },
+  DocsOnlyForLatestVersion {
+    status: NOT_FOUND,
+    "Documentation is only available for the latest version of a package.",
+  },
   EntrypointOrSymbolNotFound {
     status: NOT_FOUND,
     "The requested entrypoint or symbol was not found.",

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1385,17 +1385,25 @@ pub async fn get_docs_handler(
     .await?
     .ok_or(ApiError::PackageNotFound)?;
 
-  let maybe_version = match &version_or_latest {
+  // Docs are only served for the latest version of a package. A specific
+  // version is accepted only if it is the current latest unyanked version; any
+  // other version is rejected so callers fall back to the latest version.
+  let version = match &version_or_latest {
     VersionOrLatest::Version(version) => {
-      db.get_package_version(&scope, &package_name, version)
+      let latest = db
+        .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
         .await?
+        .ok_or(ApiError::PackageVersionNotFound)?;
+      if latest.version != *version {
+        return Err(ApiError::DocsOnlyForLatestVersion);
+      }
+      latest
     }
-    VersionOrLatest::Latest => {
-      db.get_latest_unyanked_version_for_package(&scope, &package_name)
-        .await?
-    }
+    VersionOrLatest::Latest => db
+      .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
+      .await?
+      .ok_or(ApiError::PackageVersionNotFound)?,
   };
-  let version = maybe_version.ok_or(ApiError::PackageVersionNotFound)?;
 
   let has_readme = !all_symbols
     && entrypoint.is_none()
@@ -1517,17 +1525,25 @@ pub async fn get_docs_search_handler(
     .await?
     .ok_or(ApiError::PackageNotFound)?;
 
-  let maybe_version = match &version_or_latest {
+  // Docs are only served for the latest version of a package. A specific
+  // version is accepted only if it is the current latest unyanked version; any
+  // other version is rejected so callers fall back to the latest version.
+  let version = match &version_or_latest {
     VersionOrLatest::Version(version) => {
-      db.get_package_version(&scope, &package_name, version)
+      let latest = db
+        .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
         .await?
+        .ok_or(ApiError::PackageVersionNotFound)?;
+      if latest.version != *version {
+        return Err(ApiError::DocsOnlyForLatestVersion);
+      }
+      latest
     }
-    VersionOrLatest::Latest => {
-      db.get_latest_unyanked_version_for_package(&scope, &package_name)
-        .await?
-    }
+    VersionOrLatest::Latest => db
+      .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
+      .await?
+      .ok_or(ApiError::PackageVersionNotFound)?,
   };
-  let version = maybe_version.ok_or(ApiError::PackageVersionNotFound)?;
 
   let registry_url = req.data::<RegistryUrl>().unwrap().0.to_string();
   let generate_ctx_cache =
@@ -1583,17 +1599,25 @@ pub async fn get_docs_search_structured_handler(
     .await?
     .ok_or(ApiError::PackageNotFound)?;
 
-  let maybe_version = match &version_or_latest {
+  // Docs are only served for the latest version of a package. A specific
+  // version is accepted only if it is the current latest unyanked version; any
+  // other version is rejected so callers fall back to the latest version.
+  let version = match &version_or_latest {
     VersionOrLatest::Version(version) => {
-      db.get_package_version(&scope, &package_name, version)
+      let latest = db
+        .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
         .await?
+        .ok_or(ApiError::PackageVersionNotFound)?;
+      if latest.version != *version {
+        return Err(ApiError::DocsOnlyForLatestVersion);
+      }
+      latest
     }
-    VersionOrLatest::Latest => {
-      db.get_latest_unyanked_version_for_package(&scope, &package_name)
-        .await?
-    }
+    VersionOrLatest::Latest => db
+      .get_latest_unyanked_version_for_package_for_docs(&scope, &package_name)
+      .await?
+      .ok_or(ApiError::PackageVersionNotFound)?,
   };
-  let version = maybe_version.ok_or(ApiError::PackageVersionNotFound)?;
 
   let registry_url = req.data::<RegistryUrl>().unwrap().0.to_string();
   let generate_ctx_cache =
@@ -1816,6 +1840,12 @@ pub async fn get_source_handler(
 pub async fn get_diff_handler(
   req: Request<Body>,
 ) -> ApiResult<ApiPackageVersionDocs> {
+  // The diff view is disabled. Flip to `true` to re-enable it.
+  const DIFF_ENABLED: bool = false;
+  if !DIFF_ENABLED {
+    return Err(ApiError::DiffDisabled);
+  }
+
   let scope = req.param_scope()?;
   let package_name = req.param_package()?;
   Span::current().record("scope", field::display(&scope));
@@ -4071,6 +4101,109 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
       .unwrap();
     resp
       .expect_err_code(StatusCode::NOT_FOUND, "entrypointOrSymbolNotFound")
+      .await;
+
+    // the "latest" alias resolves to the latest version
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/latest/docs")
+      .call()
+      .await
+      .unwrap();
+    let docs: ApiPackageVersionDocs = resp.expect_ok().await;
+    match docs {
+      ApiPackageVersionDocs::Content { version, .. } => {
+        assert_eq!(version.version, task.package_version);
+      }
+      ApiPackageVersionDocs::Redirect { .. } => panic!(),
+    }
+
+    // docs are only served for the latest version; any other version is
+    // rejected so callers fall back to the latest version
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/1.0.0/docs")
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "docsOnlyForLatestVersion")
+      .await;
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/1.0.0/docs/search")
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "docsOnlyForLatestVersion")
+      .await;
+    let mut resp = t
+      .http()
+      .get(
+        "/api/scopes/scope/packages/foo/versions/1.0.0/docs/search_structured",
+      )
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "docsOnlyForLatestVersion")
+      .await;
+
+    // the diff view is disabled
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/diff/1.0.0/1.2.3?all_symbols")
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "diffDisabled")
+      .await;
+  }
+
+  #[tokio::test]
+  async fn test_package_docs_prerelease_only() {
+    let mut t = TestSetup::new().await;
+
+    // publish a package that only has a prerelease version (no stable release)
+    let package_name = PackageName::try_from("foo").unwrap();
+    let version = Version::try_from("1.2.3-alpha.1").unwrap();
+    let task = crate::publish::tests::process_tarball_setup2(
+      &t,
+      create_mock_tarball("ok_prerelease"),
+      &package_name,
+      &version,
+      false,
+    )
+    .await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
+
+    // with no stable release, docs fall back to the latest prerelease for both
+    // the "latest" alias and the explicit prerelease version
+    for path in [
+      "/api/scopes/scope/packages/foo/versions/latest/docs",
+      "/api/scopes/scope/packages/foo/versions/1.2.3-alpha.1/docs",
+    ] {
+      let mut resp = t.http().get(path).call().await.unwrap();
+      let docs: ApiPackageVersionDocs = resp.expect_ok().await;
+      match docs {
+        ApiPackageVersionDocs::Content { version, .. } => {
+          assert_eq!(version.version, task.package_version);
+        }
+        ApiPackageVersionDocs::Redirect { .. } => panic!(),
+      }
+    }
+
+    // a version that is not the latest prerelease is still rejected
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/1.0.0/docs")
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::NOT_FOUND, "docsOnlyForLatestVersion")
       .await;
   }
 

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -1850,6 +1850,36 @@ gitlab_id: r.user_gitlab_id,
       .await
   }
 
+  /// Resolves the version whose docs are served for a package. This is the
+  /// latest unyanked stable version, or - for packages that only have
+  /// prerelease versions - the latest unyanked prerelease version. Ordering
+  /// stable releases ahead of prereleases keeps the result identical to
+  /// `get_latest_unyanked_version_for_package` whenever a stable release
+  /// exists.
+  #[instrument(
+    name = "Database::get_latest_unyanked_version_for_package_for_docs",
+    skip(self),
+    err
+  )]
+  pub async fn get_latest_unyanked_version_for_package_for_docs(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+  ) -> Result<Option<PackageVersion>> {
+    query_concat_as!(
+      PackageVersion,
+      "SELECT ", PACKAGE_VERSION_SELECT, "
+      FROM package_versions
+      WHERE scope = $1 AND name = $2 AND is_yanked = false
+      ORDER BY (version NOT LIKE '%-%') DESC, version DESC
+      LIMIT 1";
+      scope as _,
+      name as _,
+    )
+    .fetch_optional(&self.pool)
+    .await
+  }
+
   #[instrument(
     name = "Database::get_latest_unyanked_version_for_package_with_newer_versions_count",
     skip(self),

--- a/api/testdata/tarballs/ok_prerelease/jsr.json
+++ b/api/testdata/tarballs/ok_prerelease/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/foo",
+  "version": "1.2.3-alpha.1",
+  "exports": "./mod.ts",
+  "license": "MIT"
+}

--- a/api/testdata/tarballs/ok_prerelease/mod.ts
+++ b/api/testdata/tarballs/ok_prerelease/mod.ts
@@ -1,0 +1,11 @@
+/**
+ * This is a test module.
+ *
+ * @module
+ */
+
+/**
+ * This is a test constant.
+ */
+export const hello = "Hello, world!";
+export const 读取多键1 = 1;

--- a/frontend/routes/package/(_components)/PackageHeader.tsx
+++ b/frontend/routes/package/(_components)/PackageHeader.tsx
@@ -91,12 +91,6 @@ export function PackageHeader({
               >
                 Jump to {isNewerPrerelease ? "this version " : "latest"}
               </a>
-              <a
-                class="max-md:flex-1 max-md:block button-sm button-primary whitespace-nowrap"
-                href={`/@${pkg.scope}/${pkg.name}/diff/${selectedVersion.version}...${pkg.latestVersion}`}
-              >
-                Jump to diff
-              </a>
             </div>
           </div>
         </div>

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -59,22 +59,6 @@ export function PackageNav({
       )}
       {(latestVersion || params.version) && (
         <NavItem
-          href={`${base}/diff/${
-            (params.version && params.version !== latestVersion)
-              ? params.version
-              : ""
-          }...${
-            (params.version && params.version === latestVersion)
-              ? params.version
-              : latestVersion ?? ""
-          }`}
-          active={currentTab === "Diff"}
-        >
-          Diff
-        </NavItem>
-      )}
-      {(latestVersion || params.version) && (
-        <NavItem
           href={`${base}/${params.version || latestVersion}`}
           active={currentTab === "Files"}
         >

--- a/frontend/routes/package/diff/[file].tsx
+++ b/frontend/routes/package/diff/[file].tsx
@@ -7,6 +7,9 @@ import { PackageNav, Params } from "../(_components)/PackageNav.tsx";
 import { DiffView } from "../(_components)/Docs.tsx";
 import { scopeIAM } from "../../../utils/iam.ts";
 
+// The diff view is disabled. Flip to `true` to re-enable it.
+const DIFF_ENABLED: boolean = false;
+
 export default define.page<typeof handler>(function File({
   data,
   params,
@@ -49,6 +52,10 @@ export default define.page<typeof handler>(function File({
 
 export const handler = define.handlers({
   async GET(ctx) {
+    if (!DIFF_ENABLED) {
+      throw new HttpError(404, "The diff view is currently disabled.");
+    }
+
     if (ctx.url.pathname.endsWith("/~")) {
       return new Response(null, {
         status: 302,

--- a/frontend/routes/package/diff/[symbol].tsx
+++ b/frontend/routes/package/diff/[symbol].tsx
@@ -7,6 +7,9 @@ import { PackageNav, Params } from "../(_components)/PackageNav.tsx";
 import { DiffView } from "../(_components)/Docs.tsx";
 import { scopeIAM } from "../../../utils/iam.ts";
 
+// The diff view is disabled. Flip to `true` to re-enable it.
+const DIFF_ENABLED: boolean = false;
+
 export default define.page<typeof handler>(function Symbol(
   { data, params, state, url },
 ) {
@@ -46,6 +49,10 @@ export default define.page<typeof handler>(function Symbol(
 
 export const handler = define.handlers({
   async GET(ctx) {
+    if (!DIFF_ENABLED) {
+      throw new HttpError(404, "The diff view is currently disabled.");
+    }
+
     const docsReq = {
       entrypoint: ctx.params.entrypoint,
       symbol: ctx.params.symbol,

--- a/frontend/routes/package/diff/all_symbols.tsx
+++ b/frontend/routes/package/diff/all_symbols.tsx
@@ -7,6 +7,9 @@ import { PackageNav, Params } from "../(_components)/PackageNav.tsx";
 import { DiffView } from "../(_components)/Docs.tsx";
 import { scopeIAM } from "../../../utils/iam.ts";
 
+// The diff view is disabled. Flip to `true` to re-enable it.
+const DIFF_ENABLED: boolean = false;
+
 export default define.page<typeof handler>(function AllSymbols(
   { data, params, state, url },
 ) {
@@ -46,6 +49,10 @@ export default define.page<typeof handler>(function AllSymbols(
 
 export const handler = define.handlers({
   async GET(ctx) {
+    if (!DIFF_ENABLED) {
+      throw new HttpError(404, "The diff view is currently disabled.");
+    }
+
     const docsReq = { all_symbols: "true" } as const;
     const res = await packageDataWithDiff(
       ctx.state,

--- a/frontend/utils/data.ts
+++ b/frontend/utils/data.ts
@@ -126,6 +126,16 @@ export async function packageDataWithDocs(
     } else {
       if (pkgDocsResp.code === "scopeNotFound") return null;
       if (pkgDocsResp.code === "packageNotFound") return null;
+      if (pkgDocsResp.code === "docsOnlyForLatestVersion") {
+        // Docs are only served for the latest version; redirect to the
+        // canonical (versionless) docs URL for the latest version.
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: `/@${scope}/${pkg}/doc${compileDocsRequestPath(docs)}`,
+          },
+        });
+      }
       if (pkgDocsResp.code === "entrypointOrSymbolNotFound") {
         // redirect to all symbols page if there is no default entrypoint
         if ("entrypoint" in docs && !docs.symbol && docs.entrypoint === "") {


### PR DESCRIPTION
## Summary

Disables the package **diff view** and restricts **documentation pages to the latest version** of a package; requests for any other version redirect to the latest.

### Diff view (disabled, code kept)
- The three frontend diff routes return `404` behind a `DIFF_ENABLED` flag, and the **Diff** nav tab + **Jump to diff** button are removed.
- The API `get_diff_handler` returns a new `DiffDisabled` error behind the same flag.
- All diff rendering code (`DiffView`, `DiffVersionSelector`, `packageDataWithDiff`, the diff computation) is left intact — flip the flag(s) to re-enable.

### Docs latest-only
- `get_docs_handler`, `get_docs_search_handler`, and `get_docs_search_structured_handler` only serve a pinned `:version` if it is the current docs-latest version; anything else returns the new `DocsOnlyForLatestVersion` error. The `latest` alias still works.
- `packageDataWithDocs` turns `docsOnlyForLatestVersion` into a `302` to the canonical **versionless** docs URL (preserving entrypoint/symbol/all_symbols), so non-latest doc pages redirect to the latest.
- `source` (Files tab) is unaffected — all versions remain browsable there.

### Prerelease handling
Docs-latest resolves to the **latest unyanked stable version**, falling back to the **latest prerelease** for packages that only have prereleases (via a new `get_latest_unyanked_version_for_package_for_docs` DB method ordering stable ahead of prerelease). So prerelease-only packages keep working docs instead of 404ing.

## Behavior

| Package state | `…/doc` (versionless) | pinned latest | pinned older |
|---|---|---|---|
| Has stable release | serves stable latest | serves | → redirect to latest |
| Prerelease-only | serves latest prerelease | serves | → redirect to latest |
| Diff (any) | 404 | 404 | 404 |

## Tests
- `test_package_docs`: adds coverage for the `latest` alias, non-latest → `docsOnlyForLatestVersion` (docs + both search endpoints), and diff → `diffDisabled`.
- New `test_package_docs_prerelease_only`: prerelease-only package serves docs at `latest`/pinned, older version still rejected.

## Notes
- Includes a regenerated sqlx offline cache entry for the new query and a new `ok_prerelease` test tarball.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `deno lint`, and both docs tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)