### PR TITLE
docs: add terms of service and privacy policy

### DIFF
--- a/frontend/docs/privacy-policy.md
+++ b/frontend/docs/privacy-policy.md
@@ -1,0 +1,396 @@
+---
+description: This privacy policy describes the personal information JSR collects, how it is used, and your choices with respect to it.
+---
+
+_Last updated: August 21st, 2026_
+
+Deno Land Inc. (“Deno,” “we,” “us,” or “our”) collects and uses personal
+information in order to provide its products and services to you. This Privacy
+Policy (the “Policy”) describes the personal information we collect, the
+purposes for which we use it, the parties with whom we may share it, and your
+choices with respect to such information. For purposes of this Privacy Policy,
+“personal information” means any information that relates to you as an
+individual and could reasonably be used to identify you. This Privacy Policy
+applies to our collection and use of personal information through (i) our
+website at [https://jsr.io](https://jsr.io) (the “Site”); (ii) any websites,
+applications or other digital properties that link to this Privacy Policy; and
+(iii) the products and services (the “JSR Offerings”) we offer to you on our
+platform (the “Platform”), including the JSR registry, the JSR website, and the
+JSR API.
+
+By accessing or using the Site or any other digital property that links to this
+Privacy Policy, you may learn about JSR and our technology platform, and
+registered users may also access the JSR Offerings (collectively, the
+“Services”). To the extent permitted by applicable law, your use of JSR
+constitutes your acknowledgment and/or consent to the practices described in
+this Policy.
+
+This Privacy Policy incorporates our [Terms of Service](/docs/terms-of-service)
+(the “Terms”). Capitalized terms that are not defined in the Privacy Policy have
+the meaning given to them in the Terms.
+
+**I. The Information We Collect, And How We Collect It**
+
+We collect the following categories of information, which may include personal
+information (collectively, the “**Information**”).
+
+**1\. Information You Provide To Us**
+
+We collect information from and about you directly when you provide it to us.
+This information may be collected when you contact us, fill out a form, create
+an account, publish a package, open a support ticket, access or participate on
+our Sites, or otherwise interact with us. This information may include:
+
+_Contact Information._ We collect your contact information when you voluntarily
+provide it to us. For example, you may disclose contact information to us when
+you contact us for support, submit information by mail, telephone, in person or
+electronically, or when you sign up for our newsletters and other marketing
+communications. Contact Information typically includes first name, last name,
+e-mail address, postal address, organization, telephone number and other
+information that identifies you or can be used to identify or contact you.
+
+_Account Credentials_. When you register to create an account with us, you
+authenticate via an identity provider such as GitHub, and we will collect
+certain additional personal information, including your name, email address,
+avatar, and the user name, numeric user identifier, and public profile
+information associated with your identity provider account.
+
+_User Content_. We collect the packages, package versions, source code,
+documentation, package metadata, and scope names that you publish to JSR, along
+with records of your publishing activity. Please note that JSR is a public
+registry: everything you publish, and the scopes and packages associated with
+your account, are publicly visible. Do not publish confidential information,
+credentials, or personal information that you do not wish to make public.
+
+In addition to Contact Information, Account Credentials, and User Content, we
+may collect other kinds of information, such as:
+
+- Comments, questions, and requests you may make, including support tickets and
+  the messages within them;
+
+- Information about your preferences, such as your preferred methods of
+  communication and the types of information in which you are interested;
+
+- Details of downloads from our Sites;
+
+- Records and copies of your correspondence (including email addresses and phone
+  numbers), if you contact us; and
+
+- Any other information you voluntarily provide.
+
+**2\. Information Obtained From Third Parties**
+
+We may receive certain information about you from other sources, including
+publicly available sources (such as public records and social media platforms),
+as well as our service providers and marketing partners. In particular, when you
+authenticate to JSR through an identity provider such as GitHub, that provider
+shares certain account information with us as described above.
+
+When we collect personal information from users and visitors of other sites on
+which you have interacted with us, we will do so in accordance with the terms of
+use and privacy policies of those sites and applicable law. We may also receive
+personal information when you comment on our social media advertisements, post
+comments about us, or tag us in a public-facing social media post. Personal
+information may also be collected by the third-party social media sites that
+host our social media pages. These sites may provide aggregate information and
+analysis to us about visitors’ use of our social media pages. This allows us to
+better understand and analyze our user growth, general demographic information
+about the users of these pages, and interaction with the content that we post.
+Overall, this information may be used to help us understand the types of
+visitors and users of our social media pages and use of the content. This
+Privacy Policy does not cover personal information collected by such third-party
+social media sites. For more information on their privacy and security practices
+please review the privacy policies and terms of use on their respective
+websites.
+
+**3\. Information Collected Automatically**
+
+We and our service providers may automatically obtain certain information about
+you, your electronic device, and your interactions with us, including the
+following:
+
+- _Device data_. We may collect data such as the type of device and its
+  operating system and settings, browser type, mobile device carrier, country,
+  IP address, and unique identifiers.
+
+- _Internet and other or electronic activity data_. This includes information
+  about your interaction with our Sites, emails, and other online content.
+
+- _Tracking Data_. We may collect tracking data using first and third-party
+  cookies, pixels, web server logs, web beacons, and similar data collection and
+  tracking technologies on the Sites, third party websites, apps and online
+  services, and across your devices (such as IP address, browser, type, ISP,
+  platform type, device type). Third parties such as advertising networks and
+  analytics providers may also collect information about your online activities
+  over time and across different websites and devices when you access or use the
+  Sites.
+
+- _Audit logs_. We keep an audit log of security- and moderation-relevant
+  actions taken on the Platform, such as publishing a package, changing scope
+  membership, and administrative actions. Audit log entries record the account
+  that performed the action and the time at which it was performed.
+
+**II. How We Use And Share Your Information**
+
+Deno uses the Information for the purpose for which it was collected and in a
+manner that is consistent with this Privacy Policy. These functions include
+operation, maintenance and improvements to the Sites, providing our products and
+services, operating the registry and distributing published packages,
+solicitation of your feedback, gaining a better understanding of our customers
+and visitors of our Sites, responding to your requests and questions, and
+informing you about our organization, products, services, events, and other
+areas of interest.
+
+_Public Information_. Certain information is published as part of operating a
+public registry. Your user name, display name, and avatar, the scopes you belong
+to, and the packages and package versions you publish are publicly visible
+through the Site and the JSR API, and may be downloaded, cached, and mirrored by
+third parties.
+
+_Analytics Services_. We may use third-party web analytics services, such as
+Google Analytics, to help us understand and analyze how Site visitors use our
+services. For more information on how Google Analytics uses data collected
+through our Sites, visit
+[www.google.com/policies/privacy/partners](http://www.google.com/policies/privacy/partners).
+
+_Aggregated Data_. We may analyze your personal information in aggregate form
+which does not identify you personally (“**Aggregated Data**”). The Aggregated
+Data may be used to operate, maintain, manage, and improve the Sites, shared
+with our affiliates, agents, and business partners, and otherwise used and
+disclosed for lawful business purposes. We do not re-identify de-identified or
+aggregated information.
+
+_Service Providers/Vendors_. Like many businesses, we hire other companies to
+perform certain business-related services. We may disclose personal information
+to certain types of third party companies but only to the extent needed to
+enable them to provide such services, for example web hosting, content delivery,
+disaster recovery, client survey and marketing, and data storage.
+
+_Reorganization_. If, in the future, Deno undergoes a corporate, partnership, or
+business reorganization, we may transfer the Information, including personal
+information, to the new or surviving entity.
+
+_Protection of Rights and Compliance_. We may use your Information to protect
+the rights, privacy or safety of you, us or others; to ensure our compliance
+with legal and contractual requirements; and to prevent and investigate illegal,
+unethical, or unauthorized activities (including cyberattacks and identity
+theft).
+
+If Deno intends on using or disclosing your personal information in any manner
+that is not consistent with this Privacy Policy, you will be informed of such
+anticipated use prior to or at the time at which the personal information is
+collected.
+
+**III. How We Protect Your Information**
+
+We take commercially reasonable steps to protect your personal information from
+loss, misuse, and unauthorized access, disclosure, alteration, or destruction.
+Please understand, however, that no security system is impenetrable. We cannot
+guarantee the security of our databases, nor can we guarantee that the personal
+information that you supply will not be intercepted while being transmitted to
+and from us over the Internet.
+
+**IV. Data Retention**
+
+Deno determines the retention period for all Information based on the purposes
+for which we collect and/or receive the Information and/or tax, legal and
+regulatory requirements. In addition to this, we may consider other factors,
+such as the nature and sensitivity of the data, and whether we can achieve the
+purpose for which we collected the data through other means.
+
+**V. Account Deletion And Data Retention**
+
+You may delete your JSR account at any time from your account settings. This
+section describes what happens to your Information when you do.
+
+**1\. Information That Is Deleted**
+
+When you delete your account, your account record is permanently deleted from
+our systems. This includes your name, your email address, and your avatar, which
+are not retained.
+
+**2\. Information That Is Retained**
+
+Deleting your account does not erase the record that the account existed or the
+actions it took on the Platform. Specifically:
+
+- _Audit log entries._ Audit log entries created by your account are reassigned
+  to a system service account, so that the audit trail of actions taken on the
+  Platform remains complete and attributable.
+
+- _Pseudonymous identifiers._ We retain a minimal, pseudonymous record of the
+  deleted account. Each of your former audit log entries retains your internal
+  account identifier (a UUID, stored as `meta.original_actor_id`), and the audit
+  log entry recording the deletion itself (`user_delete`) retains that internal
+  account identifier together with the numeric user identifiers assigned to you
+  by your identity provider (for example, your GitHub or GitLab numeric user
+  ID). This record allows the account to be re-identified through the identity
+  provider if we are legally required to do so. It does not include your name,
+  email address, or avatar.
+
+- _Support tickets._ Support tickets you created and messages you sent within
+  them are reassigned to the system service account and retained.
+
+We retain this information because it is necessary for compliance with a legal
+obligation to which we are subject, for reasons of security and the prevention
+and investigation of fraud and abuse, and for the establishment, exercise, or
+defense of legal claims. We rely on Article 17(3)(b) and Article 17(3)(e) of the
+EU General Data Protection Regulation and on Section 1798.105(d) of the
+California Consumer Privacy Act as the bases for retaining it notwithstanding a
+deletion request.
+
+**3\. Published Packages Remain Public**
+
+Published package versions are immutable and are not removed when you delete
+your account. They remain publicly available through the Site, the JSR API, and
+any third-party caches and mirrors, so that packages which depend on them
+continue to resolve. Any personal information you chose to include in the
+contents or metadata of a package you published — for example, an author name or
+email address in a source file or manifest — remains part of that published
+version and remains public. See our [immutability](/docs/immutability)
+documentation for more detail.
+
+If you are the only member of a scope, that scope and its packages are
+transferred to the system service account when your account is deleted. If a
+scope you created has other members, ownership of that scope is transferred to
+another member.
+
+**4\. Deletion Holds**
+
+Our administrators can place a deletion hold on an account. While a deletion
+hold is in place, the account cannot be deleted, and a deletion request made
+from account settings will not proceed. We use deletion holds to preserve
+evidence while a legal or moderation matter concerning an account is pending —
+for example, an active abuse investigation, a dispute over a package or scope,
+or a legal claim or litigation hold. The hold is removed once the matter is
+resolved, after which the account can be deleted as described above.
+
+If you have questions about a deletion hold on your account, contact us at
+[help@jsr.io](mailto:help@jsr.io).
+
+**VI. Your Privacy Choices**
+
+**1\. Your Information**
+
+You may request access to, correction of, or deletion of the personal
+information we maintain about you, and we will endeavor to respond promptly to
+your request. In order to make such a request, please contact us as indicated
+below. Please see the section titled “Account Deletion And Data Retention” above
+for information about what is retained when an account is deleted.
+
+**2\. Marketing Communications**
+
+You may opt-out of marketing-related emails by clicking on the “unsubscribe”
+link located on the bottom of any marketing email or emailing us at
+[help@jsr.io](mailto:help@jsr.io). We will use commercially reasonable efforts
+to process such requests in a timely manner. Please note that even if you
+opt-out of marketing-related emails, you will continue to receive
+service-related and other non-marketing emails.
+
+**3\. Tracking Technology**
+
+You can choose not to permit tracking technologies, such as cookies and web
+beacons, when you use our services, but blocking some types of these tracking
+technologies may interfere with your experience.
+
+_Browser-Based Opt-Outs_. You may be able to disable tracking technologies using
+your web browser settings. Please review your browser’s instructions or visit
+[All About Cookies](https://allaboutcookies.org/) for general information. Note
+that your web browser may have settings that allow you to transmit a “Do Not
+Track” signal when you use online services. Like many websites, our Sites are
+not currently designed to respond to “Do Not Track” signals received from
+browsers.
+
+_Self-Regulatory Program Opt-Outs_. Two self-regulatory programs are available
+to help you control the use of tracking technologies on your browsers — the
+[Digital Advertising Alliance](https://digitaladvertisingalliance.org/) and the
+[Network Advertising Initiative](https://thenai.org/). Both programs help to
+regulate vendors in the digital advertising space. One function of their
+self-regulatory programs is to give you the ability to opt out of targeted (or
+interest-based) advertising, including the use of tracking technologies, from
+their member companies. You can visit the Digital Advertising Alliance’s Your Ad
+Choices website to opt out of targeted advertising for participating vendors.
+The Network Advertising Initiative similarly assists with opt outs through their
+Opt Out of Interest-Based Advertising webpage.
+
+_Google Analytics Opt-Out._ To opt out of Google Analytics cookies, visit
+Google’s [My Ad Center](https://myadcenter.google.com/personalizationoff) and/or
+download the Google Analytics Opt-Out Browser Add-On.
+
+**VII. Children**
+
+We do not knowingly collect personal information from children under the age of
+18 through the Sites. If you are under 18, please do not give us any personal
+information. We encourage parents and legal guardians to monitor their
+children’s Internet usage and to help enforce our Privacy Policy by instructing
+their children never to provide personal information through the Sites without
+their permission. If you have reason to believe that a child under the age of 18
+has provided personal information to us, please contact us, at
+[help@jsr.io](mailto:help@jsr.io) and we will endeavor to delete that
+information from our databases.
+
+**VIII. External Websites**
+
+The Sites may contain links to third-party websites. These third-party sites may
+collect information about you if you click on a link. We have no control over
+the privacy practices or the content of these websites. As such, we are not
+responsible for the content or the privacy policies of those third-party
+websites. You should check the applicable third-party privacy policy and terms
+of use when visiting any other websites.
+
+**IX. Important Notice To Non-U.S. Residents**
+
+The Sites are hosted in and provided from the United States and other countries.
+If you are located outside of the United States, please be aware that any
+information you provide to us may be transferred to the United States or other
+countries where the privacy laws may not be as protective as those in your
+country of origin. If you are located outside the United States and choose to
+use the Sites, you consent to any transfer and processing of your personal
+information in accordance with this Privacy Policy, and you do so at your own
+risk.
+
+**X. Notice To California Residents**
+
+Pursuant to Section 1798.83 of the California Civil Code, residents of
+California have the right to obtain certain information about the types of
+personal information that companies with whom they have an established business
+relationship (and that are not otherwise exempt) have shared with third parties
+for direct marketing purposes during the preceding calendar year, including the
+names and addresses of those third parties, and examples of the types of
+services or products marketed by those third parties. In order to submit such a
+request, please contact us using the contact information provided at the end of
+this document. Please note, however, that we do not share, nor have we shared in
+the past, personal information with third parties for direct marketing purposes.
+
+**XI. Notice To Nevada Residents**
+
+If you are a resident of Nevada, you have the right to opt-out of the sale of
+personal information to third parties. You can exercise this right by contacting
+us at [help@jsr.io](mailto:help@jsr.io) with the subject line “Nevada Do Not
+Sell Request” and providing us with your name and the email address. Please
+note, however, that we do not sell any personal information to third parties.
+
+**XII. Changes To This Privacy Policy**
+
+This Privacy Policy is effective as of the date stated at the top of this
+Privacy Policy. We may change this Privacy Policy from time to time. Any such
+changes will be posted on the Sites. By accessing the Sites after we make any
+such changes to this Privacy Policy, you are deemed to have accepted such
+changes. Please be aware that, to the extent permitted by applicable law, our
+use of the Information is governed by the Privacy Policy in effect at the time
+we collect the Information. Please refer back to this Privacy Policy on a
+regular basis.
+
+**XIII. How To Contact Us**
+
+Please reach out to [help@jsr.io](mailto:help@jsr.io) for any questions,
+complaints, or requests regarding this Privacy Policy, and include in the
+subject line “Privacy Policy", or contact us by mail at:
+
+Deno Land Inc.\
+1111 6th Ave Ste 550\
+PMB 702973\
+San Diego CA, 92101\
+USA
+
+**© 2026 Deno Land Inc. All rights reserved.**

--- a/frontend/docs/privacy-policy.md
+++ b/frontend/docs/privacy-policy.md
@@ -42,12 +42,9 @@ an account, publish a package, open a support ticket, access or participate on
 our Sites, or otherwise interact with us. This information may include:
 
 _Contact Information._ We collect your contact information when you voluntarily
-provide it to us. For example, you may disclose contact information to us when
-you contact us for support, submit information by mail, telephone, in person or
-electronically, or when you sign up for our newsletters and other marketing
-communications. Contact Information typically includes first name, last name,
-e-mail address, postal address, organization, telephone number and other
-information that identifies you or can be used to identify or contact you.
+provide it to us — for example, when you open a support ticket or email us for
+help. In practice this is your email address and whatever you choose to put in
+your message. We do not run a newsletter and we do not send marketing email.
 
 _Account Credentials_. When you register to create an account with us, you
 authenticate via an identity provider such as GitHub, and we will collect
@@ -80,28 +77,12 @@ may collect other kinds of information, such as:
 
 **2\. Information Obtained From Third Parties**
 
-We may receive certain information about you from other sources, including
-publicly available sources (such as public records and social media platforms),
-as well as our service providers and marketing partners. In particular, when you
-authenticate to JSR through an identity provider such as GitHub, that provider
-shares certain account information with us as described above.
-
-When we collect personal information from users and visitors of other sites on
-which you have interacted with us, we will do so in accordance with the terms of
-use and privacy policies of those sites and applicable law. We may also receive
-personal information when you comment on our social media advertisements, post
-comments about us, or tag us in a public-facing social media post. Personal
-information may also be collected by the third-party social media sites that
-host our social media pages. These sites may provide aggregate information and
-analysis to us about visitors’ use of our social media pages. This allows us to
-better understand and analyze our user growth, general demographic information
-about the users of these pages, and interaction with the content that we post.
-Overall, this information may be used to help us understand the types of
-visitors and users of our social media pages and use of the content. This
-Privacy Policy does not cover personal information collected by such third-party
-social media sites. For more information on their privacy and security practices
-please review the privacy policies and terms of use on their respective
-websites.
+When you authenticate to JSR through an identity provider — GitHub or GitLab —
+that provider shares certain account information with us: your name, email
+address, avatar, username, and numeric user identifier. That is the only routine
+source of information about you that we receive from a third party. We do not
+buy personal information, and we do not receive it from data brokers or
+marketing partners.
 
 **3\. Information Collected Automatically**
 
@@ -109,26 +90,31 @@ We and our service providers may automatically obtain certain information about
 you, your electronic device, and your interactions with us, including the
 following:
 
-- _Device data_. We may collect data such as the type of device and its
-  operating system and settings, browser type, mobile device carrier, country,
-  IP address, and unique identifiers.
+- _Server logs_. Our servers and our CDN record requests made to JSR, including
+  your IP address, user agent, the path requested, and the time of the request.
 
-- _Internet and other or electronic activity data_. This includes information
-  about your interaction with our Sites, emails, and other online content.
+- _Download counts_. When a package is downloaded we record the scope, package
+  name, version, and the user agent that requested it, so that we can show
+  download statistics. We do not record your IP address alongside this.
 
-- _Tracking Data_. We may collect tracking data using first and third-party
-  cookies, pixels, web server logs, web beacons, and similar data collection and
-  tracking technologies on the Sites, third party websites, apps and online
-  services, and across your devices (such as IP address, browser, type, ISP,
-  platform type, device type). Third parties such as advertising networks and
-  analytics providers may also collect information about your online activities
-  over time and across different websites and devices when you access or use the
-  Sites.
+- _Search_. Search on JSR is powered by Algolia. The text you type into the
+  search box is sent to Algolia in order to return results. We do not tell
+  Algolia which result you clicked, and we do not keep any identifier that would
+  let searches be linked to each other or to you.
+
+- _Bot protection_. Our login page uses Cloudflare Turnstile to distinguish
+  people from automated abuse. Turnstile receives signals from your browser in
+  order to make that determination.
 
 - _Audit logs_. We keep an audit log of security- and moderation-relevant
   actions taken on the Platform, such as publishing a package, changing scope
   membership, and administrative actions. Audit log entries record the account
   that performed the action and the time at which it was performed.
+
+We do not track you. JSR contains no advertising networks, no third-party
+analytics or advertising trackers such as Google Analytics, no tracking pixels,
+and no cross-site tracking of any kind. We do not sell advertising, and we do
+not profile you or build a record of your behaviour across visits.
 
 **II. How We Use And Share Your Information**
 
@@ -147,11 +133,23 @@ to, and the packages and package versions you publish are publicly visible
 through the Site and the JSR API, and may be downloaded, cached, and mirrored by
 third parties.
 
-_Analytics Services_. We may use third-party web analytics services, such as
-Google Analytics, to help us understand and analyze how Site visitors use our
-services. For more information on how Google Analytics uses data collected
-through our Sites, visit
-[www.google.com/policies/privacy/partners](http://www.google.com/policies/privacy/partners).
+_Service Providers._ JSR is built on a small number of third-party services, and
+those providers process data on our behalf in order to run the registry. They
+are:
+
+| Provider          | What it does for JSR                                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Google Cloud      | Runs the API, the database, background job queues, scheduled jobs, secrets, and log storage                                   |
+| Cloudflare        | CDN and edge routing, package and documentation storage (R2), download counts, and Turnstile bot protection on the login page |
+| Algolia           | Powers package and documentation search                                                                                       |
+| Postmark          | Sends transactional email — scope invitations, access token notices, and support ticket replies                               |
+| GitHub and GitLab | Provide authentication when you sign in                                                                                       |
+
+We use these providers only to operate the Services. This list is the complete
+set of third parties that receive personal information from JSR; if it changes
+we will update this page. Our infrastructure is defined in public Terraform in
+the [JSR repository](https://github.com/jsr-io/jsr), so this list can be checked
+against what we actually run.
 
 _Aggregated Data_. We may analyze your personal information in aggregate form
 which does not identify you personally (“**Aggregated Data**”). The Aggregated
@@ -181,7 +179,36 @@ that is not consistent with this Privacy Policy, you will be informed of such
 anticipated use prior to or at the time at which the personal information is
 collected.
 
-**III. How We Protect Your Information**
+**III. Legal Bases For Processing (EEA and UK)**
+
+If you are in the European Economic Area or the United Kingdom, we process your
+personal information on the following bases:
+
+- _Performance of a contract._ We process your account information and the
+  content you publish because it is necessary to provide the registry to you
+  under our [Terms of Service](/docs/terms-of-service).
+
+- _Legitimate interests._ We process server logs, download counts, search
+  analytics, audit logs, and bot-protection signals because we have a legitimate
+  interest in keeping JSR secure, available, and useful, and in understanding
+  how it is used. We balance that interest against your rights, which is why
+  these records are minimal and short-lived.
+
+- _Consent._ Where we rely on your consent — for example, for storage on your
+  device that is not strictly necessary to deliver the Services — you may
+  withdraw it at any time, and withdrawing it will not affect processing that
+  took place beforehand.
+
+- _Legal obligation._ We process and retain information where the law requires
+  it, and to establish, exercise, or defend legal claims.
+
+You have the right to access, correct, delete, restrict, and object to our
+processing of your personal information, and to receive a copy of it in a
+portable format. To exercise any of these rights, contact
+[help@jsr.io](mailto:help@jsr.io). You also have the right to lodge a complaint
+with your local data protection supervisory authority.
+
+**IV. How We Protect Your Information**
 
 We take commercially reasonable steps to protect your personal information from
 loss, misuse, and unauthorized access, disclosure, alteration, or destruction.
@@ -190,146 +217,138 @@ guarantee the security of our databases, nor can we guarantee that the personal
 information that you supply will not be intercepted while being transmitted to
 and from us over the Internet.
 
-**IV. Data Retention**
+**V. Data Retention**
 
-Deno determines the retention period for all Information based on the purposes
-for which we collect and/or receive the Information and/or tax, legal and
-regulatory requirements. In addition to this, we may consider other factors,
-such as the nature and sensitivity of the data, and whether we can achieve the
-purpose for which we collected the data through other means.
+We keep information only as long as we need it. Specifically:
 
-**V. Account Deletion And Data Retention**
+- _Server and request logs_ are retained for **30 days**, then deleted
+  automatically.
+- _Fine-grained download counts_ are retained for **7 days**; the aggregate
+  download totals shown on package pages are kept indefinitely, and are not
+  personal information.
+- _Expired sign-in state_ is deleted **hourly**, and is never kept longer than
+  an hour.
+- _Database backups_ have a **7 day** recovery window.
+- _Your account record_ is kept for as long as your account exists.
+- _Audit log entries_ are kept for as long as we need them for security and
+  moderation.
+- _Published packages_ are kept indefinitely, because other people's code
+  depends on them. See "Published Packages Remain Public" below.
 
-You may delete your JSR account at any time from your account settings. This
-section describes what happens to your Information when you do.
+Retention periods for logs and scheduled deletion jobs are configured in public
+Terraform in the [JSR repository](https://github.com/jsr-io/jsr) and can be
+verified there.
 
-**1\. Information That Is Deleted**
+**VI. Account Deletion**
 
-When you delete your account, your account record is permanently deleted from
-our systems. This includes your name, your email address, and your avatar, which
-are not retained.
+You can delete your account at any time from your account settings. This section
+describes what happens when you do.
 
-**2\. Information That Is Retained**
+**1. What is deleted**
 
-Deleting your account does not erase the record that the account existed or the
-actions it took on the Platform. Specifically:
+Your account is removed. Your name, your email address, and your avatar are no
+longer part of any account on JSR, and you stop appearing as a member of any
+scope.
 
-- _Audit log entries._ Audit log entries created by your account are reassigned
-  to a system service account, so that the audit trail of actions taken on the
-  Platform remains complete and attributable.
+**2. What you look like afterwards**
 
-- _Pseudonymous identifiers._ We retain a minimal, pseudonymous record of the
-  deleted account. Each of your former audit log entries retains your internal
-  account identifier (a UUID, stored as `meta.original_actor_id`), and the audit
-  log entry recording the deletion itself (`user_delete`) retains that internal
-  account identifier together with the numeric user identifiers assigned to you
-  by your identity provider (for example, your GitHub or GitLab numeric user
-  ID). This record allows the account to be re-identified through the identity
-  provider if we are legally required to do so. It does not include your name,
-  email address, or avatar.
+Wherever the site would previously have shown you — as the publisher of a
+version, or as a member of a scope — it shows an anonymous placeholder account
+instead. Your identity is not shown to other users after deletion.
 
-- _Support tickets._ Support tickets you created and messages you sent within
-  them are reassigned to the system service account and retained.
+**3. What we keep, and for how long**
 
-We retain this information because it is necessary for compliance with a legal
-obligation to which we are subject, for reasons of security and the prevention
-and investigation of fraud and abuse, and for the establishment, exercise, or
-defense of legal claims. We rely on Article 17(3)(b) and Article 17(3)(e) of the
-EU General Data Protection Regulation and on Section 1798.105(d) of the
-California Consumer Privacy Act as the bases for retaining it notwithstanding a
-deletion request.
+Deleting your account does not erase the record that it existed or what it did.
+We keep a single entry recording the deletion, which contains:
 
-**3\. Published Packages Remain Public**
+- _Indefinitely:_ an internal identifier for the account, and the numeric user
+  identifiers assigned to you by the identity provider you signed in with. These
+  are meaningless on their own and are not shown to anyone. They let us
+  re-identify the account through that provider if we are legally required to.
+
+- _For one year, then removed automatically:_ your name and email address. We
+  keep these for a limited period because supply-chain attacks and abuse are
+  frequently discovered long after the fact, and an attacker who can erase every
+  trace of themselves by deleting their account can attack the registry with
+  impunity. After a year a scheduled job strips both fields, leaving only the
+  pseudonymous identifiers above.
+
+We also keep the record of actions your account took — when a version was
+published, when scope membership changed — reattributed to an internal service
+account, and any support tickets and messages you sent us.
+
+We rely on Article 17(3)(b) and Article 17(3)(e) of the EU General Data
+Protection Regulation and on Section 1798.105(d) of the California Consumer
+Privacy Act as the bases for keeping this information notwithstanding a deletion
+request. It is kept for security, for the investigation of fraud and abuse, and
+for the establishment, exercise, or defense of legal claims — and no longer than
+described above.
+
+**4. Your scopes**
+
+If you are the only member of a scope, that scope and its packages transfer to
+an internal service account so the packages within it keep working. If a scope
+you belong to has other members, it stays with them.
+
+**5. Published packages remain public**
 
 Published package versions are immutable and are not removed when you delete
-your account. They remain publicly available through the Site, the JSR API, and
-any third-party caches and mirrors, so that packages which depend on them
-continue to resolve. Any personal information you chose to include in the
-contents or metadata of a package you published — for example, an author name or
-email address in a source file or manifest — remains part of that published
-version and remains public. See our [immutability](/docs/immutability)
-documentation for more detail.
+your account. They remain available through the Site, the JSR API, and any
+third-party caches and mirrors, so that packages which depend on them continue
+to resolve. Any personal information you chose to include in the contents or
+metadata of a package you published — an author name or email address in a
+source file or manifest, for example — remains part of that published version
+and remains public. See our [immutability](/docs/immutability) documentation.
 
-If you are the only member of a scope, that scope and its packages are
-transferred to the system service account when your account is deleted. If a
-scope you created has other members, ownership of that scope is transferred to
-another member.
+If you need something specific taken down rather than your whole account — a
+leaked credential, or personal information inside a package — contact us at
+[help@jsr.io](mailto:help@jsr.io) and we will work through it with you.
 
-**4\. Deletion Holds**
-
-Our administrators can place a deletion hold on an account. While a deletion
-hold is in place, the account cannot be deleted, and a deletion request made
-from account settings will not proceed. We use deletion holds to preserve
-evidence while a legal or moderation matter concerning an account is pending —
-for example, an active abuse investigation, a dispute over a package or scope,
-or a legal claim or litigation hold. The hold is removed once the matter is
-resolved, after which the account can be deleted as described above.
-
-If you have questions about a deletion hold on your account, contact us at
-[help@jsr.io](mailto:help@jsr.io).
-
-**VI. Your Privacy Choices**
+**VII. Your Privacy Choices**
 
 **1\. Your Information**
 
 You may request access to, correction of, or deletion of the personal
 information we maintain about you, and we will endeavor to respond promptly to
 your request. In order to make such a request, please contact us as indicated
-below. Please see the section titled “Account Deletion And Data Retention” above
-for information about what is retained when an account is deleted.
+below. Please see the section titled “Account Deletion” above for information
+about what is retained when an account is deleted.
 
-**2\. Marketing Communications**
+**2\. Email**
 
-You may opt-out of marketing-related emails by clicking on the “unsubscribe”
-link located on the bottom of any marketing email or emailing us at
-[help@jsr.io](mailto:help@jsr.io). We will use commercially reasonable efforts
-to process such requests in a timely manner. Please note that even if you
-opt-out of marketing-related emails, you will continue to receive
-service-related and other non-marketing emails.
+We only send transactional email: scope invitations, notices when a personal
+access token is created on your account, and replies to support tickets you
+opened. We do not send marketing email or newsletters, so there is nothing to
+unsubscribe from.
 
 **3\. Tracking Technology**
 
-You can choose not to permit tracking technologies, such as cookies and web
-beacons, when you use our services, but blocking some types of these tracking
-technologies may interfere with your experience.
+JSR stores very little in your browser. In full:
 
-_Browser-Based Opt-Outs_. You may be able to disable tracking technologies using
-your web browser settings. Please review your browser’s instructions or visit
-[All About Cookies](https://allaboutcookies.org/) for general information. Note
-that your web browser may have settings that allow you to transmit a “Do Not
-Track” signal when you use online services. Like many websites, our Sites are
-not currently designed to respond to “Do Not Track” signals received from
-browsers.
+- _Sign-in cookie._ Set when you log in, and required for you to stay logged in.
+  Logging out removes it.
+- _Turnstile._ Cloudflare's bot check on the login page may set storage in order
+  to avoid asking you to prove you are a person repeatedly.
 
-_Self-Regulatory Program Opt-Outs_. Two self-regulatory programs are available
-to help you control the use of tracking technologies on your browsers — the
-[Digital Advertising Alliance](https://digitaladvertisingalliance.org/) and the
-[Network Advertising Initiative](https://thenai.org/). Both programs help to
-regulate vendors in the digital advertising space. One function of their
-self-regulatory programs is to give you the ability to opt out of targeted (or
-interest-based) advertising, including the use of tracking technologies, from
-their member companies. You can visit the Digital Advertising Alliance’s Your Ad
-Choices website to opt out of targeted advertising for participating vendors.
-The Network Advertising Initiative similarly assists with opt outs through their
-Opt Out of Interest-Based Advertising webpage.
+That is the complete list. You can block or clear either through your browser's
+settings for jsr.io; blocking the sign-in cookie will prevent you from logging
+in.
 
-_Google Analytics Opt-Out._ To opt out of Google Analytics cookies, visit
-Google’s [My Ad Center](https://myadcenter.google.com/personalizationoff) and/or
-download the Google Analytics Opt-Out Browser Add-On.
+Our Sites do not respond to "Do Not Track" browser signals. We do not sell or
+share personal information for advertising, so there is no advertising opt-out
+to offer.
 
-**VII. Children**
+**VIII. Children**
 
 We do not knowingly collect personal information from children under the age of
-18 through the Sites. If you are under 18, please do not give us any personal
-information. We encourage parents and legal guardians to monitor their
-children’s Internet usage and to help enforce our Privacy Policy by instructing
-their children never to provide personal information through the Sites without
-their permission. If you have reason to believe that a child under the age of 18
-has provided personal information to us, please contact us, at
-[help@jsr.io](mailto:help@jsr.io) and we will endeavor to delete that
-information from our databases.
+16 through the Sites. If you are under 16, a parent or legal guardian must
+consent to and supervise your use of the Services. We encourage parents and
+legal guardians to monitor their children’s Internet usage. If you have reason
+to believe that a child under the age of 16 has provided personal information to
+us without that consent, please contact us at [help@jsr.io](mailto:help@jsr.io)
+and we will endeavor to delete that information from our databases.
 
-**VIII. External Websites**
+**IX. External Websites**
 
 The Sites may contain links to third-party websites. These third-party sites may
 collect information about you if you click on a link. We have no control over
@@ -338,18 +357,19 @@ responsible for the content or the privacy policies of those third-party
 websites. You should check the applicable third-party privacy policy and terms
 of use when visiting any other websites.
 
-**IX. Important Notice To Non-U.S. Residents**
+**X. Important Notice To Non-U.S. Residents**
 
-The Sites are hosted in and provided from the United States and other countries.
-If you are located outside of the United States, please be aware that any
-information you provide to us may be transferred to the United States or other
-countries where the privacy laws may not be as protective as those in your
-country of origin. If you are located outside the United States and choose to
-use the Sites, you consent to any transfer and processing of your personal
-information in accordance with this Privacy Policy, and you do so at your own
-risk.
+JSR is operated from the United States, and our infrastructure and service
+providers process data in the United States. If you are located elsewhere, your
+personal information will be transferred to and processed in the United States,
+where privacy laws differ from those in your country.
 
-**X. Notice To California Residents**
+Where we transfer personal information out of the European Economic Area or the
+United Kingdom, we rely on the European Commission's Standard Contractual
+Clauses with our service providers, or on another transfer mechanism permitted
+by applicable law.
+
+**XI. Notice To California Residents**
 
 Pursuant to Section 1798.83 of the California Civil Code, residents of
 California have the right to obtain certain information about the types of
@@ -362,7 +382,7 @@ request, please contact us using the contact information provided at the end of
 this document. Please note, however, that we do not share, nor have we shared in
 the past, personal information with third parties for direct marketing purposes.
 
-**XI. Notice To Nevada Residents**
+**XII. Notice To Nevada Residents**
 
 If you are a resident of Nevada, you have the right to opt-out of the sale of
 personal information to third parties. You can exercise this right by contacting
@@ -370,7 +390,7 @@ us at [help@jsr.io](mailto:help@jsr.io) with the subject line “Nevada Do Not
 Sell Request” and providing us with your name and the email address. Please
 note, however, that we do not sell any personal information to third parties.
 
-**XII. Changes To This Privacy Policy**
+**XIII. Changes To This Privacy Policy**
 
 This Privacy Policy is effective as of the date stated at the top of this
 Privacy Policy. We may change this Privacy Policy from time to time. Any such
@@ -381,7 +401,7 @@ use of the Information is governed by the Privacy Policy in effect at the time
 we collect the Information. Please refer back to this Privacy Policy on a
 regular basis.
 
-**XIII. How To Contact Us**
+**XIV. How To Contact Us**
 
 Please reach out to [help@jsr.io](mailto:help@jsr.io) for any questions,
 complaints, or requests regarding this Privacy Policy, and include in the

--- a/frontend/docs/terms-of-service.md
+++ b/frontend/docs/terms-of-service.md
@@ -1,0 +1,497 @@
+---
+description: These are the terms of service that govern your access to and use of JSR.
+---
+
+_Last updated: August 21st, 2026_
+
+These Terms of Service (these “Terms”) are a legal agreement between you and
+Deno Land Inc. (“Deno,” “we,” “us,” or “our”). They specify the terms under
+which you may access and use (i) our website at [https://jsr.io](https://jsr.io)
+(the “Site”); (ii) any websites, applications or other digital properties that
+link to these Terms; and (iii) the products and services (the “JSR Offerings”)
+we offer to you on our platform (the “Platform”), including the JSR registry,
+the JSR website, and the JSR API.
+
+By accessing or using the Site or any other digital property that links to these
+Terms, you may learn about JSR and our technology platform, and registered users
+may also access the JSR Offerings (collectively, the “Services”).
+
+PLEASE READ THESE TERMS CAREFULLY. BY ACCESSING AND/OR USING THE SERVICES, YOU
+ACKNOWLEDGE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE LEGALLY BOUND BY
+THESE TERMS AND THE TERMS AND CONDITIONS OF OUR PRIVACY POLICY (THE “PRIVACY
+POLICY”), WHICH ARE HEREBY INCORPORATED INTO THESE TERMS AND MADE A PART HEREOF
+BY REFERENCE (COLLECTIVELY, THE “AGREEMENT”). IF YOU DO NOT AGREE TO ANY OF THE
+TERMS IN THIS AGREEMENT, THEN PLEASE DO NOT USE THE SERVICES.
+
+If you accept or agree to the Agreement on behalf of a company or other legal
+entity, you represent and warrant that you have the authority to bind that
+company or other legal entity to the Agreement and, in such event, “you” and
+“your” will refer and apply to that company or other legal entity.
+
+We reserve the right, at our sole discretion, to modify, discontinue, or
+terminate the availability of any Services, or modify this Agreement, at any
+time and without prior notice. We encourage you to check these Terms and the
+“Last updated” date above whenever you access or use the Services. By continuing
+to access or use the Services after we have posted a modification to these
+Terms, you are indicating that you agree to be bound by the modified Agreement.
+If the modified Agreement is not acceptable to you, your only recourse is to
+cease accessing or using the Services.
+
+JSR is currently provided free of charge. Deno reserves the right to change the
+JSR Offerings, to introduce new or different offerings, and to modify or
+discontinue any part of the Services, at any time and in its sole discretion.
+
+Capitalized terms not defined in these Terms shall have the meaning set forth in
+our Privacy Policy.
+
+**THE SECTIONS BELOW TITLED “BINDING ARBITRATION” AND “CLASS ACTION WAIVER”
+CONTAIN A BINDING ARBITRATION AGREEMENT AND CLASS ACTION WAIVER. THEY AFFECT
+YOUR LEGAL RIGHTS. PLEASE READ THEM CAREFULLY.**
+
+1. **DESCRIPTION OF THE SERVICES; RIGHT TO ACCESS AND USE THE SERVICES**
+
+**JSR** is a public registry for JavaScript and TypeScript packages, available
+at [https://jsr.io](https://jsr.io) and operated by Deno. JSR allows you to
+publish packages, to discover and download packages published by others, and to
+browse documentation and metadata generated from those packages. Packages
+published to JSR are publicly available and may be downloaded, cached, and
+mirrored by anyone.
+
+Subject to the terms and conditions of this Agreement, Deno hereby grants you
+during the term of this Agreement a limited, non-exclusive, non-transferable,
+non-sublicensable, revocable right, to access and use the Services.
+
+Deno reserves the right to, at any time, and without notice or liability to you:
+
+1. Block, disable, or remove any package, package version, scope, or other
+   content that, for any reason, makes the Platform unstable or violates this
+   Agreement or our [usage policy](/docs/usage-policy);
+2. Impose or change quotas, rate limits, and other limits on use of the
+   Services;
+3. Change which features are supported by the Services; and
+4. Modify or discontinue the availability of any other feature, function, or
+   content relating to the Services.
+
+You agree that we will not be liable to you or to any third party for any
+modification, suspension, or discontinuance of the Services or any part thereof.
+You are free to stop using the Services at any time.
+
+2. **ACCOUNT CREDENTIALS**
+
+   In order to use the JSR Offerings, you must be an “Authorized User”. To
+   become an Authorized User, you need to create an account on the Platform, and
+   authenticate via an identity provider such as GitHub (collectively, the
+   “Account Credentials”). When creating the account, each Authorized User must
+   provide true, accurate, current, and complete information. Each Account
+   Credential can be used by only one Authorized User. Each Authorized User is
+   responsible for the confidentiality and use of their Account Credentials,
+   including all activities that are associated with their Account Credentials.
+   Authorized Users must promptly inform us of any need to deactivate any
+   Account Credentials. Deno is under no obligation to accept any individual as
+   Authorized User, and may accept or reject any registration in its sole and
+   complete discretion. We have the right to disable any Account Credentials at
+   any time for any reason, including if in our sole discretion if we believe
+   that you have failed to comply with these Terms.
+
+3. **USE OF PERSONAL INFORMATION**
+
+Your use of the Services may involve the transmission to us of certain personal
+information. Our policies with respect to the collection and use of such
+personal information are governed according to our
+[Privacy Policy](/docs/privacy-policy), which is hereby incorporated by
+reference in its entirety.
+
+4. **INTELLECTUAL PROPERTY**
+
+The Services may contain material, such as software, text, graphics, images,
+sound recordings, audiovisual works, and other material provided by or on behalf
+of Deno (collectively referred to as the “Content”). The Content may be owned by
+us or by third parties. The Content is protected under both United States and
+foreign laws. Unauthorized use of the Content may violate copyright, trademark,
+and other laws. You have no rights in or to the Content, and you will not use
+the Content except as permitted under this Agreement. No other use is permitted
+without prior written consent from us. You must retain all copyright and other
+proprietary notices contained in the original Content on any copy you make of
+the Content. You may not sell, transfer, assign, license, sublicense, or modify
+the Content or reproduce, display, publicly perform, make a derivative version
+of, distribute, or otherwise use the Content in any way for any public or
+commercial purpose. The use or posting of the Content on any other website or in
+a networked computer environment for any purpose is expressly prohibited. For
+the avoidance of doubt, the Content does not include User Content, which is
+governed by the section titled “User Content; Usage Data; Aggregate Data” below.
+
+If you violate any part of this Agreement, your permission to access and/or use
+the Content, and the Services automatically terminates and you must immediately
+destroy any copies you have made of the Content.
+
+The trademarks, service marks, and logos of Deno and JSR (the “Deno Trademarks”)
+used and displayed on the Services are registered and unregistered trademarks or
+service marks of Deno. Other company, product, and service names located on the
+Services may be trademarks or service marks owned by others (the “Third-Party
+Trademarks,” and, collectively with Deno Trademarks, the “Trademarks”). Nothing
+on the Services should be construed as granting, by implication, estoppel, or
+otherwise, any license or right to use the Trademarks, without our prior written
+permission specific for each such use. Use of the Trademarks as part of a link
+to or from any website is prohibited unless establishment of such a link is
+approved in advance by us in writing. All goodwill generated from the use of
+Deno Trademarks inures to our benefit.
+
+Elements of the Services are protected by trade dress, trademark, unfair
+competition, and other state and federal laws and may not be copied or imitated
+in whole or in part, by any means, including, but not limited to, the use of
+framing or mirrors. None of the Content may be retransmitted without our
+express, written consent for each and every instance.
+
+5. **USER CONTENT; USAGE DATA; AGGREGATE DATA**
+
+For purposes of this Agreement, “User Content” means any data and information
+that you submit to, publish through, or otherwise make available on the
+Services, including but not limited to packages, package versions, source code,
+documentation, package metadata, and scope names; and “Usage Data” means
+anonymous, analytical data that Deno collects concerning the performance and
+your use of the Services, including, without limitation, date and time that you
+access the Services, the portions of the Services visited, the frequency and
+number of times such pages are accessed, the number of times the Services is
+used in a given time period and other usage and performance data.
+
+_Publication is public and permanent._ JSR is a public registry. When you
+publish a package to JSR, that package and all of its contents, including its
+source code, documentation, and metadata, become publicly available to anyone,
+and may be downloaded, cached, and mirrored by third parties. Published package
+versions are immutable: once a version is published, its contents cannot be
+modified or deleted. You may yank a version to discourage its use, but yanked
+versions remain available so that existing dependents continue to resolve. You
+should not publish confidential information, credentials, or personal
+information to JSR. Your User Content must comply with our
+[usage policy](/docs/usage-policy), which forms part of this Agreement.
+
+As between the parties, you own all right, title, and interest in and to your
+User Content, including all modifications, improvements, adaptations,
+enhancements, or translations made thereto, and all intellectual property rights
+therein. You hereby grant Deno a non-exclusive, worldwide, perpetual,
+irrevocable, fully paid-up, royalty-free right and license, with the right to
+grant sublicenses, to reproduce, execute, use, store, archive, modify, perform,
+display and distribute your User Content in order to operate, provide, secure,
+and promote the Services, including without limitation to host your User
+Content, to distribute it to users of the Services and through content delivery
+networks, caches, and mirrors, and to generate documentation, search indexes,
+and other derived artifacts from it. Because published package versions are
+immutable and remain available to those who depend on them, this license
+continues after termination of this Agreement and after deletion of your
+account, in each case solely to the extent necessary for Deno to continue to
+make published package versions available.
+
+You are responsible for ensuring that each package you publish is accompanied by
+license terms granting recipients the rights necessary to use it as distributed
+through the Services.
+
+Notwithstanding anything to the contrary herein, we may use, and may permit our
+third-party service providers to access and use, User Content, as well as any
+Usage Data that we may collect, in an anonymous and aggregated form (“Aggregate
+Data”) for the purposes of operating, maintaining, managing, and improving our
+products and services including the Services. Aggregate Data does not identify
+Authorized Users or any individual. You hereby agree that we may collect, use,
+publish, disseminate, transfer, and otherwise exploit such Aggregate Data.
+
+6. **COMMUNITY GUIDELINES**
+
+By accessing and/or using the Services, you hereby agree to comply with the
+following guidelines:
+
+- You will not use the Services for any unlawful purpose;
+
+- You will not access or use the Services to collect any market research for a
+  competing businesses;
+
+- You will not upload, post, e-mail, transmit, or otherwise make available any
+  content that infringes any copyright, trademark, right of publicity, or other
+  proprietary rights of any person or entity;
+
+- You will not impersonate any person or entity or falsely state or otherwise
+  misrepresent your affiliation with a person or entity;
+
+- You will not decompile, reverse engineer, disassemble, or otherwise attempt to
+  discern the source code or interface protocols of any software or other
+  products or processes accessible through the Services;
+
+- You will not remove or modify any proprietary markings or restrictive legends
+  placed on the Services;
+
+- You will not use the Services, or any portion or component thereof in
+  violation of any applicable law, in order to build a competitive product or
+  service, or for any purpose not specifically permitted in these Terms;
+
+- You will not cover, obscure, block, or in any way interfere with any
+  advertisements and/or safety features on the Services;
+
+- You will not circumvent, remove, alter, deactivate, degrade, or thwart any of
+  the protections in the Services;
+
+- You will not introduce, post, or upload to the Services any Harmful Code. As
+  used herein, “Harmful Code” means computer code, programs, or programming
+  devices that are intentionally designed to disrupt, modify, access, delete,
+  damage, deactivate, disable, harm, or otherwise impede in any manner,
+  including aesthetic disruptions or distortions, the operation of the Services,
+  or any other associated software, firmware, hardware, computer system, or
+  network (including, without limitation, “Trojan horses,” “viruses,” “worms,”
+  “time bombs,” “time locks,” “devices,” “traps,” “access codes,” or “drop dead”
+  or “trap door” devices) or any other harmful, malicious, or hidden procedures,
+  routines or mechanisms that would cause the Services to cease functioning or
+  to damage or corrupt data, storage media, programs, equipment, or
+  communications, or otherwise interfere with the operations of the Services;
+
+- You will not take any action that imposes or may impose (in our sole
+  discretion) an unreasonable or disproportionately large load on our technical
+  infrastructure; and
+
+- You will not interfere with or attempt to interrupt the proper operation of
+  the Services through the use of any virus, device, information collection or
+  transmission mechanism, software or routine, or access or attempt to gain
+  access to any data, files, or passwords related to the Services through
+  hacking, password or data mining, or any other means.
+
+Although we are not obligated to monitor access to or use of the Services, we
+have the right to do so for the purpose of operating them, to ensure compliance
+with these Terms, and to comply with applicable law or other legal requirements.
+We have the right to investigate violations of these Terms or conduct that
+affects the Services. We may also consult and cooperate with law enforcement
+authorities to prosecute Users who violate the law.
+
+If you find something that violates these guidelines or our
+[usage policy](/docs/usage-policy), please let us know, and we will review it.
+
+7. **LINKING AND CITATION OF CONTENT**
+
+Deno does not object to links on third-party Services to our homepage in an
+appropriate context. However, “framing” or “mirroring” the Services or the
+Content is prohibited without the prior express written consent of Deno.
+
+8. **RESTRICTIONS**
+
+The Services are available only for individuals aged 18 years or older. If you
+are under 18 years of age, then please do not access and/or use the Services. By
+entering into this Agreement, you represent and warrant that you are 18 years or
+older.
+
+9. **FEEDBACK**
+
+We welcome and encourage you to provide feedback, comments, and suggestions for
+improvements to the Services and our services (“Feedback”). Although we
+encourage you to e-mail us, we do not want you to, and you should not, e-mail us
+any content that contains confidential information. With respect to any Feedback
+you provide, we shall be free to use and disclose any ideas, concepts, know-how,
+techniques, or other materials contained in your Feedback for any purpose
+whatsoever, including, but not limited to, the development, production and
+marketing of products and services that incorporate such information, without
+compensation or attribution to you.
+
+10. **NO WARRANTIES; LIMITATION OF LIABILITY**
+
+THE SERVICES AND THE CONTENT ARE PROVIDED ON AN “AS IS” AND “AS AVAILABLE”
+BASIS, AND NEITHER DENO NOR DENO’S SUPPLIERS MAKE ANY WARRANTIES WITH RESPECT TO
+THE SAME OR OTHERWISE IN CONNECTION WITH THIS AGREEMENT, AND DENO HEREBY
+DISCLAIMS ANY AND ALL EXPRESS, IMPLIED, OR STATUTORY WARRANTIES, INCLUDING,
+WITHOUT LIMITATION, ANY WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, AVAILABILITY, ERROR-FREE OR UNINTERRUPTED OPERATION,
+AND ANY WARRANTIES ARISING FROM A COURSE OF DEALING, COURSE OF PERFORMANCE, OR
+USAGE OF TRADE. TO THE EXTENT THAT DENO AND DENO’S SUPPLIERS MAY NOT AS A MATTER
+OF APPLICABLE LAW DISCLAIM ANY IMPLIED WARRANTY, THE SCOPE AND DURATION OF SUCH
+WARRANTY WILL BE THE MINIMUM PERMITTED UNDER SUCH LAW.
+
+DENO DOES NOT ENDORSE, AND MAKES NO WARRANTY OR REPRESENTATION WITH RESPECT TO,
+ANY PACKAGE OR OTHER USER CONTENT PUBLISHED TO JSR BY ANY THIRD PARTY. PACKAGES
+AVAILABLE THROUGH THE SERVICES ARE PROVIDED BY THEIR RESPECTIVE PUBLISHERS, AND
+YOUR USE OF ANY SUCH PACKAGE IS AT YOUR OWN AND SOLE RISK.
+
+WITHOUT LIMITING THE FOREGOING, WE DO NOT WARRANT, GUARANTEE OR MAKE ANY
+REPRESENTATION, NOR SHALL WE BE RESPONSIBLE FOR (A) THE CORRECTNESS, ACCURACY,
+RELIABILITY, COMPLETENESS OR CURRENCY OF THE SERVICES; OR (B) ANY RESULTS
+ACHIEVED OR ACTION TAKEN BY YOU IN RELIANCE ON THE SERVICES OR THE CONTENT OR
+ALERTS PROVIDED THROUGH THE SERVICES. ANY DECISION, ACT OR OMISSION OF YOURS
+THAT IS BASED ON THE SERVICES OR THE CONTENT OR ALERTS PROVIDED THROUGH THE
+SERVICES IS AT YOUR OWN AND SOLE RISK. THE SERVICES AND THE CONTENT AND ALERTS
+PROVIDED THROUGH THE SERVICES IS PROVIDED AS A CONVENIENCE ONLY AND DOES NOT
+REPLACE THE NEED TO REVIEW ITS ACCURACY, COMPLETENESS AND CORRECTNESS.
+
+IN CONNECTION WITH ANY WARRANTY, CONTRACT, OR COMMON LAW TORT CLAIMS: (I) WE
+SHALL NOT BE LIABLE FOR ANY INCIDENTAL OR CONSEQUENTIAL DAMAGES, LOST PROFITS,
+OR DAMAGES RESULTING FROM LOST DATA OR BUSINESS INTERRUPTION RESULTING FROM THE
+USE OR INABILITY TO ACCESS AND USE THE SERVICES, EVEN IF WE HAVE BEEN ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGES; AND (II) ANY DIRECT DAMAGES THAT YOU MAY SUFFER
+AS A RESULT OF YOUR USE OF THE SERVICES, SHALL BE LIMITED TO THE GREATER OF (I)
+MONIES YOU HAVE PAID US IN CONNECTION WITH YOUR USE OF THE SERVICES DURING THE
+TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE DATE THAT GAVE RISE TO THE CLAIM OR
+(II) ONE HUNDRED DOLLARS ($100).
+
+11. **EXTERNAL SITES**
+
+The Services may contain links to third-party websites (“External Sites”). These
+links are provided solely as a convenience to you and not as an endorsement by
+us of the content on such External Sites. The content of such External Sites is
+developed and provided by others. You should contact the website administrator
+or webmaster for those External Sites if you have any concerns regarding such
+links or any content located on such External Sites. We are not responsible for
+the content of any linked External Sites and do not make any representations
+regarding the content or accuracy of materials on such External Sites. You
+should take precautions when downloading files from all websites to protect your
+computer from viruses and other destructive programs. If you decide to access
+linked External Sites, you do so at your own risk.
+
+12. **REPRESENTATIONS AND WARRANTIES**
+
+You represent and warrant that you have: (i) all rights and permissions
+necessary to provide us with or grant us access to and use of User Content, and
+to grant the license set forth in the section titled “User Content; Usage Data;
+Aggregate Data,” and (ii) obtained all necessary and appropriate consents,
+permissions, and authorizations in accordance with all applicable laws and
+regulations with respect to User Content provided hereunder.
+
+13. **INDEMNIFICATION**
+
+You will indemnify, defend, and hold Deno, its affiliates, and our and their
+respective shareholders, members, officers, directors, employees, agents, and
+representatives (collectively, “Deno Indemnitees”) harmless from and against any
+and all damages, liabilities, losses, costs, and expenses, including reasonable
+attorney’s fees (collectively, “Losses”) incurred by any Deno Indemnitee in
+connection with a third-party claim, action, or proceeding (each, a “Claim”)
+arising from your (i) breach of this Agreement, including but not limited to,
+any breach of your representations and warranties; (ii) misuse of the Services,
+and/or the Content; (iii) negligence, gross negligence, willful misconduct,
+fraud, misrepresentation or violation of law; or (iv) violation of any
+third-party right, including without limitation any copyright, trademark,
+property, or privacy right; _provided_, _however_, that the foregoing
+obligations shall be subject to our: (i) promptly notifying you of the Claim;
+(ii) providing you, at your expense, with reasonable cooperation in the defense
+of the Claim; and (iii) providing you with sole control over the defense and
+negotiations for a settlement or compromise.
+
+14. **COMPLIANCE WITH APPLICABLE LAWS**
+
+The Services are based in the United States. We make no claims concerning
+whether the Services may be viewed or be appropriate for use outside of the
+United States. If you access the Services from outside of the United States, you
+do so at your own risk. Whether inside or outside of the United States, you are
+solely responsible for ensuring compliance with the laws of your specific
+jurisdiction.
+
+15. **TERM; TERMINATION**
+
+These Terms, and your right to access and use the Services, will commence upon
+your acceptance of these Terms and will continue for the period of your use of
+the Services.
+
+We reserve the right, in our sole discretion, to restrict, suspend, or terminate
+these Terms and your access to all or any part of the Services, at any time and
+for any reason without prior notice or liability. We reserve the right to
+change, suspend, or discontinue all or any part of the Services at any time
+without prior notice or liability. The Sections “Description of the Services;
+Right to Access and Use the Services,” “Use of Personal Information,”
+“Intellectual Property,” “User Content; Usage Data; Aggregate Data,” “Feedback,”
+“No Warranties; Limitation of Liability,” “Indemnification,” “Compliance with
+Applicable Laws,” “Term; Termination,” “Binding Arbitration,” “Class Action
+Waiver,” “Equitable Relief,” “Controlling Law; Exclusive Forum,” and
+“Miscellaneous” shall survive the termination of these Terms.
+
+You may delete your account at any time from your account settings. Deleting
+your account does not remove packages you have published: as described above and
+in our [Privacy Policy](/docs/privacy-policy), published package versions are
+immutable and remain publicly available after account deletion.
+
+16. **BINDING ARBITRATION**
+
+In the event of a dispute arising under or relating to this Agreement, and/or
+the Services (each, a “Dispute”), such dispute will be finally and exclusively
+resolved by binding arbitration governed by the Federal Arbitration Act (“FAA”).
+NEITHER PARTY SHALL HAVE THE RIGHT TO LITIGATE SUCH CLAIM IN COURT OR TO HAVE A
+JURY TRIAL, EXCEPT EITHER PARTY MAY BRING ITS CLAIM IN ITS LOCAL SMALL CLAIMS
+COURT, IF PERMITTED BY THAT SMALL CLAIMS COURT RULES AND IF WITHIN SUCH COURT’S
+JURISDICTION. ARBITRATION IS DIFFERENT FROM COURT, AND DISCOVERY AND APPEAL
+RIGHTS MAY ALSO BE LIMITED IN ARBITRATION. All disputes will be resolved before
+a neutral arbitrator selected jointly by the parties, whose decision will be
+final, except for a limited right of appeal under the FAA. The arbitration shall
+be commenced and conducted by JAMS pursuant to its then current Comprehensive
+Arbitration Rules and Procedures and in accordance with the Expedited Procedures
+in those rules, or, where appropriate, pursuant to JAMS’ Streamlined Arbitration
+Rules and Procedures. All applicable JAMS’ rules and procedures are available at
+the JAMS website [www.jamsadr.com](http://www.jamsadr.com). Each party will be
+responsible for paying any JAMS filing, administrative, and arbitrator fees in
+accordance with JAMS rules. Judgment on the arbitrator’s award may be entered in
+any court having jurisdiction. This clause shall not preclude parties from
+seeking provisional remedies in aid of arbitration from a court of appropriate
+jurisdiction. The arbitration may be conducted in person, through the submission
+of documents, by phone, or online. If conducted in person, the arbitration shall
+take place in the United States county where you reside. The parties may
+litigate in court to compel arbitration, to stay a proceeding pending
+arbitration, or to confirm, modify, vacate, or enter judgment on the award
+entered by the arbitrator. The parties shall cooperate in good faith in the
+voluntary and informal exchange of all non-privileged documents and other
+information (including electronically stored information) relevant to the
+Dispute immediately after commencement of the arbitration. As set forth in
+Section 18 below, nothing in this Agreement will prevent us from seeking
+injunctive relief in any court of competent jurisdiction as necessary to protect
+our proprietary interests.
+
+17. **CLASS ACTION WAIVER**
+
+You agree that any arbitration or proceeding shall be limited to the Dispute
+between us and you individually. To the full extent permitted by law, (i) no
+arbitration or proceeding shall be joined with any other; (ii) there is no right
+or authority for any Dispute to be arbitrated or resolved on a class
+action-basis or to utilize class action procedures; and (iii) there is no right
+or authority for any Dispute to be brought in a purported representative
+capacity on behalf of the general public or any other persons. YOU AGREE THAT
+YOU MAY BRING CLAIMS AGAINST US ONLY IN YOUR INDIVIDUAL CAPACITY AND NOT AS A
+PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS OR REPRESENTATIVE PROCEEDING.
+
+18. **EQUITABLE RELIEF**
+
+You acknowledge and agree that in the event of a breach or threatened violation
+of our intellectual property rights and confidential and proprietary information
+by you, we will suffer irreparable harm and will therefore be entitled to
+injunctive relief to enforce this Agreement. We may, without waiving any other
+remedies under this Agreement, seek from any court having jurisdiction any
+interim, equitable, provisional, or injunctive relief that is necessary to
+protect our rights and property pending the outcome of the arbitration
+referenced above. You hereby irrevocably and unconditionally consent to the
+personal and subject matter jurisdiction of the federal and state courts in the
+State of New York for purposes of any such action by us.
+
+19. **CONTROLLING LAW; EXCLUSIVE FORUM**
+
+The Agreement and any action related thereto will be governed by the laws of the
+State of New York without regard to its conflict of laws provisions. The parties
+hereby consent and agree to the exclusive jurisdiction of the state and federal
+courts located in the State of New York for all suits, actions, or proceedings
+directly or indirectly arising out of or relating to this Agreement, and waive
+any and all objections to such courts, including but not limited to, objections
+based on improper venue or inconvenient forum, and each party hereby irrevocably
+submits to the exclusive jurisdiction of such courts in any suits, actions, or
+proceedings arising out of or relating to this Agreement
+
+20. **MISCELLANEOUS**
+
+    Notwithstanding anything to the contrary set forth in these Terms, each
+    party may during the term of this Agreement, use the other party’s name
+    and/or logo for marketing and promotional purposes, including, without
+    limitation, identifying Authorized Users as a user of JSR on Deno’s website
+    or elsewhere. You may not assign any of your rights, duties, or obligations
+    under these Terms to any person or entity, in whole or in part, without
+    written consent from Deno. Our failure to act on or enforce any provision of
+    the Agreement shall not be construed as a waiver of that provision or any
+    other provision in this Agreement. No waiver shall be effective against us
+    unless made in writing, and no such waiver shall be construed as a waiver in
+    any other or subsequent instance. Except as expressly agreed by us and you
+    in writing, the Agreement constitutes the entire agreement between you and
+    us with respect to the subject matter, and supersedes all previous or
+    contemporaneous agreements, whether written or oral, between the parties
+    with respect to the subject matter. The section headings are provided merely
+    for convenience and shall not be given any legal import. This Agreement will
+    inure to the benefit of our successors, assigns, licensees, and
+    sublicensees.
+
+21. **HOW TO CONTACT US**
+
+Please reach out to [help@jsr.io](mailto:help@jsr.io) for any questions
+regarding these Terms.
+
+**Copyright 2026 Deno Land Inc. All rights reserved.**

--- a/frontend/docs/terms-of-service.md
+++ b/frontend/docs/terms-of-service.md
@@ -37,16 +37,14 @@ Terms, you are indicating that you agree to be bound by the modified Agreement.
 If the modified Agreement is not acceptable to you, your only recourse is to
 cease accessing or using the Services.
 
-JSR is currently provided free of charge. Deno reserves the right to change the
-JSR Offerings, to introduce new or different offerings, and to modify or
-discontinue any part of the Services, at any time and in its sole discretion.
+JSR is provided free of charge. We do not charge for publishing, downloading, or
+any other use of the Services, and we do not sell advertising on them. Deno
+reserves the right to change the JSR Offerings, to introduce new or different
+offerings, and to modify or discontinue any part of the Services, at any time
+and in its sole discretion.
 
 Capitalized terms not defined in these Terms shall have the meaning set forth in
 our Privacy Policy.
-
-**THE SECTIONS BELOW TITLED “BINDING ARBITRATION” AND “CLASS ACTION WAIVER”
-CONTAIN A BINDING ARBITRATION AGREEMENT AND CLASS ACTION WAIVER. THEY AFFECT
-YOUR LEGAL RIGHTS. PLEASE READ THEM CAREFULLY.**
 
 1. **DESCRIPTION OF THE SERVICES; RIGHT TO ACCESS AND USE THE SERVICES**
 
@@ -61,19 +59,24 @@ Subject to the terms and conditions of this Agreement, Deno hereby grants you
 during the term of this Agreement a limited, non-exclusive, non-transferable,
 non-sublicensable, revocable right, to access and use the Services.
 
-Deno reserves the right to, at any time, and without notice or liability to you:
+Deno reserves the right to:
 
 1. Block, disable, or remove any package, package version, scope, or other
-   content that, for any reason, makes the Platform unstable or violates this
-   Agreement or our [usage policy](/docs/usage-policy);
+   content that makes the Platform unstable or violates this Agreement or our
+   [usage policy](/docs/usage-policy);
 2. Impose or change quotas, rate limits, and other limits on use of the
    Services;
 3. Change which features are supported by the Services; and
 4. Modify or discontinue the availability of any other feature, function, or
    content relating to the Services.
 
-You agree that we will not be liable to you or to any third party for any
-modification, suspension, or discontinuance of the Services or any part thereof.
+Except where content presents an immediate risk to the security or stability of
+the Platform, or where the law requires us to act without delay, we will contact
+the author before removing a package, package version, or scope, explain why we
+are considering it, and give them an opportunity to respond — ordinarily around
+three weeks. We will tell you the reason for a removal or suspension and how to
+contest it. See "Reporting, Removals, and Appeals" below.
+
 You are free to stop using the Services at any time.
 
 2. **ACCOUNT CREDENTIALS**
@@ -124,23 +127,13 @@ If you violate any part of this Agreement, your permission to access and/or use
 the Content, and the Services automatically terminates and you must immediately
 destroy any copies you have made of the Content.
 
-The trademarks, service marks, and logos of Deno and JSR (the “Deno Trademarks”)
-used and displayed on the Services are registered and unregistered trademarks or
-service marks of Deno. Other company, product, and service names located on the
-Services may be trademarks or service marks owned by others (the “Third-Party
-Trademarks,” and, collectively with Deno Trademarks, the “Trademarks”). Nothing
-on the Services should be construed as granting, by implication, estoppel, or
-otherwise, any license or right to use the Trademarks, without our prior written
-permission specific for each such use. Use of the Trademarks as part of a link
-to or from any website is prohibited unless establishment of such a link is
-approved in advance by us in writing. All goodwill generated from the use of
-Deno Trademarks inures to our benefit.
-
-Elements of the Services are protected by trade dress, trademark, unfair
-competition, and other state and federal laws and may not be copied or imitated
-in whole or in part, by any means, including, but not limited to, the use of
-framing or mirrors. None of the Content may be retransmitted without our
-express, written consent for each and every instance.
+_The JSR name and logo._ You may use the JSR name and logo freely — to say that
+your package is published on JSR, to link to the registry, to write about it, or
+in documentation, articles, talks, and tooling. You do not need our permission
+and you do not need to ask. The only thing we ask is that you do not use them in
+a way that suggests JSR published, endorsed, or maintains something it did not.
+Company, product, and service names belonging to third parties remain the
+property of their respective owners.
 
 5. **USER CONTENT; USAGE DATA; AGGREGATE DATA**
 
@@ -160,26 +153,39 @@ source code, documentation, and metadata, become publicly available to anyone,
 and may be downloaded, cached, and mirrored by third parties. Published package
 versions are immutable: once a version is published, its contents cannot be
 modified or deleted. You may yank a version to discourage its use, but yanked
-versions remain available so that existing dependents continue to resolve. You
-should not publish confidential information, credentials, or personal
+versions remain available so that existing dependents continue to resolve.
+
+We recognize that this default is not right in every case. If you have published
+something that genuinely needs to come down — a leaked credential, personal
+information, material you did not have the rights to publish, or a comparable
+mistake — contact us at [help@jsr.io](mailto:help@jsr.io) and we will work with
+you on it. We take these requests seriously and handle them case by case,
+weighing the harm of leaving the content up against the breakage that removing a
+version causes for everyone depending on it. Rotate any leaked credential
+immediately regardless, since published packages are downloaded and mirrored
+within seconds.
+
+You should not publish confidential information, credentials, or personal
 information to JSR. Your User Content must comply with our
 [usage policy](/docs/usage-policy), which forms part of this Agreement.
 
 As between the parties, you own all right, title, and interest in and to your
 User Content, including all modifications, improvements, adaptations,
 enhancements, or translations made thereto, and all intellectual property rights
-therein. You hereby grant Deno a non-exclusive, worldwide, perpetual,
-irrevocable, fully paid-up, royalty-free right and license, with the right to
-grant sublicenses, to reproduce, execute, use, store, archive, modify, perform,
-display and distribute your User Content in order to operate, provide, secure,
-and promote the Services, including without limitation to host your User
-Content, to distribute it to users of the Services and through content delivery
-networks, caches, and mirrors, and to generate documentation, search indexes,
-and other derived artifacts from it. Because published package versions are
-immutable and remain available to those who depend on them, this license
-continues after termination of this Agreement and after deletion of your
-account, in each case solely to the extent necessary for Deno to continue to
-make published package versions available.
+therein. You hereby grant Deno a non-exclusive, worldwide, royalty-free license
+to store, reproduce, and distribute your User Content, and to generate
+documentation, search indexes, and npm-compatible tarballs from it, solely in
+order to operate the Services — that is, to host your packages, to serve them to
+anyone who requests them, and to serve them through the content delivery
+networks, caches, and mirrors the registry depends on. This license exists so
+that we can run a registry; it grants us no right to relicense your work, and it
+does not affect the license you chose for your package, which is what governs
+what everybody else may do with it.
+
+Because published package versions are immutable and remain available to those
+who depend on them, this license continues after termination of this Agreement
+and after deletion of your account, in each case solely to the extent necessary
+to keep published package versions available.
 
 You are responsible for ensuring that each package you publish is accompanied by
 license terms granting recipients the rights necessary to use it as distributed
@@ -200,9 +206,6 @@ following guidelines:
 
 - You will not use the Services for any unlawful purpose;
 
-- You will not access or use the Services to collect any market research for a
-  competing businesses;
-
 - You will not upload, post, e-mail, transmit, or otherwise make available any
   content that infringes any copyright, trademark, right of publicity, or other
   proprietary rights of any person or entity;
@@ -217,12 +220,10 @@ following guidelines:
 - You will not remove or modify any proprietary markings or restrictive legends
   placed on the Services;
 
-- You will not use the Services, or any portion or component thereof in
-  violation of any applicable law, in order to build a competitive product or
-  service, or for any purpose not specifically permitted in these Terms;
+- You will not use the Services in violation of any applicable law;
 
-- You will not cover, obscure, block, or in any way interfere with any
-  advertisements and/or safety features on the Services;
+- You will not cover, obscure, block, or in any way interfere with any safety
+  features on the Services;
 
 - You will not circumvent, remove, alter, deactivate, degrade, or thwart any of
   the protections in the Services;
@@ -250,30 +251,66 @@ following guidelines:
   access to any data, files, or passwords related to the Services through
   hacking, password or data mining, or any other means.
 
-Although we are not obligated to monitor access to or use of the Services, we
-have the right to do so for the purpose of operating them, to ensure compliance
-with these Terms, and to comply with applicable law or other legal requirements.
-We have the right to investigate violations of these Terms or conduct that
-affects the Services. We may also consult and cooperate with law enforcement
-authorities to prosecute Users who violate the law.
+We do not proactively monitor the registry for violations of these Terms. We
+rely on the community to bring them to our attention, and we investigate what is
+reported to us. We retain the right to investigate conduct that affects the
+Services, and to comply with applicable law and legal process.
 
 If you find something that violates these guidelines or our
-[usage policy](/docs/usage-policy), please let us know, and we will review it.
+[usage policy](/docs/usage-policy), please tell us — see "Reporting, Removals,
+and Appeals" below.
 
-7. **LINKING AND CITATION OF CONTENT**
+7. **REPORTING, REMOVALS, AND APPEALS**
 
-Deno does not object to links on third-party Services to our homepage in an
-appropriate context. However, “framing” or “mirroring” the Services or the
-Content is prohibited without the prior express written consent of Deno.
+If you believe a package violates these Terms or our
+[usage policy](/docs/usage-policy), report it using the "Report Package" button
+on the package page, or email [help@jsr.io](mailto:help@jsr.io). We review
+everything that is reported to us.
 
-8. **RESTRICTIONS**
+_Security vulnerabilities._ Please do not report security issues in the registry
+itself through the channels above. Report them privately through
+[GitHub security advisories](https://github.com/jsr-io/jsr/security/advisories/new).
 
-The Services are available only for individuals aged 18 years or older. If you
-are under 18 years of age, then please do not access and/or use the Services. By
-entering into this Agreement, you represent and warrant that you are 18 years or
-older.
+_Copyright and other legal complaints._ If you believe a package infringes your
+copyright, trademark, or other rights, email [help@jsr.io](mailto:help@jsr.io).
+Tell us what the material is and where to find it — the scope, package, version,
+and file path — what right you hold and why you believe the use is not
+authorized, and how to reach you. Please confirm that the information you have
+given us is accurate and that you are the rights holder or authorized to act for
+them.
 
-9. **FEEDBACK**
+We review every complaint we receive. If we take material down in response to
+one, we tell the publisher what was removed and why, and they may contest it by
+replying to us; if their response resolves the matter we restore the material.
+We will terminate the accounts of repeat infringers where the circumstances
+warrant it. We may share the complaint, including your contact details, with the
+publisher of the material, so that they can respond to it.
+
+_What happens when we act._ If we remove a package, package version, or scope,
+or suspend an account, we will tell the affected publisher what we removed, why,
+and how to contest it. Except where content presents an immediate risk to the
+security or stability of the Platform, or where the law requires us to act
+without delay, we contact the author first and give them an opportunity to
+explain — ordinarily around three weeks — before removing anything. If you think
+we got it wrong, reply to us at [help@jsr.io](mailto:help@jsr.io) and a person
+will look at it again.
+
+8. **LINKING AND CITATION OF CONTENT**
+
+Link to JSR freely. Packages published to JSR are public, and you are welcome to
+download, cache, mirror, and redistribute them, subject to the license each
+package carries — running a mirror or a proxy of the registry is a legitimate
+use and we encourage it. This section is about the jsr.io website itself: do not
+frame or reproduce the site in a way designed to pass it off as your own.
+
+9. **RESTRICTIONS**
+
+The Services are not directed to children under the age of 16. If you are under
+16, please do not create an account or otherwise provide us with personal
+information; a parent or legal guardian must consent to and supervise your use
+of the Services.
+
+10. **FEEDBACK**
 
 We welcome and encourage you to provide feedback, comments, and suggestions for
 improvements to the Services and our services (“Feedback”). Although we
@@ -285,7 +322,7 @@ whatsoever, including, but not limited to, the development, production and
 marketing of products and services that incorporate such information, without
 compensation or attribution to you.
 
-10. **NO WARRANTIES; LIMITATION OF LIABILITY**
+11. **NO WARRANTIES; LIMITATION OF LIABILITY**
 
 THE SERVICES AND THE CONTENT ARE PROVIDED ON AN “AS IS” AND “AS AVAILABLE”
 BASIS, AND NEITHER DENO NOR DENO’S SUPPLIERS MAKE ANY WARRANTIES WITH RESPECT TO
@@ -317,13 +354,12 @@ IN CONNECTION WITH ANY WARRANTY, CONTRACT, OR COMMON LAW TORT CLAIMS: (I) WE
 SHALL NOT BE LIABLE FOR ANY INCIDENTAL OR CONSEQUENTIAL DAMAGES, LOST PROFITS,
 OR DAMAGES RESULTING FROM LOST DATA OR BUSINESS INTERRUPTION RESULTING FROM THE
 USE OR INABILITY TO ACCESS AND USE THE SERVICES, EVEN IF WE HAVE BEEN ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGES; AND (II) ANY DIRECT DAMAGES THAT YOU MAY SUFFER
-AS A RESULT OF YOUR USE OF THE SERVICES, SHALL BE LIMITED TO THE GREATER OF (I)
-MONIES YOU HAVE PAID US IN CONNECTION WITH YOUR USE OF THE SERVICES DURING THE
-TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE DATE THAT GAVE RISE TO THE CLAIM OR
-(II) ONE HUNDRED DOLLARS ($100).
+THE POSSIBILITY OF SUCH DAMAGES; AND (II) OUR TOTAL LIABILITY FOR ANY DIRECT
+DAMAGES THAT YOU MAY SUFFER AS A RESULT OF YOUR USE OF THE SERVICES SHALL BE
+LIMITED TO ONE HUNDRED DOLLARS ($100). JSR IS PROVIDED FREE OF CHARGE AND YOU
+PAY US NOTHING FOR IT.
 
-11. **EXTERNAL SITES**
+12. **EXTERNAL SITES**
 
 The Services may contain links to third-party websites (“External Sites”). These
 links are provided solely as a convenience to you and not as an endorsement by
@@ -337,7 +373,7 @@ should take precautions when downloading files from all websites to protect your
 computer from viruses and other destructive programs. If you decide to access
 linked External Sites, you do so at your own risk.
 
-12. **REPRESENTATIONS AND WARRANTIES**
+13. **REPRESENTATIONS AND WARRANTIES**
 
 You represent and warrant that you have: (i) all rights and permissions
 necessary to provide us with or grant us access to and use of User Content, and
@@ -346,7 +382,7 @@ Aggregate Data,” and (ii) obtained all necessary and appropriate consents,
 permissions, and authorizations in accordance with all applicable laws and
 regulations with respect to User Content provided hereunder.
 
-13. **INDEMNIFICATION**
+14. **INDEMNIFICATION**
 
 You will indemnify, defend, and hold Deno, its affiliates, and our and their
 respective shareholders, members, officers, directors, employees, agents, and
@@ -365,7 +401,7 @@ obligations shall be subject to our: (i) promptly notifying you of the Claim;
 of the Claim; and (iii) providing you with sole control over the defense and
 negotiations for a settlement or compromise.
 
-14. **COMPLIANCE WITH APPLICABLE LAWS**
+15. **COMPLIANCE WITH APPLICABLE LAWS**
 
 The Services are based in the United States. We make no claims concerning
 whether the Services may be viewed or be appropriate for use outside of the
@@ -374,76 +410,33 @@ do so at your own risk. Whether inside or outside of the United States, you are
 solely responsible for ensuring compliance with the laws of your specific
 jurisdiction.
 
-15. **TERM; TERMINATION**
+16. **TERM; TERMINATION**
 
 These Terms, and your right to access and use the Services, will commence upon
 your acceptance of these Terms and will continue for the period of your use of
 the Services.
 
-We reserve the right, in our sole discretion, to restrict, suspend, or terminate
-these Terms and your access to all or any part of the Services, at any time and
-for any reason without prior notice or liability. We reserve the right to
-change, suspend, or discontinue all or any part of the Services at any time
-without prior notice or liability. The Sections “Description of the Services;
-Right to Access and Use the Services,” “Use of Personal Information,”
-“Intellectual Property,” “User Content; Usage Data; Aggregate Data,” “Feedback,”
-“No Warranties; Limitation of Liability,” “Indemnification,” “Compliance with
-Applicable Laws,” “Term; Termination,” “Binding Arbitration,” “Class Action
-Waiver,” “Equitable Relief,” “Controlling Law; Exclusive Forum,” and
-“Miscellaneous” shall survive the termination of these Terms.
+We may restrict, suspend, or terminate your access to all or any part of the
+Services if you breach this Agreement or our usage policy, or where we are
+required to do so by law. Except where the conduct presents an immediate risk to
+the security or stability of the Platform, or where the law requires us to act
+without delay, we will tell you what the problem is and give you an opportunity
+to respond before we act, and we will tell you the reason for any suspension or
+termination and how to contest it. We may change, suspend, or discontinue parts
+of the Services as the registry evolves. The Sections “Description of the
+Services; Right to Access and Use the Services,” “Use of Personal Information,”
+“Intellectual Property,” “User Content; Usage Data; Aggregate Data,” “Reporting,
+Removals, and Appeals,” “Feedback,” “No Warranties; Limitation of Liability,”
+“Indemnification,” “Compliance with Applicable Laws,” “Term; Termination,”
+“Equitable Relief,” “Controlling Law; Exclusive Forum,” and “Miscellaneous”
+shall survive the termination of these Terms.
 
 You may delete your account at any time from your account settings. Deleting
 your account does not remove packages you have published: as described above and
 in our [Privacy Policy](/docs/privacy-policy), published package versions are
 immutable and remain publicly available after account deletion.
 
-16. **BINDING ARBITRATION**
-
-In the event of a dispute arising under or relating to this Agreement, and/or
-the Services (each, a “Dispute”), such dispute will be finally and exclusively
-resolved by binding arbitration governed by the Federal Arbitration Act (“FAA”).
-NEITHER PARTY SHALL HAVE THE RIGHT TO LITIGATE SUCH CLAIM IN COURT OR TO HAVE A
-JURY TRIAL, EXCEPT EITHER PARTY MAY BRING ITS CLAIM IN ITS LOCAL SMALL CLAIMS
-COURT, IF PERMITTED BY THAT SMALL CLAIMS COURT RULES AND IF WITHIN SUCH COURT’S
-JURISDICTION. ARBITRATION IS DIFFERENT FROM COURT, AND DISCOVERY AND APPEAL
-RIGHTS MAY ALSO BE LIMITED IN ARBITRATION. All disputes will be resolved before
-a neutral arbitrator selected jointly by the parties, whose decision will be
-final, except for a limited right of appeal under the FAA. The arbitration shall
-be commenced and conducted by JAMS pursuant to its then current Comprehensive
-Arbitration Rules and Procedures and in accordance with the Expedited Procedures
-in those rules, or, where appropriate, pursuant to JAMS’ Streamlined Arbitration
-Rules and Procedures. All applicable JAMS’ rules and procedures are available at
-the JAMS website [www.jamsadr.com](http://www.jamsadr.com). Each party will be
-responsible for paying any JAMS filing, administrative, and arbitrator fees in
-accordance with JAMS rules. Judgment on the arbitrator’s award may be entered in
-any court having jurisdiction. This clause shall not preclude parties from
-seeking provisional remedies in aid of arbitration from a court of appropriate
-jurisdiction. The arbitration may be conducted in person, through the submission
-of documents, by phone, or online. If conducted in person, the arbitration shall
-take place in the United States county where you reside. The parties may
-litigate in court to compel arbitration, to stay a proceeding pending
-arbitration, or to confirm, modify, vacate, or enter judgment on the award
-entered by the arbitrator. The parties shall cooperate in good faith in the
-voluntary and informal exchange of all non-privileged documents and other
-information (including electronically stored information) relevant to the
-Dispute immediately after commencement of the arbitration. As set forth in
-Section 18 below, nothing in this Agreement will prevent us from seeking
-injunctive relief in any court of competent jurisdiction as necessary to protect
-our proprietary interests.
-
-17. **CLASS ACTION WAIVER**
-
-You agree that any arbitration or proceeding shall be limited to the Dispute
-between us and you individually. To the full extent permitted by law, (i) no
-arbitration or proceeding shall be joined with any other; (ii) there is no right
-or authority for any Dispute to be arbitrated or resolved on a class
-action-basis or to utilize class action procedures; and (iii) there is no right
-or authority for any Dispute to be brought in a purported representative
-capacity on behalf of the general public or any other persons. YOU AGREE THAT
-YOU MAY BRING CLAIMS AGAINST US ONLY IN YOUR INDIVIDUAL CAPACITY AND NOT AS A
-PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS OR REPRESENTATIVE PROCEEDING.
-
-18. **EQUITABLE RELIEF**
+17. **EQUITABLE RELIEF**
 
 You acknowledge and agree that in the event of a breach or threatened violation
 of our intellectual property rights and confidential and proprietary information
@@ -451,12 +444,11 @@ by you, we will suffer irreparable harm and will therefore be entitled to
 injunctive relief to enforce this Agreement. We may, without waiving any other
 remedies under this Agreement, seek from any court having jurisdiction any
 interim, equitable, provisional, or injunctive relief that is necessary to
-protect our rights and property pending the outcome of the arbitration
-referenced above. You hereby irrevocably and unconditionally consent to the
-personal and subject matter jurisdiction of the federal and state courts in the
-State of New York for purposes of any such action by us.
+protect our rights and property. You hereby irrevocably and unconditionally
+consent to the personal and subject matter jurisdiction of the federal and state
+courts in the State of New York for purposes of any such action by us.
 
-19. **CONTROLLING LAW; EXCLUSIVE FORUM**
+18. **CONTROLLING LAW; EXCLUSIVE FORUM**
 
 The Agreement and any action related thereto will be governed by the laws of the
 State of New York without regard to its conflict of laws provisions. The parties
@@ -468,28 +460,24 @@ based on improper venue or inconvenient forum, and each party hereby irrevocably
 submits to the exclusive jurisdiction of such courts in any suits, actions, or
 proceedings arising out of or relating to this Agreement
 
-20. **MISCELLANEOUS**
+19. **MISCELLANEOUS**
 
-    Notwithstanding anything to the contrary set forth in these Terms, each
-    party may during the term of this Agreement, use the other party’s name
-    and/or logo for marketing and promotional purposes, including, without
-    limitation, identifying Authorized Users as a user of JSR on Deno’s website
-    or elsewhere. You may not assign any of your rights, duties, or obligations
-    under these Terms to any person or entity, in whole or in part, without
-    written consent from Deno. Our failure to act on or enforce any provision of
-    the Agreement shall not be construed as a waiver of that provision or any
-    other provision in this Agreement. No waiver shall be effective against us
-    unless made in writing, and no such waiver shall be construed as a waiver in
-    any other or subsequent instance. Except as expressly agreed by us and you
-    in writing, the Agreement constitutes the entire agreement between you and
-    us with respect to the subject matter, and supersedes all previous or
+    You may not assign any of your rights, duties, or obligations under these
+    Terms to any person or entity, in whole or in part, without written consent
+    from Deno. Our failure to act on or enforce any provision of the Agreement
+    shall not be construed as a waiver of that provision or any other provision
+    in this Agreement. No waiver shall be effective against us unless made in
+    writing, and no such waiver shall be construed as a waiver in any other or
+    subsequent instance. Except as expressly agreed by us and you in writing,
+    the Agreement constitutes the entire agreement between you and us with
+    respect to the subject matter, and supersedes all previous or
     contemporaneous agreements, whether written or oral, between the parties
     with respect to the subject matter. The section headings are provided merely
     for convenience and shall not be given any legal import. This Agreement will
     inure to the benefit of our successors, assigns, licensees, and
     sublicensees.
 
-21. **HOW TO CONTACT US**
+20. **HOW TO CONTACT US**
 
 Please reach out to [help@jsr.io](mailto:help@jsr.io) for any questions
 regarding these Terms.

--- a/frontend/docs/toc.ts
+++ b/frontend/docs/toc.ts
@@ -129,6 +129,16 @@ export default [
     group: "Reference",
   },
   {
+    title: "Terms of service",
+    id: "terms-of-service",
+    group: "Reference",
+  },
+  {
+    title: "Privacy policy",
+    id: "privacy-policy",
+    group: "Reference",
+  },
+  {
     title: "API",
     id: "api",
     group: "Reference",


### PR DESCRIPTION
Adds a Terms of Service and a Privacy Policy for JSR, and links both from the **Reference** section of the docs TOC (right after "Usage policy").

⚠️ **These documents are adapted from Deno Deploy's [Terms and Conditions](https://docs.deno.com/deploy/terms_and_conditions/) and [Privacy Policy](https://docs.deno.com/deploy/privacy_policy/), and require review by legal counsel before merging.** They were written by adapting Deno's existing texts, not drafted by a lawyer for JSR specifically. The account deletion and data retention section in particular makes concrete factual claims about what JSR retains and asserts specific legal bases for that retention — it needs to be checked against both the law and the shipped behavior.

### What was adapted

- Deploy/Subhosting product descriptions replaced with JSR: a public registry for JavaScript and TypeScript packages at https://jsr.io, operated by Deno Land Inc.
- Dropped the Paid Products paragraph and the entire FEES/Subscription section; the ToS instead states JSR is currently provided free of charge, with Deno reserving the right to change its offerings. Sections renumbered accordingly.
- Dropped Deploy-specific language (deployments, regions, V8 isolates) and the reserved right to "change the regions in which the Services run", replaced with registry-appropriate rights (blocking packages/versions/scopes, changing quotas and limits).
- "User Data" reworked into **User Content**: publishing makes content public, published versions are immutable, and you grant Deno a license to host and distribute your content — surviving account deletion to the extent needed to keep published versions available. References the existing [usage policy](https://jsr.io/docs/usage-policy).
- Account credentials now describe authentication via an identity provider such as GitHub.
- Contact email is help@jsr.io throughout. Deno Land Inc.'s San Diego mailing address is kept in the privacy policy.
- Arbitration, class action waiver, NY governing law, warranty disclaimers, limitation of liability, and indemnification are kept essentially verbatim.

### Account deletion and data retention (new — needs the closest legal review)

Section V of the privacy policy discloses the behavior introduced in #1331:

- **Hard-deleted:** name, email address, avatar.
- **Retained as a pseudonymous tombstone:** the internal account UUID (`meta.original_actor_id` on the user's former audit entries) and the identity-provider numeric IDs (`github_id`, `gitlab_id`) in the `user_delete` audit entry, so the account can be re-identified through the provider if legally required. Stated retention bases: GDPR Art. 17(3)(b) and 17(3)(e), and CCPA §1798.105(d).
- **Reassigned to the system service account:** audit log entries, and support tickets/messages.
- **Published packages:** immutable and remain public after deletion, including any personal information the publisher included in package contents or metadata. Sole-owned scopes transfer to the service account; scopes with other members transfer to another member.
- **Deletion holds:** the admin-settable `deletion_hold` flag blocks account deletion while a legal or moderation matter is pending (evidence preservation / litigation hold).

### Judgment calls worth a look

- I disclosed the **support ticket / ticket message reassignment** to the service account as well. It wasn't in the original list of behaviors to document, but `delete_user` does reassign `tickets` and `ticket_messages`, and leaving a real retention behavior out of the policy seemed like the wrong default. Drop it if you'd rather keep the section narrower.
- I **dropped the DPA reference** from the ToS preamble. Deno's terms incorporate a Data Processing Addendum, which as far as I can tell doesn't exist for JSR; referencing a non-existent document seemed worse than omitting it. Restore it if a DPA does apply.
- Dates are set to today and the copyright lines to 2026 — adjust to whatever the actual effective date should be.
- The limitation of liability clause is kept verbatim, including the "monies you have paid us in the preceding twelve months" prong, which for a free service means the $100 floor always governs. Left as-is deliberately, but it reads oddly for a free registry.

`deno fmt` and `deno task lint:frontend` both pass.

Opened as a draft — this shouldn't merge until counsel has signed off.
