### PR TITLE
feat: add repository information to metadata endpoints

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -488,8 +488,7 @@ pub async fn update_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
   }
 
   // Every update variant mutates the aggressively-cached `:package` response,
-  // so cache-bust it (and the scope aggregates) afterwards. Built before the
-  // match because the GitHub-repository arm consumes `scope`/`package_name`.
+  // so cache-bust it (and the scope aggregates) afterwards.
   let registry_url = req.data::<RegistryUrl>().unwrap().0.clone();
   let purge_urls = crate::s3_paths::package_api_cache_urls(
     &registry_url,
@@ -497,7 +496,7 @@ pub async fn update_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
     &package_name,
   );
 
-  let result = match body {
+  let result: Result<ApiPackage, ApiError> = match body {
     ApiUpdatePackageRequest::Description(description) => {
       let npm_url = &req.data::<NpmUrl>().unwrap().0;
       let buckets = req.data::<Buckets>().unwrap().clone();
@@ -518,25 +517,56 @@ pub async fn update_handler(mut req: Request<Body>) -> ApiResult<ApiPackage> {
       Ok(ApiPackage::from((package, repo, meta)))
     }
     ApiUpdatePackageRequest::GithubRepository(None) => {
+      let npm_url = &req.data::<NpmUrl>().unwrap().0;
+      let buckets = req.data::<Buckets>().unwrap();
+      let cache_purge = req.data::<CachePurge>().unwrap();
       let package = db
         .delete_package_github_repository(&user.id, sudo, &scope, &package_name)
         .await?;
+      // The GitHub repository is embedded in the package `meta.json` and the
+      // npm compatibility manifest, so regenerate them.
+      upload_package_manifests(
+        db,
+        buckets,
+        &registry_url,
+        npm_url,
+        cache_purge,
+        &scope,
+        &package_name,
+      )
+      .await?;
       Ok(ApiPackage::from((package, None, meta)))
     }
     ApiUpdatePackageRequest::GithubRepository(Some(repo)) => {
+      let npm_url = &req.data::<NpmUrl>().unwrap().0;
+      let buckets = req.data::<Buckets>().unwrap();
+      let cache_purge = req.data::<CachePurge>().unwrap();
       let github_oauth2_client =
         req.data::<auth::github::Oauth2Client>().unwrap();
-      update_github_repository(
+      let package = update_github_repository(
         &user.id,
         sudo,
         user,
         db,
         github_oauth2_client,
-        scope,
-        package_name,
+        &scope,
+        &package_name,
         repo,
       )
-      .await
+      .await?;
+      // The GitHub repository is embedded in the package `meta.json` and the
+      // npm compatibility manifest, so regenerate them.
+      upload_package_manifests(
+        db,
+        buckets,
+        &registry_url,
+        npm_url,
+        cache_purge,
+        &scope,
+        &package_name,
+      )
+      .await?;
+      Ok(package)
     }
     ApiUpdatePackageRequest::RuntimeCompat(runtime_compat) => {
       let runtime_compat: RuntimeCompat = runtime_compat.into();
@@ -701,8 +731,8 @@ async fn update_github_repository(
   user: &User,
   db: &Database,
   github_oauth2_client: &auth::github::Oauth2Client,
-  scope: ScopeName,
-  package: PackageName,
+  scope: &ScopeName,
+  package: &PackageName,
   req: ApiUpdatePackageGithubRepositoryRequest,
 ) -> Result<ApiPackage, ApiError> {
   let gh_user_id = user.github_id.ok_or_else(|| {
@@ -745,11 +775,67 @@ async fn update_github_repository(
 
   let (package, repo, score) = db
     .update_package_github_repository(
-      actor_id, is_sudo, &scope, &package, new_repo,
+      actor_id, is_sudo, scope, package, new_repo,
     )
     .await?;
 
   Ok(ApiPackage::from((package, Some(repo), score)))
+}
+
+/// Regenerates the package-level `meta.json` and the npm compatibility
+/// version manifest from the current database state, uploads them to their
+/// buckets, and purges their CDN cache entries.
+async fn upload_package_manifests(
+  db: &Database,
+  buckets: &Buckets,
+  registry_url: &Url,
+  npm_url: &Url,
+  cache_purge: &CachePurge,
+  scope: &ScopeName,
+  package: &PackageName,
+) -> Result<(), ApiError> {
+  let package_metadata_path = crate::s3_paths::package_metadata(scope, package);
+  let package_metadata = PackageMetadata::create(db, scope, package).await?;
+  let content = serde_json::to_vec(&package_metadata)?;
+  buckets
+    .modules_bucket
+    .upload(
+      package_metadata_path.into(),
+      UploadTaskBody::Bytes(content.into()),
+      S3UploadOptions {
+        content_type: Some("application/json".into()),
+        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
+        gzip_encoded: false,
+      },
+    )
+    .await?;
+
+  let npm_version_manifest_path =
+    crate::s3_paths::npm_version_manifest_path(scope, package);
+  let npm_version_manifest =
+    generate_npm_version_manifest(db, npm_url, scope, package).await?;
+  let content = serde_json::to_vec_pretty(&npm_version_manifest)?;
+  buckets
+    .npm_bucket
+    .upload(
+      npm_version_manifest_path.into(),
+      UploadTaskBody::Bytes(content.into()),
+      S3UploadOptions {
+        content_type: Some("application/json".into()),
+        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
+        gzip_encoded: false,
+      },
+    )
+    .await?;
+
+  cache_purge
+    .purge(vec![
+      crate::s3_paths::package_metadata_url(registry_url, scope, package),
+      crate::s3_paths::npm_version_manifest_url(npm_url, scope, package),
+    ])
+    .await;
+
+  Ok(())
 }
 
 #[instrument(
@@ -1175,52 +1261,24 @@ pub async fn version_update_handler(
   )
   .await?;
 
-  let package_metadata_path =
-    crate::s3_paths::package_metadata(&scope, &package);
-  let package_metadata = PackageMetadata::create(db, &scope, &package).await?;
-
-  let content = serde_json::to_vec(&package_metadata)?;
-  buckets
-    .modules_bucket
-    .upload(
-      package_metadata_path.into(),
-      UploadTaskBody::Bytes(content.into()),
-      S3UploadOptions {
-        content_type: Some("application/json".into()),
-        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
-        gzip_encoded: false,
-      },
-    )
-    .await?;
-
-  let npm_version_manifest_path =
-    crate::s3_paths::npm_version_manifest_path(&scope, &package);
-  let npm_version_manifest =
-    generate_npm_version_manifest(db, npm_url, &scope, &package).await?;
-  let content = serde_json::to_vec_pretty(&npm_version_manifest)?;
-  buckets
-    .npm_bucket
-    .upload(
-      npm_version_manifest_path.into(),
-      crate::s3::UploadTaskBody::Bytes(content.into()),
-      S3UploadOptions {
-        content_type: Some("application/json".into()),
-        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
-        gzip_encoded: false,
-      },
-    )
-    .await?;
-
-  let mut purge_urls = vec![
-    crate::s3_paths::package_metadata_url(registry_url, &scope, &package),
-    crate::s3_paths::npm_version_manifest_url(npm_url, &scope, &package),
-  ];
-  purge_urls.extend(crate::s3_paths::package_api_cache_urls(
+  upload_package_manifests(
+    db,
+    &buckets,
     registry_url,
+    npm_url,
+    cache_purge,
     &scope,
     &package,
-  ));
-  cache_purge.purge(purge_urls).await;
+  )
+  .await?;
+
+  cache_purge
+    .purge(crate::s3_paths::package_api_cache_urls(
+      registry_url,
+      &scope,
+      &package,
+    ))
+    .await;
 
   Ok(
     Response::builder()
@@ -1280,52 +1338,24 @@ pub async fn version_delete_handler(
     crate::s3_paths::file_path_root_directory(&scope, &package, &version);
   buckets.modules_bucket.delete_directory(path.into()).await?;
 
-  let package_metadata_path =
-    crate::s3_paths::package_metadata(&scope, &package);
-  let package_metadata = PackageMetadata::create(db, &scope, &package).await?;
-
-  let content = serde_json::to_vec(&package_metadata)?;
-  buckets
-    .modules_bucket
-    .upload(
-      package_metadata_path.into(),
-      UploadTaskBody::Bytes(content.into()),
-      S3UploadOptions {
-        content_type: Some("application/json".into()),
-        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
-        gzip_encoded: false,
-      },
-    )
-    .await?;
-
-  let npm_version_manifest_path =
-    crate::s3_paths::npm_version_manifest_path(&scope, &package);
-  let npm_version_manifest =
-    generate_npm_version_manifest(db, npm_url, &scope, &package).await?;
-  let content = serde_json::to_vec_pretty(&npm_version_manifest)?;
-  buckets
-    .npm_bucket
-    .upload(
-      npm_version_manifest_path.into(),
-      crate::s3::UploadTaskBody::Bytes(content.into()),
-      S3UploadOptions {
-        content_type: Some("application/json".into()),
-        cache_control: Some(CACHE_CONTROL_MANIFEST.into()),
-        gzip_encoded: false,
-      },
-    )
-    .await?;
-
-  let mut purge_urls = vec![
-    crate::s3_paths::package_metadata_url(registry_url, &scope, &package),
-    crate::s3_paths::npm_version_manifest_url(npm_url, &scope, &package),
-  ];
-  purge_urls.extend(crate::s3_paths::package_api_cache_urls(
+  upload_package_manifests(
+    db,
+    &buckets,
     registry_url,
+    npm_url,
+    cache_purge,
     &scope,
     &package,
-  ));
-  cache_purge.purge(purge_urls).await;
+  )
+  .await?;
+
+  cache_purge
+    .purge(crate::s3_paths::package_api_cache_urls(
+      registry_url,
+      &scope,
+      &package,
+    ))
+    .await;
 
   Ok(
     Response::builder()
@@ -3687,6 +3717,110 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     resp
       .expect_err_code(StatusCode::NOT_FOUND, "packageNotFound")
       .await;
+  }
+
+  #[tokio::test]
+  async fn package_manifests_include_github_repository() {
+    let mut t = TestSetup::new().await;
+
+    let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;
+    assert_eq!(
+      task.status,
+      PublishingTaskStatus::Success,
+      "{:?}",
+      task.error
+    );
+
+    let scope = t.scope.scope.clone();
+    let name = PackageName::try_from("foo").unwrap();
+
+    let download_meta_json = |t: &TestSetup| {
+      let bucket = t.buckets.modules_bucket.clone();
+      async move {
+        let json = bucket
+          .download("@scope/foo/meta.json".into())
+          .await
+          .unwrap()
+          .unwrap();
+        serde_json::from_slice::<serde_json::Value>(&json).unwrap()
+      }
+    };
+    let download_npm_manifest = |t: &TestSetup| {
+      let bucket = t.buckets.npm_bucket.clone();
+      async move {
+        let json = bucket
+          .download("@jsr/scope__foo".into())
+          .await
+          .unwrap()
+          .unwrap();
+        serde_json::from_slice::<serde_json::Value>(&json).unwrap()
+      }
+    };
+
+    // No repository is linked yet, so the manifests don't contain one.
+    let meta_json = download_meta_json(&t).await;
+    assert!(meta_json.get("githubRepository").is_none());
+    let npm_json = download_npm_manifest(&t).await;
+    assert!(npm_json.get("repository").is_none());
+
+    t.ephemeral_database
+      .update_package_github_repository(
+        &t.user1.user.id,
+        false,
+        &scope,
+        &name,
+        NewGithubRepository {
+          id: 42,
+          owner: "octocat",
+          name: "hello-world",
+        },
+      )
+      .await
+      .unwrap();
+
+    // Yank state updates regenerate the manifests, which now include the
+    // linked repository.
+    let mut resp = t
+      .http()
+      .patch("/api/scopes/scope/packages/foo/versions/1.2.3")
+      .body_json(json!({ "yanked": false }))
+      .call()
+      .await
+      .unwrap();
+    resp.expect_ok_no_content().await;
+
+    let meta_json = download_meta_json(&t).await;
+    assert_eq!(
+      meta_json.get("githubRepository").unwrap(),
+      &json!({ "owner": "octocat", "name": "hello-world" })
+    );
+    let npm_json = download_npm_manifest(&t).await;
+    let expected_repository = json!({
+      "type": "git",
+      "url": "git+https://github.com/octocat/hello-world.git"
+    });
+    assert_eq!(npm_json.get("repository").unwrap(), &expected_repository);
+    assert_eq!(
+      npm_json["versions"]["1.2.3"].get("repository").unwrap(),
+      &expected_repository
+    );
+
+    // Unlinking the repository regenerates the manifests without it.
+    let mut resp = t
+      .http()
+      .patch("/api/scopes/scope/packages/foo")
+      .body_json(json!({ "githubRepository": null }))
+      .call()
+      .await
+      .unwrap();
+    let package: ApiPackage = resp.expect_ok().await;
+    assert!(package.github_repository.is_none());
+
+    let meta_json = download_meta_json(&t).await;
+    assert!(meta_json.get("githubRepository").is_none());
+    let npm_json = download_npm_manifest(&t).await;
+    assert!(npm_json.get("repository").is_none());
+    assert!(npm_json["versions"]["1.2.3"].get("repository").is_none());
   }
 
   #[tokio::test]

--- a/api/src/metadata.rs
+++ b/api/src/metadata.rs
@@ -15,6 +15,10 @@ use std::collections::HashMap;
 /// {
 ///   "scope": "ry",
 ///   "name": "foo",
+///   "githubRepository": {
+///     "owner": "ry",
+///     "name": "foo"
+///   },
 ///   "versions": {
 ///     "0.1.2": {
 ///       "yanked": true,
@@ -32,7 +36,19 @@ pub struct PackageMetadata {
   pub scope: ScopeName,
   pub name: PackageName,
   pub latest: Option<Version>,
+  #[serde(
+    rename = "githubRepository",
+    skip_serializing_if = "Option::is_none",
+    default
+  )]
+  pub github_repository: Option<PackageMetadataGithubRepository>,
   pub versions: HashMap<Version, PackageMetadataVersion>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PackageMetadataGithubRepository {
+  pub owner: String,
+  pub name: String,
 }
 
 impl PackageMetadata {
@@ -41,6 +57,10 @@ impl PackageMetadata {
     scope: &ScopeName,
     package_name: &PackageName,
   ) -> anyhow::Result<Self> {
+    let (_, github_repository, _) =
+      db.get_package(scope, package_name).await?.ok_or_else(|| {
+        anyhow::anyhow!("package not found: @{scope}/{package_name}")
+      })?;
     let mut versions = db
       .list_package_versions_for_metadata(scope, package_name)
       .await?;
@@ -53,6 +73,12 @@ impl PackageMetadata {
       scope: scope.to_owned(),
       name: package_name.to_owned(),
       latest,
+      github_repository: github_repository.map(|repo| {
+        PackageMetadataGithubRepository {
+          owner: repo.owner,
+          name: repo.name,
+        }
+      }),
       versions: HashMap::new(),
     };
     for version in versions {

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -25,6 +25,7 @@ use crate::ids::Version;
 use crate::npm::tarball::create_npm_dependencies;
 use crate::npm::types::NpmDistInfo;
 use crate::npm::types::NpmPackageInfo;
+use crate::npm::types::NpmRepositoryInfo;
 
 pub use self::tarball::NpmTarball;
 pub use self::tarball::NpmTarballFiles;
@@ -41,10 +42,15 @@ pub async fn generate_npm_version_manifest<'a>(
   scope: &'a ScopeName,
   name: &'a PackageName,
 ) -> Result<NpmPackageInfo<'a>, anyhow::Error> {
-  let (package, _, _) = db
+  let (package, github_repository, _) = db
     .get_package(scope, name)
     .await?
     .ok_or_else(|| anyhow::anyhow!("package not found: @{scope}/{name}"))?;
+
+  let repository = github_repository.map(|repo| NpmRepositoryInfo {
+    repository_type: "git".to_string(),
+    url: format!("git+https://github.com/{}/{}.git", repo.owner, repo.name),
+  });
 
   let versions = db
     .list_package_versions_for_npm_version_manifest(scope, name)
@@ -70,6 +76,7 @@ pub async fn generate_npm_version_manifest<'a>(
       package: name,
     },
     description: package.description.clone(),
+    repository: repository.clone(),
     dist_tags: IndexMap::new(),
     versions: IndexMap::new(),
     time: IndexMap::new(),
@@ -136,6 +143,7 @@ pub async fn generate_npm_version_manifest<'a>(
       },
       version: version.version.clone(),
       description: package.description.clone(),
+      repository: repository.clone(),
       dist: NpmDistInfo {
         tarball: tarball.to_string(),
         shasum: version.npm_tarball_sha1,

--- a/api/src/npm/types.rs
+++ b/api/src/npm/types.rs
@@ -43,12 +43,21 @@ pub struct NpmDistInfo {
   pub integrity: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct NpmRepositoryInfo {
+  #[serde(rename = "type")]
+  pub repository_type: String,
+  pub url: String,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NpmVersionInfo<'a> {
   pub name: NpmMappedJsrPackageName<'a>,
   pub version: Version,
   pub description: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub repository: Option<NpmRepositoryInfo>,
   pub dist: NpmDistInfo,
   pub dependencies: IndexMap<String, String>,
 }
@@ -57,6 +66,8 @@ pub struct NpmVersionInfo<'a> {
 pub struct NpmPackageInfo<'a> {
   pub name: NpmMappedJsrPackageName<'a>,
   pub description: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub repository: Option<NpmRepositoryInfo>,
   #[serde(rename = "dist-tags")]
   pub dist_tags: IndexMap<String, Version>,
   pub versions: IndexMap<Version, NpmVersionInfo<'a>>,

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -72,12 +72,20 @@ Each version in the metadata contains information about the version, such as the
 yanked status, and the `exports` field for the package version. The `exports`
 field is normalized to simple object form.
 
+If the package has a linked GitHub repository, the metadata additionally
+contains a `githubRepository` field with the `owner` and `name` of the linked
+repository.
+
 For the above `@luca/flag` package, the metadata would look like this:
 
 ```json
 {
   "scope": "luca",
   "name": "flag",
+  "githubRepository": {
+    "owner": "lucacasonato",
+    "name": "flag"
+  },
   "versions": {
     "1.0.0": {
       "yanked": true
@@ -169,6 +177,9 @@ fields:
 
 - `name`: The npm compatibility name of the package.
 - `description`: The package description.
+- `repository`: The linked GitHub repository of the package, in npm's
+  `repository` format. Only present if the package has a linked GitHub
+  repository.
 - `dist-tags`: The `latest` version of the package.
 - `versions`: A map of versions to version metadata.
 - `time`: A map of versions to publish timestamps.
@@ -180,6 +191,9 @@ fields:
 - `name`: The npm compatibility name of the package.
 - `version`: The version of the package.
 - `description`: The package description.
+- `repository`: The linked GitHub repository of the package, in npm's
+  `repository` format. Only present if the package has a linked GitHub
+  repository.
 - `dist`: The `dist` field for the package version. This contains the tarball
   URL for the package version, and the checksums / integrity hashes for the
   tarball.


### PR DESCRIPTION
Fixes #1031

Adds the linked GitHub repository of a package to both registry metadata endpoints so tools consuming them (e.g. depfu) can discover the source repository:

- **npm compatibility endpoint** (`npm.jsr.io/@jsr/scope__pkg`): adds the npm-standard `repository` field at the package level and per version:
  ```json
  "repository": { "type": "git", "url": "git+https://github.com/owner/repo.git" }
  ```
- **native JSR endpoint** (`jsr.io/@scope/pkg/meta.json`): adds a `githubRepository` field:
  ```json
  "githubRepository": { "owner": "owner", "name": "repo" }
  ```

Both fields are omitted entirely when the package has no linked repository, so existing consumers are unaffected.

Since these documents are cached in the buckets/CDN, linking or unlinking a GitHub repository via `PATCH /api/scopes/:scope/packages/:package` now regenerates both documents and purges their cache entries. The upload-and-purge logic that was previously duplicated verbatim in the yank and version-delete handlers is extracted into a shared `upload_package_manifests` helper and reused in all four places.

Also documents the new fields in `frontend/docs/api.md` and adds a test covering the full lifecycle (no repo → linked → unlinked).

Note: this intentionally does not add `repository` to the `package.json` inside published npm tarballs, as that would require an `NPM_TARBALL_REVISION` bump and regeneration of all tarballs; the issue only concerns the metadata endpoints.