### PR TITLE
fix: transpile TSX/JSX in npm-compat tarballs

### DIFF
--- a/api/src/npm/emit.rs
+++ b/api/src/npm/emit.rs
@@ -1,13 +1,14 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 
-use deno_ast::emit;
-use deno_ast::fold_program;
-use deno_ast::swc::visit::VisitMutWith;
-use deno_ast::EmittedSource;
 use deno_ast::ParsedSource;
 use deno_ast::SourceMap;
 use deno_ast::SourceMapOption;
 use deno_ast::TranspileOptions;
+use deno_ast::emit;
+use deno_ast::fold_program;
+use deno_ast::swc::ecma_visit::VisitMutWith;
+use deno_ast::{DecoratorsTranspileOption, EmittedSourceText};
+use deno_ast::{JsxAutomaticOptions, JsxClassicOptions, JsxRuntime};
 use deno_graph::FastCheckTypeModule;
 use url::Url;
 
@@ -17,64 +18,76 @@ use crate::npm::specifiers::relative_import_specifier;
 use super::specifiers::RewriteKind;
 use super::specifiers::SpecifierRewriter;
 
+/// JSX settings taken from the package compilerOptions and file pragmas.
+#[derive(Debug, Clone, Default)]
+pub struct JsxEmitOptions {
+  pub jsx: Option<String>,
+  pub jsx_import_source: Option<String>,
+  pub jsx_factory: Option<String>,
+  pub jsx_fragment_factory: Option<String>,
+}
+
 pub fn transpile_to_js(
   source: &ParsedSource,
   specifier_rewriter: SpecifierRewriter,
   target_specifier: &Url,
-) -> Result<(String, String), anyhow::Error> {
+  jsx_options: &JsxEmitOptions,
+) -> Result<(Vec<u8>, Vec<u8>), anyhow::Error> {
   let basename = target_specifier.path().rsplit_once('/').unwrap().1;
   let emit_options = deno_ast::EmitOptions {
     source_map: SourceMapOption::Separate,
     source_map_file: Some(basename.to_owned()),
+    source_map_base: None,
     inline_sources: false,
-    keep_comments: true,
+    remove_comments: false,
   };
 
   let file_name =
     relative_import_specifier(target_specifier, source.specifier());
-  let source_map =
-    SourceMap::single(file_name, source.text_info().text_str().to_owned());
+  let source_map = SourceMap::single(file_name, source.text().to_string());
 
-  let mut program = source.program_ref().clone();
+  let program = source.program_ref().to_owned();
 
   // needs to align with what's done internally in source map
-  assert_eq!(1, source.text_info().range().start.as_byte_pos().0);
+  assert_eq!(1, source.range().start.as_byte_pos().0);
   // we need the comments to be mutable, so make it single threaded
   let comments = source.comments().as_single_threaded();
   source.globals().with(|marks| {
+    let transpile_options = TranspileOptions {
+      decorators: DecoratorsTranspileOption::Ecma,
+      jsx: resolve_jsx_runtime(source, jsx_options),
+      ..Default::default()
+    };
+
+    let mut program = fold_program(
+      program,
+      &transpile_options,
+      &source_map,
+      &comments,
+      marks,
+      Box::new(source.diagnostics().iter()),
+    )?;
+
     let mut import_rewrite_transformer = ImportRewriteTransformer {
       specifier_rewriter,
       kind: RewriteKind::Source,
     };
     program.visit_mut_with(&mut import_rewrite_transformer);
 
-    let transpile_options = TranspileOptions {
-      use_decorators_proposal: true,
-      use_ts_decorators: false,
+    let EmittedSourceText { text, source_map } =
+      emit((&program).into(), &comments, &source_map, &emit_options)?;
+    let mut source = text.into_bytes();
 
-      // TODO: JSX
-      ..Default::default()
-    };
-
-    let program = fold_program(
-      program,
-      &transpile_options,
-      &source_map,
-      &comments,
-      marks,
-      source.diagnostics(),
-    )?;
-
-    let EmittedSource {
-      mut text,
-      source_map,
-    } = emit(&program, &comments, &source_map, &emit_options)?;
-    if !text.ends_with('\n') {
-      text.push('\n');
+    if let Some(last) = source.last()
+      && *last != b'\n'
+    {
+      source.push(b'\n');
     }
-    text.push_str(format!("//# sourceMappingURL={}.map", basename).as_str());
 
-    Ok((text, source_map.unwrap()))
+    source
+      .extend(format!("//# sourceMappingURL={}.map", basename).into_bytes());
+
+    Ok((source, source_map.unwrap().into_bytes()))
   })
 }
 
@@ -83,21 +96,21 @@ pub fn transpile_to_dts(
   fast_check_module: &FastCheckTypeModule,
   specifier_rewriter: SpecifierRewriter,
   target_specifier: &Url,
-) -> Result<(String, String), anyhow::Error> {
+) -> Result<(Vec<u8>, Vec<u8>), anyhow::Error> {
   let dts = fast_check_module.dts.as_ref().unwrap();
 
   let basename = target_specifier.path().rsplit_once('/').unwrap().1;
   let emit_options = deno_ast::EmitOptions {
     source_map: SourceMapOption::Separate,
     source_map_file: Some(basename.to_owned()),
+    source_map_base: None,
     inline_sources: false,
-    keep_comments: true,
+    remove_comments: false,
   };
 
   let file_name =
     relative_import_specifier(target_specifier, source.specifier());
-  let source_map =
-    SourceMap::single(file_name, source.text_info().text_str().to_owned());
+  let source_map = SourceMap::single(file_name, source.text().to_string());
 
   let comments = dts.comments.as_single_threaded();
 
@@ -109,14 +122,92 @@ pub fn transpile_to_dts(
   };
   program.visit_mut_with(&mut import_rewrite_transformer);
 
-  let EmittedSource {
-    mut text,
-    source_map,
-  } = emit(&program, &comments, &source_map, &emit_options)?;
-  if !text.ends_with('\n') {
-    text.push('\n');
-  }
-  text.push_str(format!("//# sourceMappingURL={}.map", basename).as_str());
+  let EmittedSourceText { text, source_map } =
+    emit((&program).into(), &comments, &source_map, &emit_options)?;
+  let mut source = text.into_bytes();
 
-  Ok((text, source_map.unwrap()))
+  if let Some(last) = source.last()
+    && *last != b'\n'
+  {
+    source.push(b'\n');
+  }
+
+  source.extend(format!("//# sourceMappingURL={}.map", basename).into_bytes());
+
+  Ok((source, source_map.unwrap().into_bytes()))
+}
+
+fn resolve_jsx_runtime(
+  source: &ParsedSource,
+  jsx_options: &JsxEmitOptions,
+) -> Option<JsxRuntime> {
+  if !matches!(
+    source.media_type(),
+    deno_ast::MediaType::Jsx | deno_ast::MediaType::Tsx
+  ) {
+    return None;
+  }
+
+  let pragma_import_source = jsx_import_source_from_pragma(source.text());
+  let import_source = pragma_import_source
+    .clone()
+    .or_else(|| jsx_options.jsx_import_source.clone());
+  let jsx = jsx_options.jsx.as_deref();
+
+  let automatic = JsxAutomaticOptions {
+    development: matches!(jsx, Some("react-jsxdev")),
+    import_source,
+  };
+
+  match jsx {
+    Some("precompile") => {
+      Some(JsxRuntime::Precompile(deno_ast::JsxPrecompileOptions {
+        automatic,
+        skip_elements: None,
+        dynamic_props: None,
+      }))
+    }
+    Some("react-jsx") | Some("react-jsxdev") => {
+      Some(JsxRuntime::Automatic(automatic))
+    }
+    _ => {
+      if pragma_import_source.is_some()
+        || jsx_options.jsx_import_source.is_some()
+      {
+        Some(JsxRuntime::Automatic(automatic))
+      } else {
+        Some(classic_jsx_runtime(jsx_options))
+      }
+    }
+  }
+}
+
+fn classic_jsx_runtime(jsx_options: &JsxEmitOptions) -> JsxRuntime {
+  JsxRuntime::Classic(JsxClassicOptions {
+    factory: jsx_options
+      .jsx_factory
+      .clone()
+      .unwrap_or_else(|| "React.createElement".into()),
+    fragment_factory: jsx_options
+      .jsx_fragment_factory
+      .clone()
+      .unwrap_or_else(|| "React.Fragment".into()),
+  })
+}
+
+fn jsx_import_source_from_pragma(text: &str) -> Option<String> {
+  for line in text.lines().take(50) {
+    let Some(idx) = line.find("@jsxImportSource") else {
+      continue;
+    };
+    let rest = line[idx + "@jsxImportSource".len()..].trim();
+    let value = rest
+      .split(|c: char| c.is_whitespace() || c == '*')
+      .find(|s| !s.is_empty() && *s != "*/")?;
+    let value = value.trim_end_matches("*/").trim();
+    if !value.is_empty() {
+      return Some(value.to_string());
+    }
+  }
+  None
 }

--- a/api/src/npm/import_transform.rs
+++ b/api/src/npm/import_transform.rs
@@ -9,24 +9,40 @@ use deno_ast::swc::ast::Lit;
 use deno_ast::swc::ast::NamedExport;
 use deno_ast::swc::ast::Str;
 use deno_ast::swc::ast::TsImportType;
-use deno_ast::swc::visit::VisitMut;
-use deno_ast::swc::visit::VisitMutWith;
+use deno_ast::swc::ecma_visit::VisitMut;
+use deno_ast::swc::ecma_visit::VisitMutWith;
 
 use super::specifiers::RewriteKind;
 use super::specifiers::SpecifierRewriter;
+use super::specifiers::rewrite_npm_and_jsr_specifier;
 
 pub struct ImportRewriteTransformer<'a> {
   pub specifier_rewriter: SpecifierRewriter<'a>,
   pub kind: RewriteKind,
 }
 
-impl<'a> VisitMut for ImportRewriteTransformer<'a> {
+impl ImportRewriteTransformer<'_> {
+  fn remap(&self, value: &str) -> Option<String> {
+    self
+      .specifier_rewriter
+      .rewrite(value, self.kind)
+      .or_else(|| rewrite_npm_and_jsr_specifier(value))
+  }
+
+  fn remap_declaration(&self, value: &str) -> Option<String> {
+    self
+      .specifier_rewriter
+      .rewrite(value, RewriteKind::Declaration)
+      .or_else(|| rewrite_npm_and_jsr_specifier(value))
+  }
+}
+
+impl VisitMut for ImportRewriteTransformer<'_> {
   fn visit_mut_import_decl(&mut self, node: &mut ImportDecl) {
     node.visit_mut_children_with(self);
 
-    if let Some(remapped) = self
-      .specifier_rewriter
-      .rewrite(node.src.value.as_str(), self.kind)
+    if let Some(value) = node.src.value.as_str()
+      && let Some(remapped) = self.remap(value)
     {
       node.src = Box::new(remapped.into());
     }
@@ -35,22 +51,19 @@ impl<'a> VisitMut for ImportRewriteTransformer<'a> {
   fn visit_mut_named_export(&mut self, node: &mut NamedExport) {
     node.visit_mut_children_with(self);
 
-    if let Some(src) = &node.src {
-      if let Some(remapped) = self
-        .specifier_rewriter
-        .rewrite(src.value.as_str(), self.kind)
-      {
-        node.src = Some(Box::new(remapped.into()));
-      }
+    if let Some(src) = &node.src
+      && let Some(value) = src.value.as_str()
+      && let Some(remapped) = self.remap(value)
+    {
+      node.src = Some(Box::new(remapped.into()));
     }
   }
 
   fn visit_mut_export_all(&mut self, node: &mut ExportAll) {
     node.visit_mut_children_with(self);
 
-    if let Some(remapped) = self
-      .specifier_rewriter
-      .rewrite(node.src.value.as_str(), self.kind)
+    if let Some(value) = node.src.value.as_str()
+      && let Some(remapped) = self.remap(value)
     {
       node.src = Box::new(remapped.into());
     }
@@ -59,9 +72,8 @@ impl<'a> VisitMut for ImportRewriteTransformer<'a> {
   fn visit_mut_ts_import_type(&mut self, n: &mut TsImportType) {
     n.visit_mut_children_with(self);
 
-    if let Some(remapped) = self
-      .specifier_rewriter
-      .rewrite(n.arg.value.as_str(), RewriteKind::Declaration)
+    if let Some(value) = n.arg.value.as_str()
+      && let Some(remapped) = self.remap_declaration(value)
     {
       n.arg = remapped.into();
     }
@@ -70,23 +82,22 @@ impl<'a> VisitMut for ImportRewriteTransformer<'a> {
   fn visit_mut_call_expr(&mut self, node: &mut CallExpr) {
     node.visit_mut_children_with(self);
 
-    if let Callee::Import(_) = node.callee {
-      if let Some(arg) = node.args.first() {
-        if let Expr::Lit(Lit::Str(lit_str)) = *arg.expr.clone() {
-          let maybe_rewritten =
-            self.specifier_rewriter.rewrite(&lit_str.value, self.kind);
-          if let Some(rewritten) = maybe_rewritten {
-            let replacer = Expr::Lit(Lit::Str(Str {
-              span: lit_str.span,
-              value: rewritten.into(),
-              raw: None,
-            }));
-            node.args[0] = ExprOrSpread {
-              spread: None,
-              expr: Box::new(replacer),
-            };
-          }
-        }
+    if let Callee::Import(_) = node.callee
+      && let Some(arg) = node.args.first()
+      && let Expr::Lit(Lit::Str(lit_str)) = *arg.expr.clone()
+      && let Some(value) = lit_str.value.as_str()
+    {
+      let maybe_rewritten = self.remap(value);
+      if let Some(rewritten) = maybe_rewritten {
+        let replacer = Expr::Lit(Lit::Str(Str {
+          span: lit_str.span,
+          value: rewritten.into(),
+          raw: None,
+        }));
+        node.args[0] = ExprOrSpread {
+          spread: None,
+          expr: Box::new(replacer),
+        };
       }
     }
   }

--- a/api/src/npm/mod.rs
+++ b/api/src/npm/mod.rs
@@ -8,28 +8,33 @@ mod tests;
 mod types;
 
 use chrono::SecondsFormat;
+use deno_semver::StackString;
+use deno_semver::VersionReq;
 use deno_semver::package::PackageReq;
 use deno_semver::package::PackageReqReference;
-use deno_semver::VersionReq;
 use indexmap::IndexMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use url::Url;
 
 use crate::db::Database;
+use crate::db::PackageVersionDependency;
 use crate::ids::PackageName;
 use crate::ids::ScopeName;
+use crate::ids::Version;
 use crate::npm::tarball::create_npm_dependencies;
 use crate::npm::types::NpmDistInfo;
 use crate::npm::types::NpmPackageInfo;
+use crate::npm::types::NpmRepositoryInfo;
 
-pub use self::tarball::create_npm_tarball;
 pub use self::tarball::NpmTarball;
 pub use self::tarball::NpmTarballFiles;
 pub use self::tarball::NpmTarballOptions;
+pub use self::tarball::create_npm_tarball;
 pub use self::types::NpmMappedJsrPackageName;
 use self::types::NpmVersionInfo;
 
-pub const NPM_TARBALL_REVISION: u32 = 10;
+pub const NPM_TARBALL_REVISION: u32 = 12;
 
 pub async fn generate_npm_version_manifest<'a>(
   db: &Database,
@@ -37,12 +42,33 @@ pub async fn generate_npm_version_manifest<'a>(
   scope: &'a ScopeName,
   name: &'a PackageName,
 ) -> Result<NpmPackageInfo<'a>, anyhow::Error> {
-  let (package, _, _) = db
+  let (package, github_repository, _) = db
     .get_package(scope, name)
     .await?
     .ok_or_else(|| anyhow::anyhow!("package not found: @{scope}/{name}"))?;
 
-  let versions = db.list_package_versions(scope, name).await?;
+  let repository = github_repository.map(|repo| NpmRepositoryInfo {
+    repository_type: "git".to_string(),
+    url: format!("git+https://github.com/{}/{}.git", repo.owner, repo.name),
+  });
+
+  let versions = db
+    .list_package_versions_for_npm_version_manifest(scope, name)
+    .await?;
+
+  let all_dependencies = db.list_package_dependencies(scope, name).await?;
+
+  let mut dependencies_per_version: HashMap<
+    Version,
+    Vec<PackageVersionDependency>,
+  > = HashMap::new();
+
+  for dep in all_dependencies {
+    dependencies_per_version
+      .entry(dep.package_version.clone())
+      .or_default()
+      .push(dep);
+  }
 
   let mut out = NpmPackageInfo {
     name: NpmMappedJsrPackageName {
@@ -50,6 +76,7 @@ pub async fn generate_npm_version_manifest<'a>(
       package: name,
     },
     description: package.description.clone(),
+    repository: repository.clone(),
     dist_tags: IndexMap::new(),
     versions: IndexMap::new(),
     time: IndexMap::new(),
@@ -68,33 +95,28 @@ pub async fn generate_npm_version_manifest<'a>(
       .to_rfc3339_opts(SecondsFormat::Millis, true),
   );
 
-  for (version, _) in versions {
+  for version in versions {
     // We don't publish yanked versions in the NPM manifest.
     if version.is_yanked {
       continue;
     }
 
-    // Skip versions that don't have a tarball.
-    let Some(npm_tarball) = db
-      .get_latest_npm_tarball_for_version(scope, name, &version.version)
-      .await?
-    else {
-      continue;
-    };
+    let dependencies = dependencies_per_version
+      .remove(&version.version)
+      .unwrap_or_default();
 
-    let dependencies = db
-      .list_package_version_dependencies(scope, name, &version.version)
-      .await?;
     let dependencies = dependencies.into_iter().map(|dep| {
       let sub_path = if dep.dependency_path.is_empty() {
         None
       } else {
-        Some(dep.dependency_path)
+        Some(deno_semver::package::PackageSubPath::from_string(
+          dep.dependency_path,
+        ))
       };
       let version_req =
         VersionReq::parse_from_specifier(&dep.dependency_constraint).unwrap();
       let req = PackageReq {
-        name: dep.dependency_name,
+        name: StackString::from_string(dep.dependency_name),
         version_req,
       };
       Cow::Owned((dep.dependency_kind, PackageReqReference { req, sub_path }))
@@ -105,7 +127,7 @@ pub async fn generate_npm_version_manifest<'a>(
       .base_url(Some(npm_url))
       .parse(&format!(
         "./~/{}/{}/{}.tgz",
-        npm_tarball.revision,
+        version.npm_tarball_revision,
         NpmMappedJsrPackageName {
           scope,
           package: name,
@@ -121,10 +143,11 @@ pub async fn generate_npm_version_manifest<'a>(
       },
       version: version.version.clone(),
       description: package.description.clone(),
+      repository: repository.clone(),
       dist: NpmDistInfo {
         tarball: tarball.to_string(),
-        shasum: npm_tarball.sha1,
-        integrity: format!("sha512-{}", npm_tarball.sha512),
+        shasum: version.npm_tarball_sha1,
+        integrity: format!("sha512-{}", version.npm_tarball_sha512),
       },
       dependencies: npm_dependencies,
     };

--- a/api/src/npm/specifiers.rs
+++ b/api/src/npm/specifiers.rs
@@ -27,8 +27,9 @@ pub struct SpecifierRewriter<'a> {
   pub dependencies: &'a IndexMap<String, Dependency>,
 }
 
-impl<'a> SpecifierRewriter<'a> {
+impl SpecifierRewriter<'_> {
   pub fn rewrite(&self, specifier: &str, kind: RewriteKind) -> Option<String> {
+    let source_text_specifier = specifier;
     let dep = self.dependencies.get(specifier)?;
 
     let specifier = match kind {
@@ -68,17 +69,17 @@ impl<'a> SpecifierRewriter<'a> {
       }
     }
 
-    if *resolved_specifier == *specifier {
-      // No need to rewrite if the specifier is the same as the resolved
-      // specifier.
-      return None;
-    }
-
     let new_specifier = if resolved_specifier.scheme() == "file" {
       relative_import_specifier(self.base_specifier, &resolved_specifier)
     } else {
       resolved_specifier.to_string()
     };
+
+    if new_specifier == source_text_specifier {
+      // No need to rewrite if the specifier is the same as the resolved
+      // specifier.
+      return None;
+    }
 
     Some(new_specifier)
   }
@@ -90,7 +91,10 @@ pub fn relative_import_specifier(
 ) -> String {
   let relative = base_specifier.make_relative(specifier).unwrap();
   if relative.is_empty() {
-    format!("./{}", specifier.path_segments().unwrap().last().unwrap())
+    format!(
+      "./{}",
+      specifier.path_segments().unwrap().next_back().unwrap()
+    )
   } else if relative.starts_with("../") {
     relative.to_string()
   } else {
@@ -122,7 +126,7 @@ pub fn follow_specifier<'a>(
 pub fn rewrite_npm_and_jsr_specifier(specifier: &str) -> Option<String> {
   if let Ok(jsr) = JsrPackageReqReference::from_str(specifier) {
     let req = jsr.into_inner();
-    let jsr_name = ScopedPackageName::new(req.req.name).ok()?;
+    let jsr_name = ScopedPackageName::new(req.req.name.to_string()).ok()?;
     let npm_name = NpmMappedJsrPackageName {
       scope: &jsr_name.scope,
       package: &jsr_name.package,
@@ -158,7 +162,6 @@ pub fn rewrite_npm_and_jsr_specifier(specifier: &str) -> Option<String> {
 
 pub enum Extension {
   Js,
-  #[allow(dead_code)]
   Dts,
 }
 
@@ -292,6 +295,14 @@ mod tests {
     );
     assert_eq!(
       rewrite_path_extension("foo/bar.jsx", Extension::Dts),
+      Some("foo/bar.d.ts".to_owned())
+    );
+    assert_eq!(
+      rewrite_path_extension("foo/bar.tsx", Extension::Js),
+      Some("foo/bar.js".to_owned())
+    );
+    assert_eq!(
+      rewrite_path_extension("foo/bar.tsx", Extension::Dts),
       Some("foo/bar.d.ts".to_owned())
     );
   }

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -4,18 +4,18 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use base64::Engine;
-use deno_ast::apply_text_changes;
 use deno_ast::SourceTextInfo;
 use deno_ast::TextChange;
-use deno_graph::CapturingModuleAnalyzer;
-use deno_graph::DependencyDescriptor;
-use deno_graph::ModuleAnalyzer;
+use deno_ast::apply_text_changes;
 use deno_graph::ModuleGraph;
-use deno_graph::ModuleInfo;
 use deno_graph::ModuleSpecifier;
-use deno_graph::ParsedSourceStore;
 use deno_graph::PositionRange;
 use deno_graph::Resolution;
+use deno_graph::analysis::DependencyDescriptor;
+use deno_graph::analysis::ModuleAnalyzer;
+use deno_graph::analysis::ModuleInfo;
+use deno_graph::ast::CapturingModuleAnalyzer;
+use deno_graph::ast::ParsedSourceStore;
 use deno_semver::package::PackageReqReference;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -25,7 +25,6 @@ use tar::Header;
 use tracing::error;
 use url::Url;
 
-use crate::buckets::BucketWithQueue;
 use crate::db::DependencyKind;
 use crate::db::ExportsMap;
 use crate::ids::PackageName;
@@ -33,19 +32,21 @@ use crate::ids::PackagePath;
 use crate::ids::ScopeName;
 use crate::ids::ScopedPackageName;
 use crate::ids::Version;
+use crate::s3::BucketWithQueue;
 
+use super::NPM_TARBALL_REVISION;
+use super::emit::JsxEmitOptions;
 use super::emit::transpile_to_dts;
 use super::emit::transpile_to_js;
-use super::specifiers::follow_specifier;
-use super::specifiers::relative_import_specifier;
-use super::specifiers::rewrite_file_specifier;
 use super::specifiers::Extension;
 use super::specifiers::RewriteKind;
 use super::specifiers::SpecifierRewriter;
+use super::specifiers::follow_specifier;
+use super::specifiers::relative_import_specifier;
+use super::specifiers::rewrite_file_specifier;
 use super::types::NpmExportConditions;
 use super::types::NpmMappedJsrPackageName;
 use super::types::NpmPackageJson;
-use super::NPM_TARBALL_REVISION;
 
 pub struct NpmTarball {
   /// The gzipped tarball contents.
@@ -99,6 +100,9 @@ pub async fn create_npm_tarball<'a>(
 
   let npm_package_id = NpmMappedJsrPackageName { scope, package };
 
+  let jsx_options =
+    load_jsx_emit_options(&files, scope, package, version).await;
+
   let npm_dependencies =
     create_npm_dependencies(dependencies.map(Cow::Borrowed))?;
 
@@ -127,33 +131,37 @@ pub async fn create_npm_tarball<'a>(
 
     match js.media_type {
       deno_ast::MediaType::JavaScript | deno_ast::MediaType::Mjs => {
-        if let Some(types_dep) = &js.maybe_types_dependency {
-          if let Resolution::Ok(resolved) = &types_dep.dependency {
-            declaration_rewrites
-              .insert(module.specifier(), resolved.specifier.clone());
-          }
+        if let Some(types_dep) = &js.maybe_types_dependency
+          && let Resolution::Ok(resolved) = &types_dep.dependency
+        {
+          declaration_rewrites
+            .insert(module.specifier(), resolved.specifier.clone());
         }
       }
       deno_ast::MediaType::Jsx => {
         let source_specifier =
-          rewrite_file_specifier(module.specifier(), "/_dist", Extension::Js);
-        if let Some(source_specifier) = source_specifier {
+          rewrite_file_specifier(module.specifier(), "", Extension::Js);
+        if let Some(source_specifier) = source_specifier.clone() {
           source_rewrites.insert(module.specifier(), source_specifier);
         }
 
-        if let Some(types_dep) = &js.maybe_types_dependency {
-          if let Resolution::Ok(resolved) = &types_dep.dependency {
-            declaration_rewrites
-              .insert(module.specifier(), resolved.specifier.clone());
-          }
+        if let Some(types_dep) = &js.maybe_types_dependency
+          && let Resolution::Ok(resolved) = &types_dep.dependency
+        {
+          declaration_rewrites
+            .insert(module.specifier(), resolved.specifier.clone());
+        } else if let Some(source_specifier) = source_specifier {
+          declaration_rewrites.insert(module.specifier(), source_specifier);
         }
       }
       deno_ast::MediaType::Dts | deno_ast::MediaType::Dmts => {
         // no extra work needed for these, as they can not have type dependencies
       }
-      deno_ast::MediaType::TypeScript | deno_ast::MediaType::Mts => {
+      deno_ast::MediaType::TypeScript
+      | deno_ast::MediaType::Mts
+      | deno_ast::MediaType::Tsx => {
         let source_specifier =
-          rewrite_file_specifier(module.specifier(), "/_dist", Extension::Js);
+          rewrite_file_specifier(module.specifier(), "", Extension::Js);
         if let Some(source_specifier) = source_specifier.clone() {
           source_rewrites.insert(module.specifier(), source_specifier);
         }
@@ -183,7 +191,8 @@ pub async fn create_npm_tarball<'a>(
       deno_ast::MediaType::JavaScript | deno_ast::MediaType::Mjs => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
         let module_info = sources
-          .analyze(&js.specifier, js.source.clone(), js.media_type)
+          .analyze(&js.specifier, js.source.text.clone(), js.media_type)
+          .await
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
@@ -192,7 +201,7 @@ pub async fn create_npm_tarball<'a>(
           dependencies: &js.dependencies,
         };
         let rewritten = rewrite_specifiers(
-          parsed_source.text_info(),
+          parsed_source.text_info_lazy(),
           &module_info,
           specifier_rewriter,
           RewriteKind::Source,
@@ -203,7 +212,8 @@ pub async fn create_npm_tarball<'a>(
       deno_ast::MediaType::Dts | deno_ast::MediaType::Dmts => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
         let module_info = sources
-          .analyze(&js.specifier, js.source.clone(), js.media_type)
+          .analyze(&js.specifier, js.source.text.clone(), js.media_type)
+          .await
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
@@ -212,7 +222,7 @@ pub async fn create_npm_tarball<'a>(
           dependencies: &js.dependencies,
         };
         let rewritten = rewrite_specifiers(
-          parsed_source.text_info(),
+          parsed_source.text_info_lazy(),
           &module_info,
           specifier_rewriter,
           RewriteKind::Declaration,
@@ -229,20 +239,24 @@ pub async fn create_npm_tarball<'a>(
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
         };
-        let (source, source_map) =
-          transpile_to_js(&parsed_source, specifier_rewriter, source_target)
-            .unwrap();
+        let (source, source_map) = transpile_to_js(
+          &parsed_source,
+          specifier_rewriter,
+          source_target,
+          &jsx_options,
+        )
+        .unwrap();
+        package_files.insert(source_target.path().to_owned(), source);
         package_files
-          .insert(source_target.path().to_owned(), source.into_bytes());
-        package_files.insert(
-          format!("{}.map", source_target.path()),
-          source_map.into_bytes(),
-        );
+          .insert(format!("{}.map", source_target.path()), source_map);
       }
-      deno_ast::MediaType::TypeScript | deno_ast::MediaType::Mts => {
+      deno_ast::MediaType::TypeScript
+      | deno_ast::MediaType::Mts
+      | deno_ast::MediaType::Tsx => {
         let parsed_source = sources.get_parsed_source(&js.specifier).unwrap();
         let module_info = sources
-          .analyze(&js.specifier, js.source.clone(), js.media_type)
+          .analyze(&js.specifier, js.source.text.clone(), js.media_type)
+          .await
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
@@ -251,7 +265,7 @@ pub async fn create_npm_tarball<'a>(
           dependencies: &js.dependencies,
         };
         let rewritten = rewrite_specifiers(
-          parsed_source.text_info(),
+          parsed_source.text_info_lazy(),
           &module_info,
           specifier_rewriter,
           RewriteKind::Source,
@@ -267,15 +281,16 @@ pub async fn create_npm_tarball<'a>(
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
         };
-        let (source, source_map) =
-          transpile_to_js(&parsed_source, specifier_rewriter, source_target)
-            .unwrap();
+        let (source, source_map) = transpile_to_js(
+          &parsed_source,
+          specifier_rewriter,
+          source_target,
+          &jsx_options,
+        )
+        .unwrap();
+        package_files.insert(source_target.path().to_owned(), source);
         package_files
-          .insert(source_target.path().to_owned(), source.into_bytes());
-        package_files.insert(
-          format!("{}.map", source_target.path()),
-          source_map.into_bytes(),
-        );
+          .insert(format!("{}.map", source_target.path()), source_map);
 
         if let Some(fast_check_module) = js.fast_check_module() {
           let declaration_target =
@@ -292,13 +307,11 @@ pub async fn create_npm_tarball<'a>(
             specifier_rewriter,
             declaration_target,
           )?;
-          package_files.insert(
-            declaration_target.path().to_owned(),
-            declaration.into_bytes(),
-          );
+          package_files
+            .insert(declaration_target.path().to_owned(), declaration);
           package_files.insert(
             format!("{}.map", declaration_target.path()),
-            declaration_map.into_bytes(),
+            declaration_map,
           );
         }
       }
@@ -327,13 +340,13 @@ pub async fn create_npm_tarball<'a>(
 
       let downloads = futures::stream::iter(paths_to_download.into_iter())
         .map(|path| {
-          let gcs_path =
-            crate::gcs_paths::file_path(scope, package, version, path).into();
+          let s3_path =
+            crate::s3_paths::file_path(scope, package, version, path).into();
           async move {
             let bytes = modules_bucket
-              .download(gcs_path)
+              .download(s3_path)
               .await?
-              .ok_or_else(|| anyhow::anyhow!("file missing on GCS: {path}"))?;
+              .ok_or_else(|| anyhow::anyhow!("file missing on S3: {path}"))?;
             Ok::<_, anyhow::Error>((path, bytes))
           }
         })
@@ -392,7 +405,7 @@ pub async fn create_npm_tarball<'a>(
       }
     })?;
     header.set_size(content.len() as u64);
-    header.set_mode(0o777);
+    header.set_mode(0o644);
     header.set_mtime(mtime);
     header.set_cksum();
     tarball.append(&header, content.as_slice()).unwrap();
@@ -400,6 +413,9 @@ pub async fn create_npm_tarball<'a>(
 
   tarball.into_inner().unwrap();
   gz_encoder.finish().unwrap();
+
+  // Free the in-memory file map now that the tarball is built
+  drop(package_files);
 
   let sha1_digest = sha1::Sha1::digest(&tar_gz_bytes);
   let sha1 = format!("{sha1_digest:X}");
@@ -411,6 +427,70 @@ pub async fn create_npm_tarball<'a>(
     sha1,
     sha512,
   })
+}
+
+async fn load_jsx_emit_options(
+  files: &NpmTarballFiles<'_>,
+  scope: &ScopeName,
+  package: &PackageName,
+  version: &Version,
+) -> JsxEmitOptions {
+  const CANDIDATES: &[&str] =
+    &["/deno.json", "/deno.jsonc", "/jsr.json", "/jsr.jsonc"];
+  match files {
+    NpmTarballFiles::WithBytes(map) => {
+      for candidate in CANDIDATES {
+        if let Some((_, content)) =
+          map.iter().find(|(p, _)| p.to_string() == *candidate)
+          && let Some(opts) = parse_jsx_emit_options(content)
+        {
+          return opts;
+        }
+      }
+    }
+    NpmTarballFiles::FromBucket {
+      files,
+      modules_bucket,
+    } => {
+      for candidate in CANDIDATES {
+        let Ok(path) = PackagePath::new(candidate.to_string()) else {
+          continue;
+        };
+        if !files.contains(&path) {
+          continue;
+        }
+        let s3_path =
+          crate::s3_paths::file_path(scope, package, version, &path).into();
+        if let Ok(Some(bytes)) = modules_bucket.download(s3_path).await
+          && let Some(opts) = parse_jsx_emit_options(&bytes)
+        {
+          return opts;
+        }
+      }
+    }
+  }
+  JsxEmitOptions::default()
+}
+
+fn parse_jsx_emit_options(bytes: &[u8]) -> Option<JsxEmitOptions> {
+  let text = std::str::from_utf8(bytes).ok()?;
+  let value = jsonc_parser::parse_to_serde_value(
+    text,
+    &jsonc_parser::ParseOptions::default(),
+  )
+  .ok()
+  .flatten()?;
+  let co = value.get("compilerOptions")?;
+  Some(JsxEmitOptions {
+    jsx: json_opt_string(co.get("jsx")),
+    jsx_import_source: json_opt_string(co.get("jsxImportSource")),
+    jsx_factory: json_opt_string(co.get("jsxFactory")),
+    jsx_fragment_factory: json_opt_string(co.get("jsxFragmentFactory")),
+  })
+}
+
+fn json_opt_string(value: Option<&serde_json::Value>) -> Option<String> {
+  value.and_then(|v| v.as_str()).map(str::to_string)
 }
 
 fn rewrite_specifiers(
@@ -460,34 +540,36 @@ fn rewrite_specifiers(
         }
       }
       DependencyDescriptor::Dynamic(desc) => match &desc.argument {
-        deno_graph::DynamicArgument::String(specifier) => {
+        deno_graph::analysis::DynamicArgument::String(specifier) => {
           if let Some(specifier) = specifier_rewriter.rewrite(specifier, kind) {
             add_text_change(&mut text_changes, specifier, &desc.argument_range);
           }
         }
-        deno_graph::DynamicArgument::Template(_) => {}
-        deno_graph::DynamicArgument::Expr => {}
+        deno_graph::analysis::DynamicArgument::Template(_) => {}
+        deno_graph::analysis::DynamicArgument::Expr => {}
       },
     }
   }
 
   for ts_ref in &module_info.ts_references {
     match ts_ref {
-      deno_graph::TypeScriptReference::Path(s) => {
+      deno_graph::analysis::TypeScriptReference::Path(s) => {
         if let Some(specifier) =
           specifier_rewriter.rewrite(&s.text, RewriteKind::Declaration)
         {
           add_text_change(&mut text_changes, specifier, &s.range);
         }
       }
-      deno_graph::TypeScriptReference::Types(s) => {
+      deno_graph::analysis::TypeScriptReference::Types {
+        specifier, ..
+      } => {
         match kind {
           RewriteKind::Source => {
             // Type reference comments in JS are a Deno specific concept, and
             // are thus not relevant for the tarball. We remove them.
 
             let start_pos = source_text_info.range().start;
-            let start = s.range.start.as_source_pos(source_text_info);
+            let start = specifier.range.start.as_source_pos(source_text_info);
             let start = source_text_info.line_and_column_index(start);
 
             let line_start = source_text_info.line_start(start.line_index);
@@ -509,10 +591,14 @@ fn rewrite_specifiers(
             });
           }
           RewriteKind::Declaration => {
-            if let Some(specifier) =
-              specifier_rewriter.rewrite(&s.text, RewriteKind::Declaration)
+            if let Some(rewritten_specifier) = specifier_rewriter
+              .rewrite(&specifier.text, RewriteKind::Declaration)
             {
-              add_text_change(&mut text_changes, specifier, &s.range);
+              add_text_change(
+                &mut text_changes,
+                rewritten_specifier,
+                &specifier.range,
+              );
             }
           }
         }
@@ -522,9 +608,9 @@ fn rewrite_specifiers(
 
   for s in &module_info.jsdoc_imports {
     if let Some(specifier) =
-      specifier_rewriter.rewrite(&s.text, RewriteKind::Declaration)
+      specifier_rewriter.rewrite(&s.specifier.text, RewriteKind::Declaration)
     {
-      add_text_change(&mut text_changes, specifier, &s.range);
+      add_text_change(&mut text_changes, specifier, &s.specifier.range);
     }
   }
 
@@ -539,7 +625,7 @@ pub fn create_npm_dependencies<'a>(
     let (kind, req) = &*dep;
     match kind {
       DependencyKind::Jsr => {
-        let jsr_name = ScopedPackageName::new(req.req.name.clone())?;
+        let jsr_name = ScopedPackageName::new(req.req.name.to_string())?;
         let npm_name = NpmMappedJsrPackageName {
           scope: &jsr_name.scope,
           package: &jsr_name.package,
@@ -549,7 +635,7 @@ pub fn create_npm_dependencies<'a>(
       }
       DependencyKind::Npm => {
         npm_dependencies
-          .insert(req.req.name.clone(), req.req.version_req.to_string());
+          .insert(req.req.name.to_string(), req.req.version_req.to_string());
       }
     }
   }
@@ -581,27 +667,23 @@ pub fn create_npm_exports(
 
     if let Some(source_specifier) =
       follow_specifier(&specifier, source_rewrites)
+      && source_specifier.scheme() == "file"
+      && package_files.contains_key(source_specifier.path())
     {
-      if source_specifier.scheme() == "file"
-        && package_files.contains_key(source_specifier.path())
-      {
-        let new_specifier =
-          relative_import_specifier(&package_json_specifier, source_specifier);
-        conditions.default = Some(new_specifier);
-      }
+      let new_specifier =
+        relative_import_specifier(&package_json_specifier, source_specifier);
+      conditions.default = Some(new_specifier);
     }
 
     if let Some(types_specifier) =
       follow_specifier(&specifier, declaration_rewrites)
+      && types_specifier.scheme() == "file"
+      && package_files.contains_key(types_specifier.path())
     {
-      if types_specifier.scheme() == "file"
-        && package_files.contains_key(types_specifier.path())
-      {
-        let new_specifier =
-          relative_import_specifier(&package_json_specifier, types_specifier);
-        if conditions.default.as_ref() != Some(&new_specifier) {
-          conditions.types = Some(new_specifier);
-        }
+      let new_specifier =
+        relative_import_specifier(&package_json_specifier, types_specifier);
+      if conditions.default.as_ref() != Some(&new_specifier) {
+        conditions.types = Some(new_specifier);
       }
     }
 
@@ -618,33 +700,33 @@ mod tests {
 
   use async_tar::Archive;
   use deno_ast::ModuleSpecifier;
-  use deno_graph::source::MemoryLoader;
-  use deno_graph::source::NullFileSystem;
-  use deno_graph::source::Source;
   use deno_graph::BuildFastCheckTypeGraphOptions;
   use deno_graph::BuildOptions;
   use deno_graph::GraphKind;
   use deno_graph::ModuleGraph;
   use deno_graph::WorkspaceFastCheckOption;
   use deno_graph::WorkspaceMember;
-  use deno_semver::package::PackageNv;
+  use deno_graph::source::MemoryLoader;
+  use deno_graph::source::NullFileSystem;
+  use deno_graph::source::Source;
   use deno_semver::package::PackageReqReference;
   use futures::AsyncReadExt;
   use futures::StreamExt;
   use url::Url;
 
+  use crate::analysis::JsrResolver;
   use crate::analysis::ModuleAnalyzer;
   use crate::analysis::PassthroughJsrUrlProvider;
   use crate::db::DependencyKind;
   use crate::ids::PackagePath;
+  use crate::npm::NPM_TARBALL_REVISION;
   use crate::npm::tests::helpers;
   use crate::npm::tests::helpers::Spec;
-  use crate::npm::NPM_TARBALL_REVISION;
   use crate::tarball::exports_map_from_json;
 
-  use super::create_npm_tarball;
   use super::NpmTarballFiles;
   use super::NpmTarballOptions;
+  use super::create_npm_tarball;
 
   async fn test_npm_tarball(
     spec_path: &Path,
@@ -652,7 +734,7 @@ mod tests {
   ) -> Result<(), anyhow::Error> {
     let scope = spec.jsr_json.name.scope.clone();
     let package = spec.jsr_json.name.package.clone();
-    let version = spec.jsr_json.version.clone();
+    let version = spec.jsr_json.version.clone().unwrap();
 
     let exports = match exports_map_from_json(spec.jsr_json.exports.clone()) {
       Ok(exports) => exports,
@@ -690,14 +772,13 @@ mod tests {
 
     let loader = MemoryLoader::new(memory_files, vec![]);
     let mut graph = ModuleGraph::new(GraphKind::All);
-    let workspace_members = vec![WorkspaceMember {
+    let workspace_member = WorkspaceMember {
       base: Url::parse("file:///").unwrap(),
+      name: StackString::from_string(format!("@{}/{}", scope, package)),
+      version: Some(version.0.clone()),
       exports: exports.clone().into_inner(),
-      nv: PackageNv {
-        name: format!("@{}/{}", scope, package),
-        version: version.0.clone(),
-      },
-    }];
+    };
+    let workspace_members = vec![workspace_member.clone()];
 
     let mut roots: Vec<ModuleSpecifier> = vec![];
     for ex in exports.iter() {
@@ -710,13 +791,15 @@ mod tests {
     graph
       .build(
         roots,
+        vec![],
         &loader,
         BuildOptions {
           is_dynamic: false,
           module_analyzer: &module_analyzer,
-          workspace_members: &workspace_members,
           file_system: &NullFileSystem,
-          resolver: None,
+          resolver: Some(&JsrResolver {
+            member: workspace_member,
+          }),
           npm_resolver: None,
           reporter: None,
           jsr_url_provider: &PassthroughJsrUrlProvider,
@@ -730,9 +813,8 @@ mod tests {
       fast_check_cache: Default::default(),
       fast_check_dts: true,
       jsr_url_provider: &PassthroughJsrUrlProvider,
-      module_parser: Some(&module_analyzer.analyzer),
+      es_parser: Some(&module_analyzer.analyzer),
       resolver: None,
-      npm_resolver: None,
       workspace_fast_check: WorkspaceFastCheckOption::Enabled(
         &workspace_members,
       ),
@@ -769,6 +851,12 @@ mod tests {
       let len = "package".to_string().len();
       let formatted_path = path[len..].to_string();
 
+      let mode = entry.header().mode().unwrap();
+      assert_eq!(
+        mode, 0o644,
+        "file {path} has unexpected mode {mode:o}, want 0o644",
+      );
+
       let mut buf = vec![];
       entry.read_to_end(&mut buf).await?;
       transpiled_files.push((formatted_path, buf));
@@ -785,14 +873,14 @@ mod tests {
       );
       write!(
         &mut output,
-        "== {path} ==\n{}\n{}",
+        "== {path} ==\n{}{}",
         content,
         if content.ends_with('\n') { "" } else { "\n" }
       )?;
     }
 
     if std::env::var("UPDATE").is_ok() {
-      spec.output_file.text = output.clone();
+      spec.output_file.text.clone_from(&output);
       std::fs::write(spec_path, spec.emit())?;
     } else {
       assert_eq!(
@@ -804,6 +892,7 @@ mod tests {
     Ok(())
   }
 
+  use deno_semver::StackString;
   use std::path::Path;
 
   #[tokio::test]

--- a/api/testdata/specs/npm_tarballs/transpile_jsx_with_import_source.txt
+++ b/api/testdata/specs/npm_tarballs/transpile_jsx_with_import_source.txt
@@ -1,0 +1,59 @@
+# index.jsx
+/** @jsxImportSource npm:preact@^10.22.0 */
+export function Hello() {
+  return <div>hello</div>;
+}
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.jsx"
+}
+
+# npm:preact@^10.22.0
+<external>
+
+# npm:preact@^10.22.0/jsx-runtime
+<external>
+
+# output
+== /index.js ==
+import { jsx as _jsx } from "preact/jsx-runtime";
+/** @jsxImportSource npm:preact@^10.22.0 */ export function Hello() {
+  return /*#__PURE__*/ _jsx("div", {
+    children: "hello"
+  });
+}
+//# sourceMappingURL=index.js.map
+
+== /index.js.map ==
+{"version":3,"file":"index.js","sources":["./index.jsx"],"names":[],"mappings":";AAAA,yCAAyC,GACzC,OAAO,SAAS;EACd,qBAAO,KAAC;cAAI;;AACd"}
+
+== /index.jsx ==
+/** @jsxImportSource npm:preact@^10.22.0 */
+export function Hello() {
+  return <div>hello</div>;
+}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.jsx"
+}
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "1.0.0",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  },
+  "_jsr_revision": 0
+}

--- a/api/testdata/specs/npm_tarballs/transpile_tsx.txt
+++ b/api/testdata/specs/npm_tarballs/transpile_tsx.txt
@@ -1,0 +1,62 @@
+# index.tsx
+/** @jsxImportSource npm:preact@^10.22.0 */
+export function Hello(props: { name: string }) {
+  return <div>hello {props.name}</div>;
+}
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.tsx"
+}
+
+# npm:preact@^10.22.0
+<external>
+
+# npm:preact@^10.22.0/jsx-runtime
+<external>
+
+# output
+== /index.js ==
+import { jsxs as _jsxs } from "preact/jsx-runtime";
+/** @jsxImportSource npm:preact@^10.22.0 */ export function Hello(props) {
+  return /*#__PURE__*/ _jsxs("div", {
+    children: [
+      "hello ",
+      props.name
+    ]
+  });
+}
+//# sourceMappingURL=index.js.map
+
+== /index.js.map ==
+{"version":3,"file":"index.js","sources":["./index.tsx"],"names":[],"mappings":";AAAA,yCAAyC,GACzC,OAAO,SAAS,MAAM,KAAuB;EAC3C,qBAAO,MAAC;;MAAI;MAAO,MAAM,IAAI;;;AAC/B"}
+
+== /index.tsx ==
+/** @jsxImportSource npm:preact@^10.22.0 */
+export function Hello(props: { name: string }) {
+  return <div>hello {props.name}</div>;
+}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.tsx"
+}
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "1.0.0",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  },
+  "_jsr_revision": 0
+}

--- a/api/testdata/specs/npm_tarballs/transpile_tsx_compiler_options.txt
+++ b/api/testdata/specs/npm_tarballs/transpile_tsx_compiler_options.txt
@@ -1,0 +1,65 @@
+# index.tsx
+export function Hello(props: { name: string }) {
+  return <div>hello {props.name}</div>;
+}
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.tsx",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "npm:preact"
+  }
+}
+
+# npm:preact
+<external>
+
+# output
+== /index.js ==
+import { jsxs as _jsxs } from "preact/jsx-runtime";
+export function Hello(props) {
+  return /*#__PURE__*/ _jsxs("div", {
+    children: [
+      "hello ",
+      props.name
+    ]
+  });
+}
+//# sourceMappingURL=index.js.map
+
+== /index.js.map ==
+{"version":3,"file":"index.js","sources":["./index.tsx"],"names":[],"mappings":";AAAA,OAAO,SAAS,MAAM,KAAuB;EAC3C,qBAAO,MAAC;;MAAI;MAAO,MAAM,IAAI;;;AAC/B"}
+
+== /index.tsx ==
+export function Hello(props: { name: string }) {
+  return <div>hello {props.name}</div>;
+}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "1.0.0",
+  "exports": "./index.tsx",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "npm:preact"
+  }
+}
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "1.0.0",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  },
+  "_jsr_revision": 0
+}


### PR DESCRIPTION
## Summary

npm-compat tarballs previously left `.tsx` sources untranspiled. `MediaType::Tsx` fell through the packing match (it was not treated like TypeScript/MTS), so packages such as [`@luca/highlightable-textarea`](https://jsr.io/@luca/highlightable-textarea) shipped a raw `index.tsx` as the npm entry. Downstream consumers then failed to load the module.

This change:

- Treats `MediaType::Tsx` like TypeScript: emit JS (+ source map) and optional fast-check `.d.ts`.
- Reads package JSX `compilerOptions` (`jsx`, `jsxImportSource`, `jsxFactory`, `jsxFragmentFactory`) from `deno.json(c)` / `jsr.json(c)`, and honors `@jsxImportSource` file pragmas.
- Rewrites specifiers *after* `fold_program`, so injected `jsx-runtime` imports (e.g. `npm:preact/jsx-runtime` → `preact/jsx-runtime`) are remapped for npm.
- Bumps `NPM_TARBALL_REVISION` 11 → 12 so existing packages get new tarballs.

## Tests

New npm-tarball specs:

- `transpile_tsx.txt` — TSX + `@jsxImportSource` pragma
- `transpile_jsx_with_import_source.txt` — JSX + pragma
- `transpile_tsx_compiler_options.txt` — TSX + `compilerOptions.jsx` / `jsxImportSource`

Fixes #996