### PR TITLE
fix: accept GitHub Enterprise Cloud unique OIDC issuer URLs for trusted publishing

### DIFF
--- a/api/src/external/github.rs
+++ b/api/src/external/github.rs
@@ -220,9 +220,65 @@ pub struct GitHubClaims {
   pub aud: String,
 }
 
+/// Validate that `iss` is a GitHub Actions OIDC issuer: either the shared
+/// issuer, or an enterprise-scoped one of the form
+/// `https://token.actions.githubusercontent.com/<enterpriseSlug>`, which GitHub
+/// Enterprise Cloud uses when the "unique OIDC issuer URL" setting is enabled.
+/// The slug charset check also keeps the JWKS fetch below pinned to GitHub's
+/// domain.
+fn validate_oidc_issuer(iss: &str) -> ApiResult<()> {
+  if iss == GITHUB_OIDC_ISSUER {
+    return Ok(());
+  }
+  if let Some(slug) = iss.strip_prefix(GITHUB_OIDC_ISSUER)
+    && let Some(slug) = slug.strip_prefix('/')
+    && !slug.is_empty()
+    && slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+  {
+    return Ok(());
+  }
+  Err(ApiError::InvalidOidcToken {
+    msg: format!("invalid issuer: {iss}").into(),
+  })
+}
+
+/// Extract the `iss` claim from a JWT without verifying its signature. The
+/// value must only be used to select the JWKS endpoint; `verify_oidc_token`
+/// re-validates it under the token signature.
+fn extract_unverified_issuer(token: &str) -> ApiResult<String> {
+  use base64::Engine as _;
+  use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+
+  #[derive(Deserialize)]
+  struct UnverifiedClaims {
+    iss: String,
+  }
+
+  let payload = token.split('.').nth(1).ok_or(ApiError::InvalidOidcToken {
+    msg: "malformed token".into(),
+  })?;
+  let payload = BASE64_URL_SAFE_NO_PAD.decode(payload).map_err(|err| {
+    ApiError::InvalidOidcToken {
+      msg: format!("failed to decode claims: {err}").into(),
+    }
+  })?;
+  let claims: UnverifiedClaims =
+    serde_json::from_slice(&payload).map_err(|err| {
+      ApiError::InvalidOidcToken {
+        msg: format!("failed to parse claims: {err}").into(),
+      }
+    })?;
+  Ok(claims.iss)
+}
+
 #[instrument(name = "github::verify_oidc_token", err, skip(token))]
 pub async fn verify_oidc_token(token: &str) -> ApiResult<GitHubClaims> {
-  let url = format!("{GITHUB_OIDC_ISSUER}/.well-known/jwks");
+  // The issuer is needed before verification to know which JWKS endpoint to
+  // fetch: enterprise-scoped issuers serve their keys from their own path.
+  let issuer = extract_unverified_issuer(token)?;
+  validate_oidc_issuer(&issuer)?;
+
+  let url = format!("{issuer}/.well-known/jwks");
   let res = shared_http_client()
     .get(url)
     .header("Accept", "application/json")
@@ -262,7 +318,7 @@ pub async fn verify_oidc_token(token: &str) -> ApiResult<GitHubClaims> {
     })?
     .into();
   let mut validation = jsonwebtoken::Validation::new(alg);
-  validation.set_issuer(&[GITHUB_OIDC_ISSUER]);
+  validation.set_issuer(&[&issuer]);
   let decoded = jsonwebtoken::decode::<GitHubClaims>(
     token,
     &jwk.key.to_decoding_key(),
@@ -273,4 +329,59 @@ pub async fn verify_oidc_token(token: &str) -> ApiResult<GitHubClaims> {
   })?;
 
   Ok(decoded.claims)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::GITHUB_OIDC_ISSUER;
+  use super::extract_unverified_issuer;
+  use super::validate_oidc_issuer;
+  use base64::Engine as _;
+  use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+
+  #[test]
+  fn validate_oidc_issuer_accepts_github_issuers() {
+    validate_oidc_issuer(GITHUB_OIDC_ISSUER).unwrap();
+    // Enterprise-scoped issuer (GHEC "unique OIDC issuer URL"), see
+    // jsr-io/jsr#1485.
+    validate_oidc_issuer(
+      "https://token.actions.githubusercontent.com/octocat-inc",
+    )
+    .unwrap();
+  }
+
+  #[test]
+  fn validate_oidc_issuer_rejects_other_issuers() {
+    for iss in [
+      "",
+      "https://example.com",
+      "https://token.actions.githubusercontent.com/",
+      "https://token.actions.githubusercontent.com//foo",
+      "https://token.actions.githubusercontent.com/foo/bar",
+      "https://token.actions.githubusercontent.com/foo?x=1",
+      "https://token.actions.githubusercontent.com/../foo",
+      "https://token.actions.githubusercontent.com.evil.com",
+      "https://token.actions.githubusercontent.com.evil.com/foo",
+      "https://token.actions.ghe.com/foo",
+    ] {
+      assert!(validate_oidc_issuer(iss).is_err(), "accepted: {iss}");
+    }
+  }
+
+  #[test]
+  fn extract_unverified_issuer_reads_iss_claim() {
+    let payload = BASE64_URL_SAFE_NO_PAD.encode(
+      br#"{"iss":"https://token.actions.githubusercontent.com/octocat-inc"}"#,
+    );
+    let token = format!("e30.{payload}.signature");
+    assert_eq!(
+      extract_unverified_issuer(&token).unwrap(),
+      "https://token.actions.githubusercontent.com/octocat-inc"
+    );
+
+    assert!(extract_unverified_issuer("garbage").is_err());
+    assert!(extract_unverified_issuer("e30.!!!.sig").is_err());
+    let no_iss = BASE64_URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+    assert!(extract_unverified_issuer(&format!("e30.{no_iss}.sig")).is_err());
+  }
 }

--- a/api/src/provenance.rs
+++ b/api/src/provenance.rs
@@ -13,7 +13,10 @@ use x509_parser::public_key::PublicKey;
 
 /// The OIDC issuer that GitHub Actions uses when requesting a Fulcio signing
 /// certificate. JSR provenance is only ever produced by GitHub Actions, so the
-/// signing certificate must carry this issuer.
+/// signing certificate must carry this issuer. The check below is a substring
+/// match, which deliberately also accepts enterprise-scoped issuers of the
+/// form `https://token.actions.githubusercontent.com/<enterpriseSlug>` (GHEC
+/// "unique OIDC issuer URL") — do not tighten it to an equality check.
 const GITHUB_ACTIONS_ISSUER: &str =
   "https://token.actions.githubusercontent.com";
 
@@ -561,6 +564,19 @@ mod tests {
     assert!(parse_github_repo("https://gitlab.com/foo/bar").is_none());
     assert!(parse_github_repo("https://github.com/").is_none());
     assert!(parse_github_repo("https://github.com/onlyowner").is_none());
+  }
+
+  #[test]
+  fn issuer_check_accepts_enterprise_scoped_issuers() {
+    // Certificates minted for GHEC enterprises with a unique OIDC issuer URL
+    // carry `<issuer>/<enterpriseSlug>`; the substring match must keep
+    // accepting them (jsr-io/jsr#1485).
+    let enterprise_issuer =
+      "https://token.actions.githubusercontent.com/octocat-inc";
+    assert!(find_subslice(
+      enterprise_issuer.as_bytes(),
+      GITHUB_ACTIONS_ISSUER.as_bytes()
+    ));
   }
 
   #[test]


### PR DESCRIPTION
## Problem

GHEC enterprises can enable a [unique OIDC issuer URL](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/oidc), which makes GitHub Actions mint tokens with `iss: https://token.actions.githubusercontent.com/<enterpriseSlug>` instead of the shared issuer. `verify_oidc_token` hardcoded the shared issuer, so trusted publishing from repos under such an enterprise consistently failed with `The provided OIDC token is invalid: InvalidIssuer` — the exact failure signature in #1485: the `kid` lookup succeeds (the enterprise issuer serves the same signing keys), the signature verifies, and then the strict issuer equality check rejects the token.

## Fix

- `verify_oidc_token` reads the token's `iss` claim up front (unverified, via `extract_unverified_issuer`), validates it with `validate_oidc_issuer` — the shared issuer, or the shared issuer plus exactly one slug segment restricted to `[A-Za-z0-9-]` — fetches the JWKS from that issuer's own `/.well-known/jwks`, and passes the same issuer to `set_issuer` so it is re-checked under the token signature.
- The slug charset restriction also pins the JWKS fetch to GitHub's domain (no traversal, no lookalike domains — covered by tests, including `token.actions.githubusercontent.com.evil.com`).
- Provenance verification needs no functional change: the Fulcio certificate issuer check is a substring match that already accepts enterprise-scoped issuers. That is now documented on `GITHUB_ACTIONS_ISSUER` with a regression test so it doesn't get tightened to an equality check later.

## Out of scope

GHEC with data residency (`token.actions.<subdomain>.ghe.com`) is a different domain with different signing keys; those tokens now fail with a clear `invalid issuer` message instead of a confusing kid/issuer error.

Fixes #1485
