### PR TITLE
fix(api): minimize personal data in telemetry

### DIFF
--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -254,7 +254,7 @@ impl Database {
   #[instrument(name = "Database::upsert_user_by_github_id", skip(
     self,
     new_user
-  ), err, fields(user.name = new_user.name, user.email = new_user.email, user.avatar_url = new_user.avatar_url, user.github_id = new_user.github_id, user.is_blocked = new_user.is_blocked, user.is_staff = new_user.is_staff
+  ), err, fields(user.github_id = new_user.github_id, user.is_blocked = new_user.is_blocked, user.is_staff = new_user.is_staff
   ))]
   pub async fn upsert_user_by_github_id(
     &self,
@@ -282,7 +282,7 @@ impl Database {
   #[instrument(name = "Database::upsert_user_by_gitlab_id", skip(
     self,
     new_user
-  ), err, fields(user.name = new_user.name, user.email = new_user.email, user.avatar_url = new_user.avatar_url, user.github_id = new_user.github_id, user.gitlab_id = new_user.gitlab_id, user.is_blocked = new_user.is_blocked, user.is_staff = new_user.is_staff
+  ), err, fields(user.github_id = new_user.github_id, user.gitlab_id = new_user.gitlab_id, user.is_blocked = new_user.is_blocked, user.is_staff = new_user.is_staff
   ))]
   pub async fn upsert_user_by_gitlab_id(
     &self,


### PR DESCRIPTION
## Summary

Stop attaching OAuth profile fields to the production user-upsert tracing spans.

The GitHub and GitLab upsert spans no longer export:

- display name
- email address
- avatar URL

They retain the identity-provider numeric ID and operational account flags, which are sufficient to correlate authentication failures without duplicating the full profile in observability storage. The complete new_user value was already excluded by skip(new_user).

This changes telemetry only. It does not alter account data stored in PostgreSQL, authentication behavior, or API responses.

## Motivation

This is the telemetry-minimization follow-up identified while reviewing the JSR Terms and Privacy Notice in #1495, specifically [review comment 5374905980](https://github.com/jsr-io/jsr/pull/1495#issuecomment-5374905980). Keeping profile data out of exported spans reduces the number of systems and retention paths containing it.

The test-only insert_user instrumentation is unchanged because that method is compiled only under cfg(test) and is not part of production Grafana export.

## Verification

- cargo fmt --check
- cargo check --tests
- git diff --check

### PR checklist

- [x] Conventional-commit title
- [x] Full description and rationale
- [x] Backend change compiles with test targets
- [x] No database query or schema changes
