### PR TITLE
fix: publishing tasks with oversized version meta wedge in pending forever

### DIFF
--- a/api/migrations/20260824000000_package_versions_latest_index_row_size.sql
+++ b/api/migrations/20260824000000_package_versions_latest_index_row_size.sql
@@ -1,0 +1,12 @@
+-- Drop INCLUDE (meta) from the latest-version index. INCLUDE columns are
+-- stored inline in the b-tree index tuple and can never be TOASTed
+-- out-of-line, so an index row is hard-capped at ~8191 bytes (after
+-- compression). A `meta` above that cap (e.g. `entrypoints_without_docs`
+-- listing thousands of undocumented entrypoints) made the INSERT INTO
+-- package_versions fail, permanently wedging the publishing task in
+-- `pending` (jsr-io/jsr#1505). The lateral latest-meta lookup this covered
+-- is a LIMIT 1 probe, so losing the index-only scan costs a single heap
+-- fetch per package.
+DROP INDEX IF EXISTS idx_package_versions_latest;
+CREATE INDEX idx_package_versions_latest ON package_versions (scope, name, version DESC)
+  WHERE is_yanked = false AND version NOT LIKE '%-%';

--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -348,6 +348,14 @@ fn generate_score(
   }
 }
 
+/// Cap on how many undocumented entrypoints are recorded in
+/// `PackageVersionMeta`. The full list is unbounded (one entry per export) and
+/// `meta` is stored in the database and returned in API responses, so a
+/// package with tens of thousands of undocumented entrypoints would bloat
+/// both (jsr-io/jsr#1505). `all_entrypoints_docs` stays accurate: a capped
+/// list is non-empty iff the uncapped list was.
+pub(crate) const MAX_ENTRYPOINTS_WITHOUT_DOCS: usize = 100;
+
 fn entrypoints_missing_module_doc(
   documents_by_url: &ParseOutput,
   main_entrypoint: Option<ModuleSpecifier>,
@@ -394,6 +402,7 @@ fn entrypoints_missing_module_doc(
     missing.push(name);
   }
 
+  missing.truncate(MAX_ENTRYPOINTS_WITHOUT_DOCS);
   missing
 }
 
@@ -1415,6 +1424,25 @@ mod tests {
     );
 
     assert_eq!(missing, vec!["./utils".to_string()]);
+  }
+
+  #[test]
+  fn entrypoints_missing_docs_caps_list() {
+    let mut output = indexmap::IndexMap::new();
+    let mut exports_map = indexmap::IndexMap::new();
+    for i in 0..(super::MAX_ENTRYPOINTS_WITHOUT_DOCS + 50) {
+      output.insert(
+        deno_ast::ModuleSpecifier::parse(&format!("file:///m{i}.ts")).unwrap(),
+        make_document(make_js_doc(None), vec![]),
+      );
+      exports_map.insert(format!("./m{i}"), format!("./m{i}.ts"));
+    }
+    let exports = crate::db::ExportsMap::new(exports_map);
+
+    let missing =
+      super::entrypoints_missing_module_doc(&output, None, false, &exports);
+
+    assert_eq!(missing.len(), super::MAX_ENTRYPOINTS_WITHOUT_DOCS);
   }
 
   #[test]

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -315,6 +315,7 @@ pub async fn requeue_publishing_tasks(req: Request<Body>) -> ApiResult<()> {
     let span = Span::current();
     let fut = publish_task(
       publishing_task_id,
+      0,
       buckets,
       license_store,
       registry,

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1113,6 +1113,7 @@ pub async fn version_publish_handler(
     let span = Span::current();
     let fut = publish_task(
       publishing_task.id,
+      0,
       buckets,
       license_store,
       registry_url,

--- a/api/src/db/tests.rs
+++ b/api/src/db/tests.rs
@@ -695,6 +695,57 @@ async fn create_package_version_and_finalize_publishing_task() {
 }
 
 #[tokio::test]
+async fn package_version_with_large_meta() {
+  let db = EphemeralDatabase::create().await;
+
+  let user_id = uuid::Uuid::default();
+  let scope_name: ScopeName = "scope".try_into().unwrap();
+  let package_name: PackageName = "testpkg".try_into().unwrap();
+  let version: Version = "1.0.0".try_into().unwrap();
+
+  db.create_scope(
+    &user_id,
+    false,
+    &scope_name,
+    user_id,
+    &ScopeDescription::default(),
+  )
+  .await
+  .unwrap();
+  let CreatePackageResult::Ok(package) =
+    db.create_package(&scope_name, &package_name).await.unwrap()
+  else {
+    unreachable!()
+  };
+
+  // Regression test for jsr-io/jsr#1505: `meta` used to be an INCLUDE column
+  // of idx_package_versions_latest, so a meta larger than Postgres' ~8KB
+  // b-tree index row cap (e.g. thousands of undocumented entrypoints) made
+  // this insert fail, permanently wedging the publishing task. The version
+  // must be non-prerelease and non-yanked so the row lands in that partial
+  // index.
+  let meta = PackageVersionMeta {
+    entrypoints_without_docs: (0..20_000)
+      .map(|i| format!("./entrypoint{i}"))
+      .collect(),
+    ..Default::default()
+  };
+  db.create_package_version_for_test(NewPackageVersion {
+    scope: &package.scope,
+    name: &package.name,
+    version: &version,
+    user_id: None,
+    readme_path: None,
+    exports: &ExportsMap::mock(),
+    uses_npm: false,
+    meta,
+    license: "MIT".to_string(),
+  })
+  .await
+  .unwrap();
+}
+
+#[tokio::test]
 async fn package_files() {
   let db = EphemeralDatabase::create().await;
 

--- a/api/src/publish.rs
+++ b/api/src/publish.rs
@@ -46,13 +46,32 @@ use tracing::instrument;
 use url::Url;
 use uuid::Uuid;
 
+/// How many times a publishing task may fail with a retryable error before it
+/// is marked as failed instead of being handed back to the task queue. Without
+/// this bound, a deterministic "retryable" error (e.g. the database rejecting
+/// the version insert, jsr-io/jsr#1505) burns through all of Cloud Tasks'
+/// retries and then strands the task in `pending` forever, with the client
+/// polling indefinitely. Must be below the queue's `max_attempts` (30, see
+/// terraform/queues.tf) or Cloud Tasks gives up first and the failure is
+/// never recorded.
+const MAX_PUBLISH_ATTEMPTS: u32 = 10;
+
 #[instrument(
   name = "POST /tasks/publish",
   skip(req),
   err,
-  fields(publishing_task_id)
+  fields(publishing_task_id, task_retry_count)
 )]
 pub async fn publish_handler(mut req: Request<Body>) -> ApiResult<()> {
+  // Number of times Cloud Tasks has retried this task; 0 on the first
+  // attempt. Absent when the handler is invoked outside Cloud Tasks.
+  let task_retry_count: u32 = req
+    .headers()
+    .get("X-CloudTasks-TaskRetryCount")
+    .and_then(|v| v.to_str().ok())
+    .and_then(|v| v.parse().ok())
+    .unwrap_or(0);
+  tracing::Span::current().record("task_retry_count", task_retry_count);
   let publishing_task_id: Uuid = decode_json(&mut req).await?;
 
   let db = req.data::<Database>().unwrap().clone();
@@ -67,6 +86,7 @@ pub async fn publish_handler(mut req: Request<Body>) -> ApiResult<()> {
 
   publish_task(
     publishing_task_id,
+    task_retry_count,
     buckets,
     license_store,
     registry_url,
@@ -97,6 +117,7 @@ pub async fn publish_handler(mut req: Request<Body>) -> ApiResult<()> {
 )]
 pub async fn publish_task(
   publish_id: Uuid,
+  task_retry_count: u32,
   buckets: Buckets,
   license_store: LicenseStore,
   registry_url: Url,
@@ -129,7 +150,30 @@ pub async fn publish_task(
         )
         .await;
         if let Err(err) = res {
-          // retryable errors
+          // A retryable error on the final allowed attempt is recorded as a
+          // failure so the client stops polling; before that, the task is
+          // handed back to the queue as `pending` for another attempt. The
+          // underlying error is only logged — it can contain infrastructure
+          // internals that don't belong in a user-facing message.
+          if task_retry_count + 1 >= MAX_PUBLISH_ATTEMPTS {
+            error!(
+              "publishing task failed after {} attempts, giving up: {}",
+              task_retry_count + 1,
+              err
+            );
+            db.update_publishing_task_status(
+              None,
+              publishing_task.id,
+              PublishingTaskStatus::Processing,
+              PublishingTaskStatus::Failure,
+              Some(PublishingTaskError {
+                code: "internalError".to_string(),
+                message: "the registry repeatedly failed to process this publish; please retry, and report the problem at https://github.com/jsr-io/jsr/issues if it keeps happening".to_string(),
+              }),
+            )
+            .await?;
+            return Ok(());
+          }
           db.update_publishing_task_status(
             None,
             publishing_task.id,
@@ -618,6 +662,7 @@ pub mod tests {
 
     publish_task(
       task.0.id,
+      0,
       t.buckets(),
       t.license_store(),
       t.registry_url(),
@@ -636,6 +681,147 @@ pub mod tests {
         .unwrap()
         .0,
     )
+  }
+
+  // Regression test for jsr-io/jsr#1505: a package with many undocumented
+  // entrypoints publishes successfully, and the stored meta records only a
+  // capped list of them.
+  #[tokio::test]
+  async fn publish_many_undocumented_entrypoints() {
+    let n = crate::analysis::MAX_ENTRYPOINTS_WITHOUT_DOCS + 50;
+
+    let mut tar_bytes = Vec::new();
+    let mut tar = tar::Builder::new(&mut tar_bytes);
+    let mut append = |path: &str, content: &[u8]| {
+      let mut header = tar::Header::new_gnu();
+      header.set_size(content.len() as u64);
+      header.set_mode(0o644);
+      header.set_cksum();
+      tar.append_data(&mut header, path, content).unwrap();
+    };
+
+    let mut exports = serde_json::Map::new();
+    exports.insert(".".into(), "./mod.ts".into());
+    append("mod.ts", b"/** Main module. */\nexport const a = 1;\n");
+    for i in 0..n {
+      // No module-level doc comment, so every one of these entrypoints lands
+      // in `meta.entrypoints_without_docs`.
+      append(
+        &format!("e{i}.ts"),
+        format!("export const e{i} = {i};\n").as_bytes(),
+      );
+      exports.insert(format!("./e{i}"), format!("./e{i}.ts").into());
+    }
+    let config = json!({
+      "name": "@scope/foo",
+      "version": "1.2.3",
+      "license": "MIT",
+      "exports": exports,
+    });
+    append("jsr.json", serde_json::to_vec(&config).unwrap().as_slice());
+    tar.finish().unwrap();
+    drop(tar);
+
+    let mut gz_bytes = Vec::new();
+    let mut encoder = GzEncoder::new(&mut gz_bytes, Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap();
+
+    let t = TestSetup::new().await;
+    let task = process_tarball_setup(&t, Bytes::from(gz_bytes)).await;
+    assert_eq!(
+      task.status,
+      PublishingTaskStatus::Success,
+      "{:?}",
+      task.error
+    );
+
+    let package_name = PackageName::try_from("foo").unwrap();
+    let version = Version::try_from("1.2.3").unwrap();
+    let package_version = t
+      .db()
+      .get_package_version(
+        &"scope".try_into().unwrap(),
+        &package_name,
+        &version,
+      )
+      .await
+      .unwrap()
+      .unwrap();
+    assert!(!package_version.meta.all_entrypoints_docs);
+    assert_eq!(
+      package_version.meta.entrypoints_without_docs.len(),
+      crate::analysis::MAX_ENTRYPOINTS_WITHOUT_DOCS
+    );
+  }
+
+  #[tokio::test]
+  async fn publish_fails_fast_after_max_attempts() {
+    let t = TestSetup::new().await;
+    let scope_name = "scope".try_into().unwrap();
+    let package_name = PackageName::try_from("foo").unwrap();
+    let version = Version::try_from("1.2.3").unwrap();
+
+    let res = t
+      .db()
+      .create_package(&scope_name, &package_name)
+      .await
+      .unwrap();
+    assert!(matches!(res, crate::db::CreatePackageResult::Ok(_)));
+
+    let CreatePublishingTaskResult::Created(task) = t
+      .db()
+      .create_publishing_task(NewPublishingTask {
+        user_id: Some(t.user1.user.id),
+        package_scope: &scope_name,
+        package_name: &package_name,
+        package_version: &version,
+        config_file: &PackagePath::try_from("/jsr.json").unwrap(),
+      })
+      .await
+      .unwrap()
+    else {
+      unreachable!()
+    };
+
+    // No tarball was uploaded, so processing fails with a retryable error.
+    // Below the attempt cap the task goes back to `pending` for the queue to
+    // retry, and the error propagates so Cloud Tasks schedules that retry.
+    let run = |retry_count| {
+      publish_task(
+        task.0.id,
+        retry_count,
+        t.buckets(),
+        t.license_store(),
+        t.registry_url(),
+        t.npm_url(),
+        t.fallback_registry_url.clone(),
+        t.db(),
+        None,
+        CachePurge(None),
+      )
+    };
+    run(0).await.unwrap_err();
+    let (task_after, _) = t
+      .db()
+      .get_publishing_task(task.0.id)
+      .await
+      .unwrap()
+      .unwrap();
+    assert_eq!(task_after.status, PublishingTaskStatus::Pending);
+    assert!(task_after.error.is_none());
+
+    // On the final allowed attempt the task is marked as failed instead, so
+    // clients stop polling (jsr-io/jsr#1505).
+    run(MAX_PUBLISH_ATTEMPTS - 1).await.unwrap();
+    let (task_after, _) = t
+      .db()
+      .get_publishing_task(task.0.id)
+      .await
+      .unwrap()
+      .unwrap();
+    assert_eq!(task_after.status, PublishingTaskStatus::Failure);
+    assert_eq!(task_after.error.unwrap().code, "internalError");
   }
 
   pub fn create_mock_tarball(name: &str) -> Bytes {

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -251,11 +251,26 @@ resource "google_cloud_run_v2_service" "registry_api_tasks" {
     # task.
     max_instance_request_concurrency = 1
 
+    # Publishing a package with tens of thousands of files needs longer than
+    # the 300s default. Cloud Tasks abandons a buffered dispatch after its
+    # fixed 10 minute deadline, so anything above 600s is unreachable anyway.
+    timeout = "600s"
+
     containers {
       image = var.api_image_id
       args = [
         "--tasks", "--api=false", "--database_pool_size=1"
       ]
+
+      # Analyzing a package with ~20k modules peaks near 512Mi (the default
+      # limit), which risks the instance being OOM-killed mid-publish and the
+      # task stranding in `processing` until the reaper picks it up.
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "2Gi"
+        }
+      }
 
       dynamic "env" {
         for_each = local.api_envs


### PR DESCRIPTION
## The bug

Publishing a package whose version `meta` exceeds ~8KB — in practice, a package with a few thousand exports whose modules lack module-level doc comments — never completes. The upload succeeds, the task is created, and the status page shows the task pending forever while the CLI polls indefinitely (#1505).

Root cause: `idx_package_versions_latest` (added in #1372) declares `INCLUDE (meta)`. Postgres stores INCLUDE columns inline in the b-tree index tuple and never TOASTs them out-of-line, so an index row is hard-capped at ~8191 bytes (after compression). `meta.entrypoints_without_docs` holds one entry per undocumented export, so large-export packages blow the cap and the `INSERT INTO package_versions` fails:

```
error returned from database: index row requires 13464 bytes, maximum size is 8191
```

That error is classified as retryable, so `publish_task` resets the task to `pending` and returns 500; Cloud Tasks retries the identical deterministic failure 30 times, then gives up silently, stranding the task in `pending` with no error ever surfaced.

Verified by publishing a synthetic 4,000-export package through the full pipeline in the test harness (fails exactly as above), and the same package with a module doc on every entrypoint (publishes fine — the trigger is meta size, not export count).

## The fix

- **Migration**: rebuild `idx_package_versions_latest` without `INCLUDE (meta)`. The covered lookup is a `LIMIT 1` lateral probe, so this costs one heap fetch per package. (If the transactional `DROP`+`CREATE` lock is a concern on prod, the replacement index can be pre-created `CONCURRENTLY` by hand before deploying.)
- **Cap `entrypoints_without_docs` at 100 entries**. The unbounded list also bloated every API response and Algolia record carrying meta. `all_entrypoints_docs` stays accurate: a capped list is non-empty iff the uncapped one was.
- **Fail fast**: `publish_handler` reads `X-CloudTasks-TaskRetryCount`; a retryable error on the 10th attempt marks the task `Failure` with a user-facing `internalError` instead of handing it back to the queue. Clients stop polling, and the version number becomes usable again (`create_publishing_task` only blocks on non-failure tasks).
- **Headroom**: the `registry-api-tasks` Cloud Run service gets 2Gi memory (analyzing a ~20k-module package peaks near the old 512Mi default, risking OOM mid-publish) and a 600s request timeout (Cloud Tasks abandons buffered dispatches at 10 minutes, so 600s is the useful ceiling).

With these changes a 19,201-export package publishes end-to-end in ~25s in the test harness, so no exports-count limit is needed.

## Tests

- `db::tests::package_version_with_large_meta` — inserts a version whose meta lists 20,000 entrypoints; fails on the old schema, passes with the migration
- `publish::tests::publish_many_undocumented_entrypoints` — full-pipeline publish with 150 undocumented exports succeeds and stores the capped list
- `publish::tests::publish_fails_fast_after_max_attempts` — below the cap the task returns to `pending` and the error propagates; on the final attempt it is marked `Failure` with `internalError`
- `analysis::tests::entrypoints_missing_docs_caps_list`

## Follow-up (ops, after deploy)

Requeue the stuck tasks for `@marianmeres/icons-fns@6.0.0`/`6.0.1` and `@marianmeres/emoji-fns@2.0.1` via the admin endpoint — their tarballs are still in the publishing bucket and should publish cleanly, and terraform apply for the Cloud Run changes.

Fixes #1505