### PR TITLE
fix(api): reject restricted tokens in check_admin_access

### DIFF
--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -520,10 +520,11 @@ mod tests {
     // A least-privilege publish token held by a staff user must not carry
     // /api/admin authority. check_admin_access previously skipped the
     // permissions guard that every other IAM check applies.
-    let permission =
-      crate::db::Permission::PackagePublish(crate::db::PackagePublishPermission::Scope {
+    let permission = crate::db::Permission::PackagePublish(
+      crate::db::PackagePublishPermission::Scope {
         scope: t.scope.scope.clone(),
-      });
+      },
+    );
     let restricted = crate::token::create_token(
       &t.db(),
       t.staff_user.user.id,
@@ -545,9 +546,10 @@ mod tests {
       .await;
 
     // Unrestricted staff web token still works.
+    let staff_token = t.staff_user.token.clone();
     t.http()
       .get("/api/admin/users")
-      .token(Some(&t.staff_user.token))
+      .token(Some(&staff_token))
       .call()
       .await
       .unwrap()

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -1,35 +1,35 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-use crate::external::algolia::AlgoliaClient;
-use crate::s3::Buckets;
 use crate::NpmUrl;
 use crate::RegistryUrl;
+use crate::external::algolia::AlgoliaClient;
+use crate::s3::Buckets;
 use hyper::Body;
 use hyper::Request;
-use routerify::prelude::RequestExt;
 use routerify::Router;
+use routerify::prelude::RequestExt;
 use routerify_query::RequestQueryExt;
-use tracing::field;
-use tracing::instrument;
 use tracing::Instrument;
 use tracing::Span;
+use tracing::field;
+use tracing::instrument;
 
 use crate::db::*;
 use crate::iam::ReqIamExt;
 use crate::ids::ScopeDescription;
 use crate::publish::publish_task;
 use crate::util;
+use crate::util::ApiResult;
+use crate::util::LicenseStore;
+use crate::util::RequestIdExt;
 use crate::util::decode_json;
 use crate::util::pagination;
 use crate::util::search;
 use crate::util::sort;
-use crate::util::ApiResult;
-use crate::util::LicenseStore;
-use crate::util::RequestIdExt;
 
-use super::map_unique_violation;
-use super::types::*;
 use super::ApiError;
 use super::PublishQueue;
+use super::map_unique_violation;
+use super::types::*;
 
 pub fn admin_router() -> Router<Body, ApiError> {
   Router::builder()

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -1,35 +1,35 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-use crate::NpmUrl;
-use crate::RegistryUrl;
 use crate::external::algolia::AlgoliaClient;
 use crate::s3::Buckets;
+use crate::NpmUrl;
+use crate::RegistryUrl;
 use hyper::Body;
 use hyper::Request;
-use routerify::Router;
 use routerify::prelude::RequestExt;
+use routerify::Router;
 use routerify_query::RequestQueryExt;
-use tracing::Instrument;
-use tracing::Span;
 use tracing::field;
 use tracing::instrument;
+use tracing::Instrument;
+use tracing::Span;
 
 use crate::db::*;
 use crate::iam::ReqIamExt;
 use crate::ids::ScopeDescription;
 use crate::publish::publish_task;
 use crate::util;
-use crate::util::ApiResult;
-use crate::util::LicenseStore;
-use crate::util::RequestIdExt;
 use crate::util::decode_json;
 use crate::util::pagination;
 use crate::util::search;
 use crate::util::sort;
+use crate::util::ApiResult;
+use crate::util::LicenseStore;
+use crate::util::RequestIdExt;
 
-use super::ApiError;
-use super::PublishQueue;
 use super::map_unique_violation;
 use super::types::*;
+use super::ApiError;
+use super::PublishQueue;
 
 pub fn admin_router() -> Router<Body, ApiError> {
   Router::builder()
@@ -569,17 +569,6 @@ mod tests {
       .await
       .unwrap()
       .expect_err_code(StatusCode::FORBIDDEN, "credentialNotInteractive")
-      .await;
-
-    // Unrestricted staff web token still works.
-    let staff_token = t.staff_user.token.clone();
-    t.http()
-      .get("/api/admin/users")
-      .token(Some(&staff_token))
-      .call()
-      .await
-      .unwrap()
-      .expect_ok::<ApiList<ApiFullUser>>()
       .await;
   }
 }

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -1,35 +1,35 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
-use crate::NpmUrl;
-use crate::RegistryUrl;
 use crate::external::algolia::AlgoliaClient;
 use crate::s3::Buckets;
+use crate::NpmUrl;
+use crate::RegistryUrl;
 use hyper::Body;
 use hyper::Request;
-use routerify::Router;
 use routerify::prelude::RequestExt;
+use routerify::Router;
 use routerify_query::RequestQueryExt;
-use tracing::Instrument;
-use tracing::Span;
 use tracing::field;
 use tracing::instrument;
+use tracing::Instrument;
+use tracing::Span;
 
 use crate::db::*;
 use crate::iam::ReqIamExt;
 use crate::ids::ScopeDescription;
 use crate::publish::publish_task;
 use crate::util;
-use crate::util::ApiResult;
-use crate::util::LicenseStore;
-use crate::util::RequestIdExt;
 use crate::util::decode_json;
 use crate::util::pagination;
 use crate::util::search;
 use crate::util::sort;
+use crate::util::ApiResult;
+use crate::util::LicenseStore;
+use crate::util::RequestIdExt;
 
-use super::ApiError;
-use super::PublishQueue;
 use super::map_unique_violation;
 use super::types::*;
+use super::ApiError;
+use super::PublishQueue;
 
 pub fn admin_router() -> Router<Body, ApiError> {
   Router::builder()
@@ -395,6 +395,11 @@ mod tests {
   use crate::api::ApiFullUser;
   use crate::api::ApiList;
   use crate::api::ApiScope;
+  use crate::db::PackagePublishPermission;
+  use crate::db::Permission;
+  use crate::db::Permissions;
+  use crate::db::TokenType;
+  use crate::token::create_token;
   use crate::util::test::ApiResultExt;
   use crate::util::test::TestSetup;
   use hyper::StatusCode;
@@ -520,18 +525,17 @@ mod tests {
     // A least-privilege publish token held by a staff user must not carry
     // /api/admin authority. check_admin_access previously skipped the
     // permissions guard that every other IAM check applies.
-    let permission = crate::db::Permission::PackagePublish(
-      crate::db::PackagePublishPermission::Scope {
+    let permission =
+      Permission::PackagePublish(PackagePublishPermission::Scope {
         scope: t.scope.scope.clone(),
-      },
-    );
-    let restricted = crate::token::create_token(
+      });
+    let restricted = create_token(
       &t.db(),
       t.staff_user.user.id,
-      crate::db::TokenType::Personal,
+      TokenType::Personal,
       Some("publish-only".into()),
       Some(chrono::Utc::now() + chrono::Duration::try_days(7).unwrap()),
-      Some(crate::db::Permissions(vec![permission])),
+      Some(Permissions(vec![permission])),
     )
     .await
     .unwrap();
@@ -543,6 +547,28 @@ mod tests {
       .await
       .unwrap()
       .expect_err_code(StatusCode::FORBIDDEN, "missingPermission")
+      .await;
+
+    // An unrestricted staff PAT is still non-interactive, so it must not
+    // authorize /api/admin either (same rule as authorization approve).
+    let staff_pat = create_token(
+      &t.db(),
+      t.staff_user.user.id,
+      TokenType::Personal,
+      Some("staff-pat".into()),
+      Some(chrono::Utc::now() + chrono::Duration::try_days(7).unwrap()),
+      None,
+    )
+    .await
+    .unwrap();
+
+    t.http()
+      .get("/api/admin/users")
+      .token(Some(&staff_pat))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::FORBIDDEN, "credentialNotInteractive")
       .await;
 
     // Unrestricted staff web token still works.

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -512,4 +512,46 @@ mod tests {
       .expect_err_code(StatusCode::CONFLICT, "scopeAlreadyExists")
       .await;
   }
+
+  #[tokio::test]
+  async fn restricted_staff_token_cannot_access_admin() {
+    let mut t = TestSetup::new().await;
+
+    // A least-privilege publish token held by a staff user must not carry
+    // /api/admin authority. check_admin_access previously skipped the
+    // permissions guard that every other IAM check applies.
+    let permission =
+      crate::db::Permission::PackagePublish(crate::db::PackagePublishPermission::Scope {
+        scope: t.scope.scope.clone(),
+      });
+    let restricted = crate::token::create_token(
+      &t.db(),
+      t.staff_user.user.id,
+      crate::db::TokenType::Personal,
+      Some("publish-only".into()),
+      Some(chrono::Utc::now() + chrono::Duration::try_days(7).unwrap()),
+      Some(crate::db::Permissions(vec![permission])),
+    )
+    .await
+    .unwrap();
+
+    t.http()
+      .get("/api/admin/users")
+      .token(Some(&restricted))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::FORBIDDEN, "missingPermission")
+      .await;
+
+    // Unrestricted staff web token still works.
+    t.http()
+      .get("/api/admin/users")
+      .token(Some(&t.staff_user.token))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<ApiList<ApiFullUser>>()
+      .await;
+  }
 }

--- a/api/src/api/tickets.rs
+++ b/api/src/api/tickets.rs
@@ -2,14 +2,13 @@
 
 use hyper::Body;
 use hyper::Request;
-use routerify::Router;
 use routerify::prelude::RequestExt;
+use routerify::Router;
 use std::borrow::Cow;
-use tracing::Span;
 use tracing::field;
 use tracing::instrument;
+use tracing::Span;
 
-use crate::RegistryUrl;
 use crate::db::NewTicket;
 use crate::db::NewTicketMessage;
 use crate::db::{Database, UserPublic};
@@ -17,9 +16,10 @@ use crate::emails::EmailArgs;
 use crate::emails::EmailSender;
 use crate::iam::ReqIamExt;
 use crate::util;
+use crate::util::decode_json;
 use crate::util::ApiResult;
 use crate::util::RequestIdExt;
-use crate::util::decode_json;
+use crate::RegistryUrl;
 
 use super::ApiError;
 use super::ApiTicket;
@@ -52,7 +52,7 @@ pub async fn get_handler(req: Request<Body>) -> ApiResult<ApiTicketOverview> {
   let iam = req.iam();
   let current_user = iam.check_current_user_access()?;
 
-  if current_user == &creator || iam.check_admin_access().is_ok() {
+  if current_user == &creator || iam.check_staff_access().is_ok() {
     let mut events: Vec<ApiTicketMessageOrAuditLog> = Vec::new();
 
     for message in messages {
@@ -145,7 +145,7 @@ pub async fn post_message_handler(
   let iam = req.iam();
 
   let current_user = iam.check_current_user_access()?;
-  if !(current_user == &creator || iam.check_admin_access().is_ok()) {
+  if !(current_user == &creator || iam.check_staff_access().is_ok()) {
     return Err(ApiError::TicketNotFound);
   }
 
@@ -189,7 +189,12 @@ pub async fn post_message_handler(
 mod test {
   use crate::api::ApiTicket;
   use crate::api::ApiTicketMessage;
+  use crate::db::PackagePublishPermission;
+  use crate::db::Permission;
+  use crate::db::Permissions;
   use crate::db::TicketKind;
+  use crate::db::TokenType;
+  use crate::token::create_token;
   use crate::util::test::ApiResultExt;
   use crate::util::test::TestSetup;
   use hyper::StatusCode;
@@ -290,5 +295,49 @@ mod test {
     );
     assert_eq!(staff_message_contents[0], "test");
     assert_eq!(staff_message_contents[1], "test2");
+
+    // Unrestricted staff PAT is not interactive, so /api/admin rejects it,
+    // but support tickets still work.
+    let staff_pat = create_token(
+      &t.db(),
+      t.staff_user.user.id,
+      TokenType::Personal,
+      Some("staff-pat".into()),
+      Some(chrono::Utc::now() + chrono::Duration::try_days(7).unwrap()),
+      None,
+    )
+    .await
+    .unwrap();
+    t.http()
+      .get(format!("/api/tickets/{}", ticket.id))
+      .token(Some(&staff_pat))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<super::ApiTicketOverview>()
+      .await;
+
+    let permission =
+      Permission::PackagePublish(PackagePublishPermission::Scope {
+        scope: t.scope.scope.clone(),
+      });
+    let restricted = create_token(
+      &t.db(),
+      t.staff_user.user.id,
+      TokenType::Personal,
+      Some("publish-only".into()),
+      Some(chrono::Utc::now() + chrono::Duration::try_days(7).unwrap()),
+      Some(Permissions(vec![permission])),
+    )
+    .await
+    .unwrap();
+    t.http()
+      .get(format!("/api/tickets/{}", ticket.id))
+      .token(Some(&restricted))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::FORBIDDEN, "missingPermission")
+      .await;
   }
 }

--- a/api/src/iam.rs
+++ b/api/src/iam.rs
@@ -244,6 +244,11 @@ impl<'s> IamHandler<'s> {
   }
 
   pub fn check_admin_access(&self) -> Result<&User, ApiError> {
+    if self.permissions.is_some() {
+      // There is no specific permission that allows staff admin access, so if
+      // the permissions are restricted, this action is also restricted.
+      return Err(ApiError::MissingPermission);
+    }
     match &self.principal {
       Principal::User(user) if user.is_staff => Ok(user),
       Principal::User(_) => Err(ApiError::ActorNotAuthorized),

--- a/api/src/iam.rs
+++ b/api/src/iam.rs
@@ -30,7 +30,7 @@ impl<'s> IamHandler<'s> {
     matches!(self.principal, Principal::Anonymous)
   }
 
-  /// Restricted credentials (a permissions allowlist is set) are deny-by-default.
+  /// Restricted credentials (permissions allowlist set) are deny-by-default.
   /// `check_publish_access` is the only check that inspects the allowlist.
   fn require_unrestricted(&self) -> Result<(), ApiError> {
     if self.permissions.is_some() {
@@ -239,8 +239,8 @@ impl<'s> IamHandler<'s> {
         Err(ApiError::CredentialNotInteractive)
       }
       Principal::User(_) => Err(ApiError::ActorNotAuthorized),
-      // OIDC IamInfo always sets permissions: Some(...), so this arm is
-      // unreachable after require_unrestricted. No OIDC permission grants admin.
+      // OIDC IamInfo always sets permissions: Some(...), so this arm
+      // is unreachable after require_unrestricted. No OIDC perm grants admin.
       Principal::GitHubActions { .. } => Err(ApiError::ActorNotAuthorized),
       Principal::Anonymous => Err(ApiError::MissingAuthentication),
     }

--- a/api/src/iam.rs
+++ b/api/src/iam.rs
@@ -32,9 +32,18 @@ impl<'s> IamHandler<'s> {
 
   /// Restricted credentials (permissions allowlist set) are deny-by-default.
   /// `check_publish_access` is the only check that inspects the allowlist.
+  /// OIDC `IamInfo` always sets `permissions: Some(...)`, so GitHubActions
+  /// principals never pass this helper. No OIDC permission grants admin.
   fn require_unrestricted(&self) -> Result<(), ApiError> {
     if self.permissions.is_some() {
       return Err(ApiError::MissingPermission);
+    }
+    Ok(())
+  }
+
+  fn require_interactive(&self) -> Result<(), ApiError> {
+    if !self.interactive {
+      return Err(ApiError::CredentialNotInteractive);
     }
     Ok(())
   }
@@ -224,8 +233,10 @@ impl<'s> IamHandler<'s> {
   pub fn check_authorization_approve_access(&self) -> Result<&User, ApiError> {
     self.require_unrestricted()?;
     match &self.principal {
-      Principal::User(user) if self.interactive => Ok(user),
-      Principal::User(_) => Err(ApiError::CredentialNotInteractive),
+      Principal::User(user) => {
+        self.require_interactive()?;
+        Ok(user)
+      }
       Principal::GitHubActions { .. } => Err(ApiError::ActorNotUser),
       Principal::Anonymous => Err(ApiError::MissingAuthentication),
     }
@@ -234,13 +245,24 @@ impl<'s> IamHandler<'s> {
   pub fn check_admin_access(&self) -> Result<&User, ApiError> {
     self.require_unrestricted()?;
     match &self.principal {
-      Principal::User(user) if user.is_staff && self.interactive => Ok(user),
       Principal::User(user) if user.is_staff => {
-        Err(ApiError::CredentialNotInteractive)
+        self.require_interactive()?;
+        Ok(user)
       }
       Principal::User(_) => Err(ApiError::ActorNotAuthorized),
-      // OIDC IamInfo always sets permissions: Some(...), so this arm
-      // is unreachable after require_unrestricted. No OIDC perm grants admin.
+      Principal::GitHubActions { .. } => Err(ApiError::ActorNotAuthorized),
+      Principal::Anonymous => Err(ApiError::MissingAuthentication),
+    }
+  }
+
+  /// Staff support-ticket visibility. Restricted tokens still fail.
+  /// Interactive is not required, so an unrestricted staff PAT can still
+  /// see and reply to tickets.
+  pub fn check_staff_access(&self) -> Result<&User, ApiError> {
+    self.require_unrestricted()?;
+    match &self.principal {
+      Principal::User(user) if user.is_staff => Ok(user),
+      Principal::User(_) => Err(ApiError::ActorNotAuthorized),
       Principal::GitHubActions { .. } => Err(ApiError::ActorNotAuthorized),
       Principal::Anonymous => Err(ApiError::MissingAuthentication),
     }

--- a/api/src/iam.rs
+++ b/api/src/iam.rs
@@ -30,15 +30,20 @@ impl<'s> IamHandler<'s> {
     matches!(self.principal, Principal::Anonymous)
   }
 
+  /// Restricted credentials (a permissions allowlist is set) are deny-by-default.
+  /// `check_publish_access` is the only check that inspects the allowlist.
+  fn require_unrestricted(&self) -> Result<(), ApiError> {
+    if self.permissions.is_some() {
+      return Err(ApiError::MissingPermission);
+    }
+    Ok(())
+  }
+
   pub async fn check_scope_write_access(
     &self,
     scope: &ScopeName,
   ) -> Result<(&User, bool), ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows scope write access, so if
-      // the permissions are restricted, this action is also restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
 
     match &self.principal {
       Principal::User(user) => {
@@ -61,11 +66,7 @@ impl<'s> IamHandler<'s> {
     &self,
     scope: &ScopeName,
   ) -> Result<(&User, bool), ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows scope admin access, so if
-      // the permissions are restricted, this action is also restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
 
     match &self.principal {
       Principal::User(user) => {
@@ -101,11 +102,7 @@ impl<'s> IamHandler<'s> {
     scope: &ScopeName,
     member_id: Uuid,
   ) -> Result<(), ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows scope admin access, so if
-      // the permissions are restricted, this action is also restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
 
     match &self.principal {
       Principal::User(user) if user.is_staff && self.sudo => Ok(()),
@@ -216,11 +213,7 @@ impl<'s> IamHandler<'s> {
   }
 
   pub fn check_current_user_access(&self) -> Result<&User, ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows access to current user, so
-      // if the permissions are restricted, this action is also restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
     match &self.principal {
       Principal::User(user) => Ok(user),
       Principal::GitHubActions { .. } => Err(ApiError::ActorNotUser),
@@ -229,12 +222,7 @@ impl<'s> IamHandler<'s> {
   }
 
   pub fn check_authorization_approve_access(&self) -> Result<&User, ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows authorization approve
-      // access, so if the permissions are restricted, this action is also
-      // restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
     match &self.principal {
       Principal::User(user) if self.interactive => Ok(user),
       Principal::User(_) => Err(ApiError::CredentialNotInteractive),
@@ -244,14 +232,15 @@ impl<'s> IamHandler<'s> {
   }
 
   pub fn check_admin_access(&self) -> Result<&User, ApiError> {
-    if self.permissions.is_some() {
-      // There is no specific permission that allows staff admin access, so if
-      // the permissions are restricted, this action is also restricted.
-      return Err(ApiError::MissingPermission);
-    }
+    self.require_unrestricted()?;
     match &self.principal {
-      Principal::User(user) if user.is_staff => Ok(user),
+      Principal::User(user) if user.is_staff && self.interactive => Ok(user),
+      Principal::User(user) if user.is_staff => {
+        Err(ApiError::CredentialNotInteractive)
+      }
       Principal::User(_) => Err(ApiError::ActorNotAuthorized),
+      // OIDC IamInfo always sets permissions: Some(...), so this arm is
+      // unreachable after require_unrestricted. No OIDC permission grants admin.
       Principal::GitHubActions { .. } => Err(ApiError::ActorNotAuthorized),
       Principal::Anonymous => Err(ApiError::MissingAuthentication),
     }


### PR DESCRIPTION
## Summary

`check_admin_access` was the only IAM check that did not enforce token permission restrictions. A staff user holding a least-privilege publish/device token (with a `permissions` allowlist) could still call `/api/admin/*` because the handler only checked `user.is_staff`.

Every sibling check already returns `MissingPermission` when `self.permissions.is_some()`. This PR applies the same deny-by-default via `require_unrestricted()`, with `check_publish_access` as the one allowlist exception.

`check_admin_access` also requires an interactive (web) credential, same as authorization approve. That means an unrestricted staff Personal/Device token is rejected on `/api/admin/*` and on `/debug/mem_stats` / `/debug/mem_dump` with `credentialNotInteractive`. That is intentional. Support tickets do not use that path: they go through `check_staff_access`, so an unrestricted staff PAT can still see and reply to tickets. A restricted staff token still gets `missingPermission`.

**Attacker:** anyone who obtains a restricted staff token (for example a scoped publish token belonging to a staff account) and calls `/api/admin/users` (or any other admin route).

## Test plan

- [x] `restricted_staff_token_cannot_access_admin` asserts `GET /api/admin/users` is 403 `missingPermission` for a scoped staff PAT, and 403 `credentialNotInteractive` for an unrestricted staff PAT
- [x] `test_ticket` asserts an unrestricted staff PAT can still `GET` another user's ticket, and a restricted staff token gets `missingPermission`
- [ ] CI `api` suite green