### PR TITLE
fix: unbreak support email delivery, and sort out the ticket page's controls

### DIFF
--- a/api/src/api/hooks.rs
+++ b/api/src/api/hooks.rs
@@ -888,6 +888,43 @@ mod integration {
   }
 
   #[tokio::test]
+  async fn a_delivery_is_not_lost_when_no_sender_is_configured() {
+    let t = TestSetup::new().await;
+    let db = t.ephemeral_database.database.as_ref().unwrap();
+
+    let id = db
+      .enqueue_email(crate::db::NewEmailDelivery {
+        to_address: "someone@example.com".to_owned(),
+        subject: "subject".to_owned(),
+        body_text: "text".to_owned(),
+        body_html: "<p>html</p>".to_owned(),
+        message_id: None,
+        in_reply_to: None,
+        reference_ids: vec![],
+      })
+      .await
+      .unwrap();
+
+    // The queue dispatches to a service that has no Postmark credential. This
+    // used to be swallowed with a 200, which marked the delivery done without
+    // ever sending it. It must be recorded as a failure instead, so the mail is
+    // still there to send once the configuration is fixed.
+    let terminal = crate::emails::deliver(db, None, id).await.unwrap();
+    assert!(!terminal, "a missing sender must not end the delivery");
+
+    let pending = db.get_pending_email_delivery(id).await.unwrap().unwrap();
+    assert_eq!(pending.attempts, 1);
+    assert!(pending.last_error.unwrap().contains("no email sender"));
+    assert!(pending.sent_at.is_none());
+
+    // And it is still visible to the sweeper, so it goes out after a fix.
+    assert_eq!(
+      db.list_stale_email_deliveries(0, 10).await.unwrap(),
+      vec![id]
+    );
+  }
+
+  #[tokio::test]
   async fn a_delivery_is_abandoned_after_too_many_failures() {
     let t = TestSetup::new().await;
     let db = t.ephemeral_database.database.as_ref().unwrap();

--- a/api/src/emails/mod.rs
+++ b/api/src/emails/mod.rs
@@ -366,7 +366,7 @@ pub async fn enqueue(
       }
     }
     None => {
-      if let Err(err) = deliver(db, email_sender, id).await {
+      if let Err(err) = deliver(db, Some(email_sender), id).await {
         tracing::error!(
           delivery_id = %id,
           "failed to send email inline: {:?}",
@@ -394,13 +394,35 @@ pub struct SendEmailTask {
 #[instrument(name = "emails::deliver", skip(db, email_sender), err)]
 pub async fn deliver(
   db: &crate::db::Database,
-  email_sender: &EmailSender,
+  email_sender: Option<&EmailSender>,
   id: uuid::Uuid,
 ) -> Result<bool, anyhow::Error> {
   let Some(delivery) = db.get_pending_email_delivery(id).await? else {
     // Already sent or abandoned. Cloud Tasks redelivering a task it has already
     // run must not produce a second email.
     return Ok(true);
+  };
+
+  // A delivery can reach a deployment that has no Postmark credential — most
+  // easily by the queue dispatching to a service that was never given one.
+  // Recorded as an ordinary failure rather than swallowed, so it retries if the
+  // configuration is fixed, and is eventually abandoned with a readable reason
+  // instead of disappearing.
+  let Some(email_sender) = email_sender else {
+    let abandoned = db
+      .record_email_delivery_failure(
+        id,
+        "no email sender is configured on this service",
+        MAX_EMAIL_ATTEMPTS,
+      )
+      .await?;
+    tracing::error!(
+      delivery_id = %id,
+      to = %delivery.to_address,
+      abandoned,
+      "cannot deliver email: no email sender is configured on this service"
+    );
+    return Ok(abandoned);
   };
 
   let thread = delivery

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -514,20 +514,12 @@ pub async fn send_email_handler(
   let db = req.data::<Database>().unwrap();
   let email_sender = req.data::<Option<EmailSender>>().unwrap();
 
-  let Some(email_sender) = email_sender else {
-    // Nothing can be delivered without a Postmark client. Returning 2xx stops
-    // Cloud Tasks retrying a task that can never succeed in this deployment.
-    error!("received an email delivery task but no email sender is configured");
-    return Ok(util::create_response(StatusCode::OK, "text/plain", "OK"));
-  };
-
-  let done =
-    emails::deliver(db, email_sender, task.id)
-      .await
-      .map_err(|err| {
-        error!("failed to process email delivery: {:?}", err);
-        ApiError::InternalServerError
-      })?;
+  let done = emails::deliver(db, email_sender.as_ref(), task.id)
+    .await
+    .map_err(|err| {
+      error!("failed to process email delivery: {:?}", err);
+      ApiError::InternalServerError
+    })?;
 
   if done {
     Ok(util::create_response(StatusCode::OK, "text/plain", "OK"))
@@ -575,12 +567,11 @@ pub async fn sweep_pending_emails_handler(req: Request<Body>) -> ApiResult<()> {
           error!(delivery_id = %id, "failed to re-drive email delivery: {:?}", err);
         }
       }
-      (None, Some(email_sender)) => {
-        if let Err(err) = emails::deliver(db, email_sender, id).await {
+      (None, _) => {
+        if let Err(err) = emails::deliver(db, email_sender.as_ref(), id).await {
           error!(delivery_id = %id, "failed to re-drive email delivery: {:?}", err);
         }
       }
-      (None, None) => break,
     }
   }
 

--- a/frontend/components/TicketActor.tsx
+++ b/frontend/components/TicketActor.tsx
@@ -44,12 +44,14 @@ export function TicketActor(
           </span>
           {!actor.emailVerified && (
             // The sending domain failed SPF or DKIM, so the address proves
-            // nothing about who actually sent this.
+            // nothing about who actually sent this. Muted rather than alarming:
+            // it sits on most inbound mail, and a warning that is always on
+            // stops being read.
             <span
-              class="rounded-full text-sm px-2 inline-block bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100"
-              title="This email failed SPF or DKIM checks, so the sender address is unverified."
+              class="rounded-full text-sm px-2 inline-block bg-jsr-yellow-100 text-jsr-gray-700 dark:bg-jsr-gray-700 dark:text-jsr-yellow-200"
+              title="This email did not pass SPF and DKIM checks, so the sender address is unverified."
             >
-              unverified sender
+              unverified
             </span>
           )}
         </>

--- a/frontend/components/TicketStatus.tsx
+++ b/frontend/components/TicketStatus.tsx
@@ -6,7 +6,8 @@ import TbClock from "tb-icons/TbClock";
 import TbMessage from "tb-icons/TbMessage";
 import type { TicketStatus } from "../utils/api_types.ts";
 
-/// The order staff work tickets in, and the order the admin filter offers them.
+/// The order staff work tickets in, and the order the status control offers
+/// them.
 export const TICKET_STATUSES: TicketStatus[] = [
   "open",
   "waiting_on_support",
@@ -68,17 +69,29 @@ function statusStyle(
   }
 }
 
+/// Just the coloured marker, without the label. Used in the timeline, where the
+/// surrounding sentence already names the status.
+export function TicketStatusDot(
+  { status }: { status: TicketStatus },
+): JSX.Element {
+  const { color, icon } = statusStyle(status);
+  return (
+    <div class={`${color} rounded-full p-1 shrink-0`}>
+      {icon}
+    </div>
+  );
+}
+
 export function TicketStatusBadge(
   { status, unread }: { status: TicketStatus; unread?: boolean },
 ): JSX.Element {
-  const { color, icon } = statusStyle(status);
   return (
     <div class="flex items-center gap-1.5">
       {unread
         ? <div class="rounded-full bg-orange-600 h-2.5 w-2.5" />
         // Keeps the badge aligned with rows that do carry an unread dot.
         : <div class="h-2.5 w-2.5" />}
-      <div class={`${color} rounded-full p-1`}>{icon}</div>
+      <TicketStatusDot status={status} />
       <span>{ticketStatusLabel(status)}</span>
     </div>
   );

--- a/frontend/islands/TicketMessageInput.tsx
+++ b/frontend/islands/TicketMessageInput.tsx
@@ -7,7 +7,6 @@ import type {
   NewTicketMessage,
   TicketStatus,
 } from "../utils/api_types.ts";
-import { TICKET_STATUSES } from "../components/TicketStatus.tsx";
 import { api, path } from "../utils/api.ts";
 import { useSignal } from "@preact/signals";
 
@@ -24,6 +23,7 @@ export function TicketMessageInput(
 ) {
   const message = useSignal("");
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     if (error) {
@@ -49,6 +49,7 @@ export function TicketMessageInput(
           return;
         }
 
+        setBusy(true);
         api.post(
           path`/tickets/${ticketId}`,
           {
@@ -61,6 +62,7 @@ export function TicketMessageInput(
             window.location.reload();
           } else {
             console.error(resp);
+            setBusy(false);
             setError("Could not send your message. Please try again.");
           }
         });
@@ -81,57 +83,52 @@ export function TicketMessageInput(
             </p>
           </div>
         )}
-        <button type="submit" class="button-primary">Send message</button>
+        {
+          /* The common status change, as one button. Anything else (spam, the
+            waiting-on states) is done through the status control at the top of
+            the page, so there is only ever one control per job. */
+        }
         {isStaff && (
-          <>
-            <select
-              class="input-container select"
-              value={status}
-              onChange={(e) => setStatus(ticketId, e.currentTarget.value)}
-            >
-              {TICKET_STATUSES.map((option) => (
-                <option key={option} value={option}>
-                  {option.replaceAll("_", " ")}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              class="button-danger"
-              onClick={(e) => {
-                e.preventDefault();
-                setStatus(ticketId, closed ? "open" : "closed");
-              }}
-            >
-              {closed
-                ? (
-                  <>
-                    <TbClock class="text-white" /> Re-open
-                  </>
-                )
-                : (
-                  <>
-                    <TbCheck class="text-white" /> Close
-                  </>
-                )} ticket
-            </button>
-          </>
+          <button
+            type="button"
+            class={closed ? "button-primary" : "button-danger"}
+            disabled={busy}
+            onClick={() => {
+              setBusy(true);
+              api.patch(
+                path`/admin/tickets/${ticketId}`,
+                {
+                  status: closed ? "open" : "closed",
+                } satisfies AdminUpdateTicketRequest,
+              ).then((resp) => {
+                if (resp.ok) {
+                  // deno-lint-ignore no-window
+                  window.location.reload();
+                } else {
+                  console.error(resp);
+                  setBusy(false);
+                  setError("Could not update the ticket.");
+                }
+              });
+            }}
+          >
+            {closed
+              ? (
+                <>
+                  <TbClock /> Reopen ticket
+                </>
+              )
+              : (
+                <>
+                  <TbCheck /> Close ticket
+                </>
+              )}
+          </button>
         )}
+        <button type="submit" class="button-primary" disabled={busy}>
+          Send message
+        </button>
       </div>
     </form>
   );
-}
-
-function setStatus(ticketId: string, status: string) {
-  api.patch(
-    path`/admin/tickets/${ticketId}`,
-    { status: status as TicketStatus } satisfies AdminUpdateTicketRequest,
-  ).then((resp) => {
-    if (resp.ok) {
-      // deno-lint-ignore no-window
-      window.location.reload();
-    } else {
-      console.error(resp);
-    }
-  });
 }

--- a/frontend/islands/TicketStatusControl.tsx
+++ b/frontend/islands/TicketStatusControl.tsx
@@ -1,0 +1,95 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+import { useState } from "preact/hooks";
+import type {
+  AdminUpdateTicketRequest,
+  TicketStatus,
+} from "../utils/api_types.ts";
+import {
+  TICKET_STATUSES,
+  TicketStatusBadge,
+  ticketStatusLabel,
+} from "../components/TicketStatus.tsx";
+import { api, path } from "../utils/api.ts";
+
+/// The ticket's status, and — for staff — the control that changes it.
+///
+/// Picking a value does not apply it. A native select fires `change` while the
+/// keyboard moves through its options, so applying on change means arrowing past
+/// "spam" silently marks the ticket as spam. The change only happens when the
+/// separate button is pressed, which also gives the reader somewhere to see what
+/// they are about to do.
+export function TicketStatusControl(
+  { ticketId, status, canEdit }: {
+    ticketId: string;
+    status: TicketStatus;
+    canEdit: boolean;
+  },
+) {
+  const [selected, setSelected] = useState<TicketStatus>(status);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!canEdit) {
+    return (
+      <div>
+        <span class="font-semibold">status:</span>
+        <br />
+        <TicketStatusBadge status={status} />
+      </div>
+    );
+  }
+
+  const dirty = selected !== status;
+
+  return (
+    <div>
+      <label
+        class="font-semibold"
+        for="ticket-status"
+      >
+        status:
+      </label>
+      <div class="flex items-center gap-2 mt-1">
+        <select
+          id="ticket-status"
+          class="input-container select py-1"
+          value={selected}
+          disabled={saving}
+          onChange={(e) => setSelected(e.currentTarget.value as TicketStatus)}
+        >
+          {TICKET_STATUSES.map((option) => (
+            <option key={option} value={option}>
+              {ticketStatusLabel(option)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          class="button-primary py-1"
+          // Nothing to apply until the selection actually differs, which also
+          // makes it obvious that picking a value on its own changed nothing.
+          disabled={!dirty || saving}
+          onClick={() => {
+            setSaving(true);
+            setError(null);
+            api.patch(
+              path`/admin/tickets/${ticketId}`,
+              { status: selected } satisfies AdminUpdateTicketRequest,
+            ).then((resp) => {
+              if (resp.ok) {
+                // deno-lint-ignore no-window
+                window.location.reload();
+              } else {
+                setSaving(false);
+                setError("Could not update the status.");
+              }
+            });
+          }}
+        >
+          {saving ? "Updating…" : "Update"}
+        </button>
+      </div>
+      {error && <p class="text-red-500 text-sm mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/routes/ticket.tsx
+++ b/frontend/routes/ticket.tsx
@@ -8,12 +8,18 @@ import { assertOk, path } from "../utils/api.ts";
 import { TicketMessageInput } from "../islands/TicketMessageInput.tsx";
 import { ClaimTicket } from "../islands/ClaimTicket.tsx";
 import { TicketActor } from "../components/TicketActor.tsx";
-import { TicketStatusBadge } from "../components/TicketStatus.tsx";
+import { TicketStatusControl } from "../islands/TicketStatusControl.tsx";
+import {
+  TicketStatusDot,
+  ticketStatusLabel,
+} from "../components/TicketStatus.tsx";
 import { TicketTitle } from "../components/TicketTitle.tsx";
 import type {
+  ApiTicketActor,
   ApiTicketAttachment,
   ApiTicketOverview,
   TicketKind,
+  TicketStatus,
 } from "../utils/api_types.ts";
 
 export default define.page<typeof handler>(function Ticket({
@@ -61,11 +67,11 @@ export default define.page<typeof handler>(function Ticket({
                 {value}
               </div>
             ))}
-          <div>
-            <span class="font-semibold">status:</span>
-            <br />
-            <TicketStatusBadge status={ticket.status} />
-          </div>
+          <TicketStatusControl
+            ticketId={ticket.id}
+            status={ticket.status}
+            canEdit={state.user?.isStaff ?? false}
+          />
         </div>
       </div>
 
@@ -81,26 +87,21 @@ export default define.page<typeof handler>(function Ticket({
         {ticket.events.map((event) => {
           if (event.kind === "message") {
             const { message } = event;
-            const fromReporter = message.direction === "inbound";
 
             return (
               <div
                 key={message.id}
                 class="w-full rounded border-1.5 border-current dark:border-cyan-700 px-4 py-3"
               >
-                <div class="flex justify-between mb-2">
-                  <div class="flex items-center gap-3">
+                <div class="flex justify-between items-start gap-4 mb-2">
+                  <div class="flex items-center gap-2 flex-wrap">
                     <TicketActor actor={message.author} />
-                    <span
-                      class={"rounded-full text-sm px-2 inline-block " +
-                        (fromReporter
-                          ? "bg-jsr-cyan-500 text-white"
-                          : "bg-jsr-yellow-400 text-jsr-gray-800")}
-                    >
-                      {fromReporter ? "User" : "Staff"}
-                    </span>
+                    <AuthorRole
+                      author={message.author}
+                      inbound={message.direction === "inbound"}
+                    />
                   </div>
-                  <div>
+                  <div class="text-sm text-gray-600 dark:text-gray-300 shrink-0">
                     {twas(new Date(message.updatedAt).getTime())}
                   </div>
                 </div>
@@ -117,19 +118,13 @@ export default define.page<typeof handler>(function Ticket({
               </div>
             );
           } else {
-            const { user, auditLog } = event;
-            const status = auditLog.meta.status as string | undefined;
-
             return (
-              <div class="flex items-center gap-1.5">
-                <p class="text-sm">
-                  <span class="font-semibold">{user.name}</span>{" "}
-                  set the ticket to{" "}
-                  <span class="font-semibold">{status ?? "a new status"}</span>
-                  {" "}
-                  {twas(new Date(auditLog.createdAt).getTime())}
-                </p>
-              </div>
+              <StatusChange
+                key={event.auditLog.createdAt}
+                actorName={event.user.name}
+                meta={event.auditLog.meta}
+                createdAt={event.auditLog.createdAt}
+              />
             );
           }
         })}
@@ -163,6 +158,66 @@ export default define.page<typeof handler>(function Ticket({
     </div>
   );
 });
+
+/// Which side of the conversation a message came from. Derived from the author
+/// rather than the direction alone: the automatic acknowledgement is outbound
+/// but nobody on the team wrote it, and labelling it "Staff" implies a human
+/// replied.
+function AuthorRole(
+  { author, inbound }: { author: ApiTicketActor; inbound: boolean },
+) {
+  if (author.kind === "system") {
+    return (
+      <span class="rounded-full text-sm px-2 inline-block bg-jsr-gray-200 text-jsr-gray-700 dark:bg-jsr-gray-700 dark:text-jsr-gray-100">
+        Automatic
+      </span>
+    );
+  }
+
+  return (
+    <span
+      class={"rounded-full text-sm px-2 inline-block " +
+        (inbound
+          ? "bg-jsr-cyan-500 text-white"
+          : "bg-jsr-yellow-400 text-jsr-gray-800")}
+    >
+      {inbound ? "User" : "Staff"}
+    </span>
+  );
+}
+
+/// A status change, rendered as a timeline marker rather than a stray line of
+/// prose: same left gutter as the message cards, muted, and carrying the colour
+/// of the status it moved to.
+function StatusChange(
+  { actorName, meta, createdAt }: {
+    actorName: string;
+    meta: Record<string, unknown>;
+    createdAt: string;
+  },
+) {
+  // Audit log entries written before the status enum recorded a `closed`
+  // boolean instead, and those rows are still in the log.
+  const status = (meta.status as TicketStatus | undefined) ??
+    (typeof meta.closed === "boolean"
+      ? (meta.closed ? "closed" : "open")
+      : undefined);
+
+  return (
+    <div class="flex items-center gap-2 pl-4 text-sm text-gray-600 dark:text-gray-300">
+      {status
+        ? <TicketStatusDot status={status} />
+        : <div class="rounded-full bg-jsr-gray-400 p-1 shrink-0" />}
+      <p>
+        <span class="font-semibold">{actorName}</span> set the status to{" "}
+        <span class="font-semibold">
+          {status ? ticketStatusLabel(status) : "a new value"}
+        </span>{" "}
+        · {twas(new Date(createdAt).getTime())}
+      </p>
+    </div>
+  );
+}
 
 function Attachments(
   { ticketId, claimToken, attachments }: {

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -314,6 +314,19 @@ resource "google_cloud_run_v2_service" "registry_api_tasks" {
         }
       }
 
+      // Outgoing email is delivered by /tasks/send_email, which runs here
+      // rather than on the API service, so the Postmark credential has to be
+      // present on this service too.
+      env {
+        name = "POSTMARK_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postmark_token.id
+            version = "latest"
+          }
+        }
+      }
+
       env {
         name = "TURNSTILE_SECRET_KEY"
         value_source {


### PR DESCRIPTION
Two fixes to the support ticket system, both found after #1501 went live.

---

## 1. Queued email was never delivered

Inbound support email opens a ticket and records the automatic reply on it, but the reply itself is never sent. The ticket dashboard shows *"Automatic reply: we received your email and opened this ticket."* while the sender's inbox stays empty.

### Cause

Delivering queued email moved to `/tasks/send_email` in #1501, which runs on the `registry-api-tasks` service. Only `registry-api` was ever given `POSTMARK_TOKEN`, so on the tasks service `email_sender` is `None` and nothing can be sent. Both services already run as the same service account, so the secret's IAM binding covered this — only the env var was missing.

The missing credential on its own would have been loud. What made it silent was the handler's own guard:

```rust
let Some(email_sender) = email_sender else {
    error!("received an email delivery task but no email sender is configured");
    return Ok(...OK);   // 200 → Cloud Tasks considers it delivered
};
```

It was meant to avoid retrying forever in a deployment with no email configured. Instead it turned a misconfiguration into permanent, invisible mail loss: Cloud Tasks read the 200 as success, and the delivery row was left pending with nothing to mark it.

### Fix

- `POSTMARK_TOKEN` added to `registry_api_tasks`.
- A missing sender is now recorded against the delivery like any other failure. It retries if the configuration is fixed, and is abandoned after the usual number of attempts with a readable `last_error` instead of disappearing. The handler no longer special-cases it.
- Regression test asserts a delivery with no sender stays pending, records the error, and is still visible to the sweeper.

### After deploying

Deliveries stranded by this are still pending (`sent_at IS NULL`, `abandoned_at IS NULL`), so the sweeper will pick them up within five minutes and send them — **a burst of belated auto-replies** to everyone who wrote in during the window. Probably what you want, since they were never acknowledged. To see what is queued first:

```sql
SELECT id, to_address, subject, attempts, last_error, created_at
FROM email_deliveries
WHERE sent_at IS NULL AND abandoned_at IS NULL
ORDER BY created_at;
```

If any are old enough to be confusing, mark them abandoned before deploying:

```sql
UPDATE email_deliveries
SET abandoned_at = now(), last_error = 'stranded before the tasks service had a Postmark token'
WHERE sent_at IS NULL AND abandoned_at IS NULL AND created_at < '<cutoff>';
```

---

## 2. The ticket page's status controls and timeline

The status dropdown and the close button both changed the status, so there were two controls for one job. The dropdown also applied on `change` — worse than it sounds, because a native select fires `change` as the keyboard moves through its options, so arrowing past "spam" silently marked the ticket as spam.

Now there is one control per job:

- The **footer** keeps a single close/reopen button — the common action, flipping label with the state.
- The **full status control moves to the header**, replacing the read-only badge, where you would look to change it. Picking a value selects it and nothing more; a separate **Update** button applies it, disabled until the selection actually differs.

Also in this commit:

- **Timeline events** were bare paragraphs sitting after the message cards with no visual relationship to them. They now carry the coloured marker of the status they moved to, sized and muted as timeline entries. Audit rows written before the status enum recorded `{closed: true}` rather than a status, and those rows are still in the log, so they are read too instead of rendering as "a new value".
- **The automatic acknowledgement was labelled "Staff"** — the label came from the message direction, and the acknowledgement is outbound, so it implied a person had replied. It is now derived from the author, and a JSR-generated message is marked "Automatic".
- **"unverified sender" was styled as an alarm.** It sits on nearly every inbound message (SPF does not survive a forwarding hop, which is how mail reaches the ticket system), and a warning that is always on stops being read. Muted to "unverified", explanation still on hover.

> **The UI half is not visually verified.** Local dev 404s on every route including `/`, so I could not get a screenshot before pushing. It type-checks and lints; the layout wants a human eye.

---

## Testing

230 API tests pass. Clippy `-D warnings`, `cargo fmt`, `sqlx prepare --check`, `terraform fmt`, `deno task lint:frontend`, `deno fmt` and license headers all clean.
