### PR TITLE
chore(terraform): use zonal Cloud SQL with 2 vCPU / 6GB

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -10,8 +10,8 @@ resource "google_sql_database_instance" "main_pg15" {
 
   settings {
     edition           = "ENTERPRISE"
-    tier              = var.production ? "db-custom-4-8192" : "db-f1-micro"
-    availability_type = var.production ? "REGIONAL" : "ZONAL"
+    tier              = var.production ? "db-custom-2-6144" : "db-f1-micro"
+    availability_type = "ZONAL"
 
     disk_type             = "PD_SSD"
     disk_autoresize       = true


### PR DESCRIPTION
Changes the production Cloud SQL instance from a REGIONAL `db-custom-4-8192` to a ZONAL `db-custom-2-6144` (2 vCPU, 6 GB).

Note: applying this removes the HA standby replica (no automatic failover) and restarts the instance.