### PR TITLE
chore: update deno_doc to 0.204.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.203.0"
+version = "0.204.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77987b58779235c841893c3434dd7ce9eadd64fd53695fe2ddd99210e951c97"
+checksum = "05c121a45c4001f3b89cc7af2e3cab71514db6807ded0c9a0317b118d3d3fe87"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.201.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbfdb2c55ab195429d00c54d44da0f57d72ee36dff54e6c8de1a594b5ec26e0"
+checksum = "b77987b58779235c841893c3434dd7ce9eadd64fd53695fe2ddd99210e951c97"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.109.0"
+version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1634ebdfde4f040b2c40f2510969e755e5b782319a01dc9cab88ef25b7e3f"
+checksum = "f95ac3cf9d132772c24beabf61d76f6706b7d5a23cca6d3d3f4cf2d30a7ad796"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -95,10 +95,10 @@ flate2 = "1"
 thiserror = "2"
 async-tar = "0.4.2"
 async-compression = { version = "0.4", features = ["futures-io", "gzip"] }
-deno_graph = "=0.109.0"
+deno_graph = "=0.110.2"
 deno_ast = { version = "0.53.0", features = ["view"] }
 # sync with frontend/deno.json
-deno_doc = { version = "=0.201.0", features = ["comrak"] }
+deno_doc = { version = "=0.203.0", features = ["comrak"] }
 deno_error = "0.7.0"
 comrak = { version = "0.29.0", default-features = false }
 ammonia = "4.0.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -98,7 +98,7 @@ async-compression = { version = "0.4", features = ["futures-io", "gzip"] }
 deno_graph = "=0.110.2"
 deno_ast = { version = "0.53.0", features = ["view"] }
 # sync with frontend/deno.json
-deno_doc = { version = "=0.203.0", features = ["comrak"] }
+deno_doc = { version = "=0.204.0", features = ["comrak"] }
 deno_error = "0.7.0"
 comrak = { version = "0.29.0", default-features = false }
 ammonia = "4.0.0"

--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -167,6 +167,8 @@ async fn analyze_package_inner(
         unstable_text_imports: false,
         jsr_metadata_store: None,
         unstable_css_imports: false,
+        unstable_config_imports: false,
+        prefer_cached_jsr_versions: false,
       },
     )
     .await;
@@ -658,6 +660,8 @@ async fn rebuild_npm_tarball_inner(
         unstable_text_imports: false,
         jsr_metadata_store: None,
         unstable_css_imports: false,
+        unstable_config_imports: false,
+        prefer_cached_jsr_versions: false,
       },
     )
     .await;

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -2526,6 +2526,8 @@ async fn analyze_deps_tree(
         jsr_metadata_store: None,
 
         unstable_css_imports: false,
+        unstable_config_imports: false,
+        prefer_cached_jsr_versions: false,
       },
     )
     .await;
@@ -4403,6 +4405,43 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     resp
       .expect_err_code(StatusCode::NOT_FOUND, "diffDisabled")
       .await;
+  }
+
+  #[tokio::test]
+  async fn test_package_docs_merged_export_name() {
+    let mut t = TestSetup::new().await;
+
+    let task =
+      process_tarball_setup(&t, create_mock_tarball("merged_export_name"))
+        .await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
+
+    // `ArrayExpression` is both a re-exported function (through a value
+    // `export *`) and an interface (through an `export type *`); the symbol
+    // page must show both.
+    let mut resp = t
+      .http()
+      .get(
+        "/api/scopes/scope/packages/foo/versions/1.2.3/docs?symbol=ArrayExpression",
+      )
+      .call()
+      .await
+      .unwrap();
+    let docs: ApiPackageVersionDocs = resp.expect_ok().await;
+    match docs {
+      ApiPackageVersionDocs::Content { main, .. } => {
+        let main = serde_json::to_string(&main).unwrap();
+        assert!(
+          main.contains("builder function"),
+          "function part missing from symbol page: {main}"
+        );
+        assert!(
+          main.contains("node interface"),
+          "interface part missing from symbol page: {main}"
+        );
+      }
+      ApiPackageVersionDocs::Redirect { .. } => panic!(),
+    }
   }
 
   #[tokio::test]

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -925,6 +925,49 @@ pub fn render_docs_html(
   }
 }
 
+/// Resolves the references of a doc node, keeping any non-reference
+/// declarations alongside the resolved targets so they are not lost (e.g. an
+/// interface merged with a same-named function re-exported through
+/// `export *`).
+fn resolve_doc_node_references(
+  ctx: &GenerateCtx,
+  node: DocNodeWithContext,
+) -> Vec<DocNodeWithContext> {
+  if !node
+    .declarations
+    .iter()
+    .any(|decl| decl.reference_def().is_some())
+  {
+    return vec![node];
+  }
+
+  let mut nodes = Vec::new();
+  for decl in &node.declarations {
+    if let Some(reference) = decl.reference_def() {
+      nodes.extend(
+        ctx
+          .resolve_reference(node.parent.as_deref(), &reference.target)
+          .map(|resolved| resolved.into_owned()),
+      );
+    }
+  }
+
+  let non_reference_decls = node
+    .declarations
+    .iter()
+    .filter(|decl| decl.reference_def().is_none())
+    .cloned()
+    .collect::<Vec<_>>();
+  if !non_reference_decls.is_empty() {
+    let mut stripped = node;
+    std::sync::Arc::make_mut(&mut stripped.inner).declarations =
+      non_reference_decls;
+    nodes.push(stripped);
+  }
+
+  nodes
+}
+
 fn generate_symbol_page(
   ctx: &GenerateCtx,
   short_path: &ShortPath,
@@ -944,20 +987,7 @@ fn generate_symbol_page(
           decl.declaration_kind == deno_doc::node::DeclarationKind::Private
         }) && node.get_name() == next_part
       })
-      .flat_map(|node| {
-        if let Some(reference) = node
-          .declarations
-          .iter()
-          .find_map(|decl| decl.reference_def())
-        {
-          ctx
-            .resolve_reference(node.parent.as_deref(), &reference.target)
-            .map(|node| node.into_owned())
-            .collect::<Vec<_>>()
-        } else {
-          vec![node.clone()]
-        }
-      })
+      .flat_map(|node| resolve_doc_node_references(ctx, node.clone()))
       .collect::<Vec<_>>();
 
     if name_parts.peek().is_some() {
@@ -1146,20 +1176,7 @@ fn generate_symbol_page(
 
     nodes = nodes
       .into_iter()
-      .flat_map(|node| {
-        if let Some(reference) = node
-          .declarations
-          .iter()
-          .find_map(|decl| decl.reference_def())
-        {
-          ctx
-            .resolve_reference(node.parent.as_deref(), &reference.target)
-            .map(|node| node.into_owned())
-            .collect::<Vec<_>>()
-        } else {
-          vec![node]
-        }
-      })
+      .flat_map(|node| resolve_doc_node_references(ctx, node))
       .collect::<Vec<_>>();
 
     if name_parts.peek().is_none() {
@@ -1202,6 +1219,32 @@ fn generate_symbol_page(
     return None;
   }
 
+  // One symbol name can produce multiple doc nodes (e.g. a resolved
+  // re-export alongside a same-named interface merged through `export *`);
+  // combine their declarations so the page shows all of them. Prefer the
+  // node carrying the requested name as the base so the page keeps it.
+  let doc_node = if doc_nodes.len() == 1 {
+    doc_nodes[0].clone()
+  } else {
+    let requested_name = name.rsplit('.').next().unwrap();
+    let mut merged = doc_nodes
+      .iter()
+      .find(|node| node.get_name() == requested_name)
+      .unwrap_or(&doc_nodes[0])
+      .clone();
+    let mut declarations = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for node in &doc_nodes {
+      for decl in &node.declarations {
+        if seen.insert((decl.location.clone(), decl.def.to_kind())) {
+          declarations.push(decl.clone());
+        }
+      }
+    }
+    std::sync::Arc::make_mut(&mut merged.inner).declarations = declarations;
+    merged
+  };
+
   let render_ctx = RenderContext::new(
     ctx,
     doc_nodes_for_module,
@@ -1212,7 +1255,7 @@ fn generate_symbol_page(
     deno_doc::html::pages::render_symbol_page(
       &render_ctx,
       short_path,
-      &doc_nodes[0],
+      &doc_node,
     );
 
   Some(SymbolPage::Symbol {

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -660,6 +660,13 @@ fn get_url_rewriter(
   })
 }
 
+/// Maximum number of symbol rows rendered in module symbol listings (the
+/// per-entrypoint overview and the "all symbols" page). Namespace-heavy
+/// packages (e.g. zod, which re-exports its whole API under several
+/// namespaces) can otherwise produce listings with tens of thousands of rows,
+/// blowing the docs response past Cloud Run's 32 MiB response cap.
+const SYMBOL_LISTING_LIMIT: usize = 2048;
+
 #[allow(clippy::too_many_arguments)]
 #[instrument(
   name = "get_generate_ctx",
@@ -776,6 +783,7 @@ pub fn get_generate_ctx(
       head_inject: None,
       id_prefix: None,
       diff_only: diff.as_ref().map(|diff| !diff.1).unwrap_or_default(),
+      symbol_listing_limit: Some(SYMBOL_LISTING_LIMIT),
     },
     None,
     deno_doc::html::FileMode::Normal,

--- a/api/testdata/tarballs/merged_export_name/asttypes.ts
+++ b/api/testdata/tarballs/merged_export_name/asttypes.ts
@@ -1,0 +1,9 @@
+/** node interface */
+export interface ArrayExpression {
+  elements: number[];
+}
+
+/** comment interface */
+export interface CommentBlock {
+  value: string;
+}

--- a/api/testdata/tarballs/merged_export_name/builders.ts
+++ b/api/testdata/tarballs/merged_export_name/builders.ts
@@ -1,0 +1,4 @@
+/** builder function */
+export function arrayExpression(): number {
+  return 1;
+}

--- a/api/testdata/tarballs/merged_export_name/jsr.json
+++ b/api/testdata/tarballs/merged_export_name/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/foo",
+  "version": "1.2.3",
+  "exports": "./mod.ts",
+  "license": "MIT"
+}

--- a/api/testdata/tarballs/merged_export_name/mod.ts
+++ b/api/testdata/tarballs/merged_export_name/mod.ts
@@ -1,0 +1,3 @@
+export * from "./builders.ts";
+export * from "./uppercase.ts";
+export type * from "./asttypes.ts";

--- a/api/testdata/tarballs/merged_export_name/uppercase.ts
+++ b/api/testdata/tarballs/merged_export_name/uppercase.ts
@@ -1,0 +1,1 @@
+export { arrayExpression as ArrayExpression } from "./builders.ts";

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -659,6 +659,14 @@ body .ddoc {
       hover:bg-jsr-cyan-50 dark:hover:bg-jsr-cyan-900 transition duration-75;
   }
 
+  /* Base styles for anchor links. The Anchor component applies these as
+     utility classes, but anchors embedded in rendered markdown (heading
+     anchor links) arrive as plain markup with only `class="anchor"`. */
+  .anchor {
+    @apply hidden float-left leading-none text-stone-600 ml-[-24px] p-1 pr-1
+      pt-1 top-0 bottom-0 dark:text-stone-400;
+  }
+
   .anchorable {
     @apply relative scroll-mt-16;
 

--- a/frontend/components/doc/DocEntry.tsx
+++ b/frontend/components/doc/DocEntry.tsx
@@ -1,6 +1,7 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 import type { DocEntryCtx } from "@deno/doc/html-types";
 import { Anchor } from "./Anchor.tsx";
+import { Example } from "./Example.tsx";
 import { Tag } from "./Tag.tsx";
 import { SourceButton } from "./SourceButton.tsx";
 import { getDiffColor } from "./mod.ts";
@@ -19,6 +20,9 @@ export function DocEntry(
     js_doc,
     diff_status,
     old_content,
+    params,
+    return_doc,
+    examples,
   } = entry;
 
   const renamedOldName = diff_status?.kind === "renamed"
@@ -120,6 +124,40 @@ export function DocEntry(
           // deno-lint-ignore react-no-danger
           dangerouslySetInnerHTML={{ __html: js_doc }}
         />
+      )}
+
+      {
+        /* parameter and return docs for entries that have no symbol page of
+          their own — class constructors, construct signatures and call
+          signatures */
+      }
+      {params && params.length > 0 && (
+        <div class="mt-2 pl-4 border-l border-stone-300 dark:border-stone-600">
+          <span class="text-sm font-semibold text-stone-500 dark:text-stone-400">
+            Parameters
+          </span>
+          {params.map((param, i) => <DocEntry key={i} entry={param} />)}
+        </div>
+      )}
+
+      {return_doc && (
+        <div class="mt-2 pl-4 border-l border-stone-300 dark:border-stone-600">
+          <span class="text-sm font-semibold text-stone-500 dark:text-stone-400">
+            Returns
+          </span>
+          <div
+            class="max-w-[75ch]"
+            // jsdoc rendering
+            // deno-lint-ignore react-no-danger
+            dangerouslySetInnerHTML={{ __html: return_doc }}
+          />
+        </div>
+      )}
+
+      {examples && examples.length > 0 && (
+        <div class="space-y-2 mt-3">
+          {examples.map((example, i) => <Example key={i} example={example} />)}
+        </div>
       )}
     </div>
   );

--- a/frontend/components/doc/Example.tsx
+++ b/frontend/components/doc/Example.tsx
@@ -8,7 +8,7 @@ export function Example(
   },
 ) {
   return (
-    <div class="anchorable">
+    <div class="anchorable" id={anchor.id}>
       <Anchor anchor={anchor} />
       <h3
         class="font-bold text-lg mb-3"

--- a/frontend/components/doc/ModuleDoc.tsx
+++ b/frontend/components/doc/ModuleDoc.tsx
@@ -4,10 +4,21 @@ import { Deprecated } from "./Deprecated.tsx";
 import { SymbolContent } from "./SymbolContent.tsx";
 
 export function ModuleDoc({ content }: { content: ModuleDocCtx }) {
+  // `symbols_trimmed` is missing from @deno/doc@0.204.0's html-types; drop
+  // this extension once the published types include it.
+  const symbolsTrimmed =
+    (content as ModuleDocCtx & { symbols_trimmed?: boolean }).symbols_trimmed;
+
   return (
     <section>
       <div class="space-y-2 flex-1">
         <Deprecated message={content.deprecated} />
+        {symbolsTrimmed && (
+          <div class="italic text-sm">
+            Some deeply nested symbols were omitted from this overview; they are
+            listed on the page of their containing namespace.
+          </div>
+        )}
         <SymbolContent content={content.sections} />
       </div>
     </section>

--- a/frontend/components/doc/Tag.tsx
+++ b/frontend/components/doc/Tag.tsx
@@ -31,7 +31,8 @@ export function Tag(
             </span>
           );
         }
-        return titleCase(tag.value as string);
+        // "other" tags carry preformatted text (e.g. "Since 1.2.3")
+        return tag.value;
       }
       return titleCase(tag.kind);
     }

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -14,7 +14,7 @@
     }
   },
   "imports": {
-    "@deno/doc": "jsr:@deno/doc@^0.201.0",
+    "@deno/doc": "jsr:@deno/doc@^0.204.0",
     "@fresh/plugin-tailwind": "jsr:@fresh/plugin-tailwind@^1.0.0",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.1.2",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.3.0",

--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -2,7 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@deno/cache-dir@0.25": "0.25.0",
-    "jsr:@deno/doc@0.201": "0.201.0",
+    "jsr:@deno/doc@0.204": "0.204.0",
     "jsr:@deno/esbuild-plugin@^1.2.0": "1.2.1",
     "jsr:@deno/gfm@0.11": "0.11.0",
     "jsr:@deno/graph@0.100": "0.100.1",
@@ -18,23 +18,25 @@
     "jsr:@preact-icons/common@^1.1.0": "1.1.0",
     "jsr:@preact-icons/tb@^1.0.14": "1.0.14",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
-    "jsr:@std/cli@^1.0.29": "1.0.32",
+    "jsr:@std/cli@^1.0.32": "1.0.32",
     "jsr:@std/collections@^1.1.3": "1.1.7",
-    "jsr:@std/dotenv@~0.225.5": "0.225.7",
+    "jsr:@std/dotenv@~0.225.5": "0.225.8",
     "jsr:@std/encoding@^1.0.10": "1.0.11",
+    "jsr:@std/encoding@^1.0.11": "1.0.11",
     "jsr:@std/fmt@^1.0.10": "1.0.10",
     "jsr:@std/fmt@^1.0.3": "1.0.10",
     "jsr:@std/fmt@^1.0.6": "1.0.10",
     "jsr:@std/fmt@^1.0.7": "1.0.10",
     "jsr:@std/fmt@^1.0.8": "1.0.10",
     "jsr:@std/front-matter@1": "1.0.9",
+    "jsr:@std/fs@1": "1.0.24",
     "jsr:@std/fs@^1.0.19": "1.0.24",
-    "jsr:@std/fs@^1.0.23": "1.0.24",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/fs@^1.0.6": "1.0.24",
-    "jsr:@std/html@^1.0.5": "1.0.6",
-    "jsr:@std/html@^1.0.6": "1.0.6",
-    "jsr:@std/http@1": "1.1.0",
-    "jsr:@std/http@^1.0.21": "1.1.0",
+    "jsr:@std/html@^1.0.5": "1.0.7",
+    "jsr:@std/html@^1.0.7": "1.0.7",
+    "jsr:@std/http@1": "1.1.3",
+    "jsr:@std/http@^1.0.21": "1.1.3",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/io@0.225": "0.225.3",
     "jsr:@std/json@^1.0.2": "1.1.0",
@@ -46,11 +48,11 @@
     "jsr:@std/path@^1.0.8": "1.1.6",
     "jsr:@std/path@^1.1.1": "1.1.6",
     "jsr:@std/path@^1.1.2": "1.1.6",
-    "jsr:@std/path@^1.1.4": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/path@^1.1.6": "1.1.6",
     "jsr:@std/semver@1": "1.0.8",
     "jsr:@std/semver@^1.0.6": "1.0.8",
-    "jsr:@std/streams@^1.1.0": "1.1.1",
+    "jsr:@std/streams@^1.1.2": "1.1.2",
     "jsr:@std/toml@^1.0.3": "1.0.11",
     "jsr:@std/uuid@^1.0.9": "1.1.1",
     "jsr:@std/yaml@^1.0.5": "1.1.0",
@@ -111,8 +113,8 @@
         "jsr:@std/path@^1.0.8"
       ]
     },
-    "@deno/doc@0.201.0": {
-      "integrity": "930faf1311630ca194dd0b1a962c3de54c59c1a8ceb5bda3dce511c2cb29514d",
+    "@deno/doc@0.204.0": {
+      "integrity": "2098f4924af3b193984fd0a195321bc12a996a90a428fb93d27746bb4efb5009",
       "dependencies": [
         "jsr:@deno/cache-dir",
         "jsr:@deno/graph@0.100"
@@ -159,7 +161,7 @@
     "@fresh/build-id@1.0.1": {
       "integrity": "12a2ec25fd52ae9ec68c26848a5696cd1c9b537f7c983c7e56e4fb1e7e816c20",
       "dependencies": [
-        "jsr:@std/encoding"
+        "jsr:@std/encoding@^1.0.10"
       ]
     },
     "@fresh/core@2.3.3": {
@@ -167,7 +169,7 @@
       "dependencies": [
         "jsr:@deno/esbuild-plugin",
         "jsr:@fresh/build-id",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.10",
         "jsr:@std/fmt@^1.0.8",
         "jsr:@std/fs@^1.0.19",
         "jsr:@std/html@^1.0.5",
@@ -239,8 +241,8 @@
     "@std/collections@1.1.7": {
       "integrity": "56f659d011218a69740b12829cf5ea2c9b70bbed0af02597e27dc1eb5e69e208"
     },
-    "@std/dotenv@0.225.7": {
-      "integrity": "11d8db03ca4ad5aba9eba809f2e8058b2a4f320b7b09fea4b360e162928329e3"
+    "@std/dotenv@0.225.8": {
+      "integrity": "27b8c1a9d00cbf938345a5924487c04d9b27bdd7e7bd1983f54bcf76d0a0174a"
     },
     "@std/encoding@1.0.11": {
       "integrity": "e7cef2f0b3153bccc17431e7c864a1de03a4b6d9647389c43e08aaa775d37385"
@@ -258,23 +260,24 @@
     "@std/fs@1.0.24": {
       "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
+        "jsr:@std/internal",
         "jsr:@std/path@^1.1.5"
       ]
     },
-    "@std/html@1.0.6": {
-      "integrity": "eaf759c8141e0733ca30eb49e4c08d8e6ca442b85c4d51f9894a56f502993e08"
+    "@std/html@1.0.7": {
+      "integrity": "175c818905a6e75743c69c251395e273d82698e58cfe7dd76268d70e28b8d8fe"
     },
-    "@std/http@1.1.0": {
-      "integrity": "265cd9a589fea924c5bb0bbed8bebb4bb2fa19129f760bd014e78dbd7a365a51",
+    "@std/http@1.1.3": {
+      "integrity": "73a98e05ff58aa18bea562d286172e6c815b1eddd4fcab194beda19e3683b88c",
       "dependencies": [
         "jsr:@std/cli",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.11",
         "jsr:@std/fmt@^1.0.10",
-        "jsr:@std/fs@^1.0.23",
-        "jsr:@std/html@^1.0.6",
+        "jsr:@std/fs@^1.0.24",
+        "jsr:@std/html@^1.0.7",
         "jsr:@std/media-types@^1.1.0",
         "jsr:@std/net",
-        "jsr:@std/path@^1.1.4",
+        "jsr:@std/path@^1.1.6",
         "jsr:@std/streams"
       ]
     },
@@ -311,8 +314,8 @@
     "@std/semver@1.0.8": {
       "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     },
-    "@std/streams@1.1.1": {
-      "integrity": "92556d350e537e9dce527a6d08f6f15be3ff65e656079dea69d15252187c7613"
+    "@std/streams@1.1.2": {
+      "integrity": "0249bf9b78a999f57032ca4d8e7ccaa57579090242640b35ddc948fbb745d3af"
     },
     "@std/toml@1.0.11": {
       "integrity": "e084988b872ca4bad6aedfb7350f6eeed0e8ba88e9ee5e1590621c5b5bb8f715",
@@ -3018,7 +3021,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@deno/doc@0.201",
+      "jsr:@deno/doc@0.204",
       "jsr:@deno/gfm@0.11",
       "jsr:@fresh/core@^2.3.3",
       "jsr:@fresh/plugin-tailwind@1",


### PR DESCRIPTION
Brings in the upstream docs-gen fixes for the P1 board issues and the zod 500s, plus the JSR-side changes needed to surface them.

## Upstream (deno_doc 0.204.0)

- denoland/deno_doc#837 — type references through namespace imports (`import * as ns`), aliased imports, and default imports get linked; links into other entrypoints are verified to exist; internal (non-exported / `@internal`) symbols are no longer linked, since JSR doesn't serve pages for them.

  Fixes #919, fixes #865, fixes #917, fixes #922
- denoland/deno_doc#838 — declarations are no longer lost when an export name collides: `export { foo as Bar }` next to `export interface Bar`, or the same name coming through multiple `export *` modules (the `@babel/types` case, where builder functions shadowed the same-named interfaces from an `export type *`).

  Fixes #957
- denoland/deno_doc#841 — `symbol_listing_limit` (set here to 2048): namespace-heavy packages otherwise produce module symbol listings with tens of thousands of rows. zod's entrypoint docs context serializes to 41 MB, blowing the docs API response past Cloud Run's 32 MiB response cap and turning every `/doc`, `all_symbols`, and `search_structured` request for the package into an empty 500 (measured against zod 4.4.3's production doc nodes; with the cap the page is 1.2 MB). Also fixes the "Symbols" panel linking namespace members by their bare name.

  Fixes #1301, and fixes the `https://jsr.io/@zod/zod/doc` 500s
- denoland/deno_doc#842 — `implements ns.Interface` renders as a proper qualified, linked name instead of `[ns.Interface]`; class members inherit docs from the interfaces they implement; `@example` on interface construct/call signatures renders inline.

  Fixes #1013, and the remainder of #1250

## JSR-side changes

- `generate_symbol_page` no longer drops a node's non-reference declarations when resolving a reference, and when one symbol name yields multiple doc nodes their declarations are merged before rendering — so e.g. `@babel/types`' `ArrayExpression` page shows both the re-exported builder function and the interface.
- The frontend's JSX doc components render the same context JSON that deno_doc's handlebars templates do, so every template change in the 0.201.0 → 0.204.0 range is mirrored:
  - **DocEntry** renders the new `params` / `return_doc` / `examples` fields (parameter, return, and `@example` docs for entries with no symbol page of their own — class constructors, construct signatures, call signatures), with the same bordered-left layout as deno_doc's `.docEntryParams`.
  - **Example** containers carry their anchor id, so `#example_N` links scroll correctly.
  - **ModuleDoc** renders the `symbols_trimmed` note ("Some deeply nested symbols were omitted from this overview; they are listed on the page of their containing namespace."). Typed locally for now — `symbols_trimmed` is missing from `@deno/doc@0.204.0`'s `html-types` (upstream fix filed).
  - **Tag** no longer title-cases `"other"` tags (the `@since` version chips carry preformatted text); the dead valued-tag branch is removed since only `permissions` and `other` carry values. The `other` tag color tokens already existed in our CSS.
  - A base `.anchor` CSS rule so the clickable heading anchor links now embedded in rendered markdown (plain `class="anchor"` markup, unlike the Anchor component's inline utilities) are hidden until hover like every other anchor.
  - The `@event`/`@fires`/`@listens` sections and interface-member rendering changes arrive as existing section kinds (`see`, `doc_entry`), which the components already handle.
- deno_graph `0.109` → `0.110.2`: two new `BuildOptions` fields, kept at their defaults; `@deno/doc` frontend dependency `^0.201.0` → `^0.204.0`.

## Tests

`test_package_docs_merged_export_name` regression test with a tarball fixture mirroring the babel shape. Full `registry_api` suite passes (205 tests) on 0.204.0; frontend typechecks, lints, and builds.

Note: existing packages need a docs regeneration (or a new version publish) to pick up the parser-level fixes, since stored doc nodes are cached per version; the render-level fixes (linking, listing cap, template mirrors) apply on deploy.