### PR TITLE
feat: allow scope admins to delete recently published package versions

### DIFF
--- a/api/.sqlx/query-1037aba623c2c6b3a8100adb4315159003c9effc17415fa70a0038b44551a5c6.json
+++ b/api/.sqlx/query-1037aba623c2c6b3a8100adb4315159003c9effc17415fa70a0038b44551a5c6.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE package_versions SET created_at = $4 WHERE scope = $1 AND name = $2 AND version = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1037aba623c2c6b3a8100adb4315159003c9effc17415fa70a0038b44551a5c6"
+}

--- a/api/.sqlx/query-1ed3f4e457d4d53e3915e0190d168be79929b750cf5a34a76cda77b5603745d7.json
+++ b/api/.sqlx/query-1ed3f4e457d4d53e3915e0190d168be79929b750cf5a34a76cda77b5603745d7.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT dependency_constraint\n      FROM package_version_dependencies\n      WHERE (dependency_kind = 'jsr' AND dependency_name = $1)\n        OR (dependency_kind = 'npm' AND dependency_name = $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "dependency_constraint",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1ed3f4e457d4d53e3915e0190d168be79929b750cf5a34a76cda77b5603745d7"
+}

--- a/api/.sqlx/query-2a0256f81593416d76784e5de6ab8d1d5507965cbeffacbe774deae5ff3cc4e5.json
+++ b/api/.sqlx/query-2a0256f81593416d76784e5de6ab8d1d5507965cbeffacbe774deae5ff3cc4e5.json
@@ -1,0 +1,72 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scope as \"scope: ScopeName\", name as \"name: PackageName\", version as \"version: Version\", revision, sha1, sha512, size, updated_at, created_at FROM npm_tarballs\n      WHERE scope = $1 AND name = $2 AND version = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scope: ScopeName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name: PackageName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "revision",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "sha1",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "sha512",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "size",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2a0256f81593416d76784e5de6ab8d1d5507965cbeffacbe774deae5ff3cc4e5"
+}

--- a/api/.sqlx/query-9eb62b1bc0bf975cbee6e79214176f36503cc3c3770ec6fee626bbd389996e51.json
+++ b/api/.sqlx/query-9eb62b1bc0bf975cbee6e79214176f36503cc3c3770ec6fee626bbd389996e51.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT COALESCE(SUM(count), 0) as \"count!\"\n      FROM version_download_counts_24h\n      WHERE scope = $1 AND package = $2 AND version = $3\n      ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9eb62b1bc0bf975cbee6e79214176f36503cc3c3770ec6fee626bbd389996e51"
+}

--- a/api/src/api.yml
+++ b/api/src/api.yml
@@ -1047,7 +1047,7 @@ paths:
 
     delete:
       summary: Delete package version
-      description: Deletes a package version. Scope admins may only delete versions that were published in the last 24 hours, have fewer than 10 downloads, and are not depended on by any other published package version.
+      description: Deletes a package version. Scope admins may only delete versions that were published in the last 24 hours, have fewer than 10 downloads, and are not the only version satisfying another published package's dependency constraint on this package (dependents that can resolve to a different version of the package do not block deletion).
       operationId: deletePackageVersion
       parameters:
         - name: scope

--- a/api/src/api.yml
+++ b/api/src/api.yml
@@ -1047,7 +1047,7 @@ paths:
 
     delete:
       summary: Delete package version
-      description: Deletes a package version. Only allowed for versions published in the last 24 hours with no dependents.
+      description: Deletes a package version. Scope admins may only delete versions that were published in the last 24 hours, have fewer than 10 downloads, and are not depended on by any other published package version.
       operationId: deletePackageVersion
       parameters:
         - name: scope
@@ -1072,7 +1072,7 @@ paths:
         "204":
           description: OK, no content
         "400":
-          description: Invalid request / Version has dependents / Version too old
+          description: Invalid request / Version has dependents / Version too old / Version has too many downloads
           content:
             application/json:
               schema:

--- a/api/src/api/errors.rs
+++ b/api/src/api/errors.rs
@@ -264,6 +264,14 @@ errors!(
     status: BAD_REQUEST,
     "The requested package version has dependents. Only a version without dependents can be deleted.",
   },
+  DeleteVersionTooOld {
+    status: BAD_REQUEST,
+    "The requested package version was published more than 24 hours ago. Only versions published in the last 24 hours can be deleted.",
+  },
+  DeleteVersionTooManyDownloads {
+    status: BAD_REQUEST,
+    "The requested package version has already been downloaded too many times to be deleted.",
+  },
   TicketNotFound {
     status: NOT_FOUND,
     "The requested ticket was not found.",

--- a/api/src/api/errors.rs
+++ b/api/src/api/errors.rs
@@ -262,7 +262,7 @@ errors!(
   },
   DeleteVersionHasDependents {
     status: BAD_REQUEST,
-    "The requested package version has dependents. Only a version without dependents can be deleted.",
+    "The requested package version is depended on by other published packages, and no other version satisfies their version constraints. It cannot be deleted.",
   },
   DeleteVersionTooOld {
     status: BAD_REQUEST,

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1342,17 +1342,33 @@ pub async fn version_delete_handler(
   let constraints = db
     .list_package_dependent_constraints(&scope, &package)
     .await?;
-  for constraint in constraints {
-    let blocking = match VersionReq::parse_from_specifier(&constraint) {
-      Ok(req) => match req.range() {
-        Some(range) => range.satisfies(&version.0),
-        // A dist-tag constraint cannot be proven to exclude this version.
-        None => true,
-      },
-      Err(_) => true,
-    };
-    if blocking {
-      return Err(ApiError::DeleteVersionHasDependents);
+  if !constraints.is_empty() {
+    // A dependent constraint only blocks deletion if this version is the sole
+    // remaining non-yanked version satisfying it. Dependents that can resolve
+    // to a sibling version are not broken by the deletion, so a broad range
+    // (like a wildcard) does not pin every version of the package.
+    let remaining_versions = db
+      .list_package_versions_for_metadata(&scope, &package)
+      .await?
+      .into_iter()
+      .filter(|v| !v.is_yanked && v.version != version)
+      .map(|v| v.version)
+      .collect::<Vec<_>>();
+    for constraint in constraints {
+      let blocking = match VersionReq::parse_from_specifier(&constraint) {
+        Ok(req) => match req.range() {
+          Some(range) => {
+            range.satisfies(&version.0)
+              && !remaining_versions.iter().any(|v| range.satisfies(&v.0))
+          }
+          // A dist-tag constraint cannot be proven to exclude this version.
+          None => true,
+        },
+        Err(_) => true,
+      };
+      if blocking {
+        return Err(ApiError::DeleteVersionHasDependents);
+      }
     }
   }
 
@@ -5390,6 +5406,65 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     resp
       .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionHasDependents")
       .await;
+
+    // publish foo@1.3.0, which is also matched by bar's `@1` constraint
+    let version13 = Version::try_from("1.3.0").unwrap();
+    let task = process_tarball_setup2(
+      &t,
+      create_mock_tarball("ok3"),
+      &foo_name,
+      &version13,
+      false,
+    )
+    .await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
+
+    // with foo@1.2.3 yanked, foo@1.3.0 is the only non-yanked version that
+    // bar's `@1` constraint can resolve to, so it cannot be deleted
+    let version = Version::try_from("1.2.3").unwrap();
+    t.db()
+      .yank_package_version(
+        &t.user1.user.id,
+        false,
+        &scope_name,
+        &foo_name,
+        &version,
+        true,
+      )
+      .await
+      .unwrap();
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.3.0")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionHasDependents")
+      .await;
+
+    // once foo@1.2.3 is unyanked, bar's `@1` constraint can resolve to it, so
+    // foo@1.3.0 can be deleted even though bar depends on `@1`
+    t.db()
+      .yank_package_version(
+        &t.user1.user.id,
+        false,
+        &scope_name,
+        &foo_name,
+        &version,
+        false,
+      )
+      .await
+      .unwrap();
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.3.0")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp.expect_ok_no_content().await;
 
     // publish foo@2.0.0, which is not matched by bar's `@1` constraint
     let version2 = Version::try_from("2.0.0").unwrap();

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -17,6 +17,7 @@ use deno_graph::source::LoadError;
 use deno_graph::source::LoadOptions;
 use deno_graph::source::NullFileSystem;
 use deno_semver::StackString;
+use deno_semver::VersionReq;
 use futures::StreamExt;
 use futures::TryFutureExt;
 use futures::future::Either;
@@ -68,6 +69,7 @@ use crate::docs::GeneratedDocsOutput;
 use crate::external::algolia::AlgoliaClient;
 use crate::external::cloudflare::CachePurge;
 use crate::gcp;
+use crate::iam::IamInfo;
 use crate::iam::ReqIamExt;
 use crate::ids::PackageName;
 use crate::ids::PackagePath;
@@ -123,6 +125,10 @@ use super::ApiUpdatePackageRequest;
 use super::ApiUpdatePackageVersionRequest;
 
 pub const MAX_PUBLISH_TARBALL_SIZE: u64 = 20 * 1024 * 1024; // 20mb
+
+/// The maximum number of downloads a version may have to still be deletable by
+/// a scope admin.
+const MAX_DELETABLE_VERSION_DOWNLOADS: i64 = 10;
 
 pub struct PublishQueue(pub Option<gcp::Queue>);
 
@@ -1305,18 +1311,62 @@ pub async fn version_delete_handler(
   let registry_url = &req.data::<RegistryUrl>().unwrap().0;
   let npm_url = &req.data::<NpmUrl>().unwrap().0;
   let cache_purge = req.data::<CachePurge>().unwrap();
+  let algolia_client = req.data::<Option<AlgoliaClient>>().unwrap().clone();
+  let iam_sudo = req.context::<IamInfo>().unwrap().sudo;
 
   let iam = req.iam();
-  let staff = iam.check_admin_access()?;
+  let (user, sudo) = iam.check_scope_admin_access(&scope).await?;
+  // `check_scope_admin_access` only reports sudo for staff that are not scope
+  // members, so also treat a staff scope admin with sudo enabled as sudo.
+  let sudo = sudo || (user.is_staff && iam_sudo);
+  let user_id = user.id;
 
-  let count = db.count_package_dependents(&scope, &package).await?;
+  let package_version = db
+    .get_package_version(&scope, &package, &version)
+    .await?
+    .ok_or(ApiError::PackageVersionNotFound)?;
 
-  if count > 0 {
-    return Err(ApiError::DeleteVersionHasDependents);
+  if !sudo {
+    if Utc::now() - package_version.created_at > chrono::Duration::hours(24) {
+      return Err(ApiError::DeleteVersionTooOld);
+    }
+
+    let downloads = db
+      .get_package_version_total_downloads(&scope, &package, &version)
+      .await?;
+    if downloads >= MAX_DELETABLE_VERSION_DOWNLOADS {
+      return Err(ApiError::DeleteVersionTooManyDownloads);
+    }
   }
 
-  db.delete_package_version(&staff.id, &scope, &package, &version)
+  let constraints = db
+    .list_package_dependent_constraints(&scope, &package)
     .await?;
+  for constraint in constraints {
+    let blocking = match VersionReq::parse_from_specifier(&constraint) {
+      Ok(req) => match req.range() {
+        Some(range) => range.satisfies(&version.0),
+        // A dist-tag constraint cannot be proven to exclude this version.
+        None => true,
+      },
+      Err(_) => true,
+    };
+    if blocking {
+      return Err(ApiError::DeleteVersionHasDependents);
+    }
+  }
+
+  // Collect the npm tarball rows before the delete cascades them away.
+  let npm_tarballs = db
+    .list_npm_tarballs_for_version(&scope, &package, &version)
+    .await?;
+
+  let deleted = db
+    .delete_package_version(&user_id, sudo, &scope, &package, &version)
+    .await?;
+  if !deleted {
+    return Err(ApiError::PackageVersionNotFound);
+  }
 
   let v1_path = crate::s3_paths::docs_v1_path(&scope, &package, &version);
   let v2_path = crate::s3_paths::docs_v2_path(&scope, &package, &version);
@@ -1329,6 +1379,16 @@ pub async fn version_delete_handler(
   let path =
     crate::s3_paths::file_path_root_directory(&scope, &package, &version);
   buckets.modules_bucket.delete_directory(path.into()).await?;
+
+  for npm_tarball in npm_tarballs {
+    let path = crate::s3_paths::npm_tarball_path(
+      &scope,
+      &package,
+      &version,
+      npm_tarball.revision as u32,
+    );
+    buckets.npm_bucket.delete_file(path.into()).await?;
+  }
 
   upload_package_manifests(
     db,
@@ -1348,6 +1408,13 @@ pub async fn version_delete_handler(
       &package,
     ))
     .await;
+
+  if let Some(algolia_client) = algolia_client
+    && let Some((db_package, _, meta)) =
+      db.get_package(&scope, &package).await?
+  {
+    algolia_client.upsert_package(&db_package, &meta);
+  }
 
   Ok(
     Response::builder()
@@ -2933,16 +3000,19 @@ mod test {
   use crate::api::{ApiDependency, ApiReadmeSource};
   use crate::db::CreatePackageResult;
   use crate::db::CreatePublishingTaskResult;
+  use crate::db::DownloadKind;
   use crate::db::ExportsMap;
   use crate::db::NewGithubRepository;
   use crate::db::NewPackageVersion;
   use crate::db::NewPublishingTask;
   use crate::db::NewScopeInvite;
+  use crate::db::NewScopeMember;
   use crate::db::PackagePublishPermission;
   use crate::db::Permission;
   use crate::db::Permissions;
   use crate::db::PublishingTaskStatus;
   use crate::db::TokenType;
+  use crate::db::VersionDownloadCount;
   use crate::ids::{
     PackageName, PackagePath, ScopeDescription, ScopeName, Version,
   };
@@ -2955,6 +3025,7 @@ mod test {
   use crate::util::test::ApiResultExt;
   use crate::util::test::FakeFallbackRegistry;
   use crate::util::test::TestSetup;
+  use chrono::Utc;
   use hyper::Body;
   use hyper::StatusCode;
   use indexmap::IndexSet;
@@ -5251,12 +5322,31 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
   #[tokio::test]
   async fn delete_version() {
     let mut t = TestSetup::new().await;
+    let admin_token = t.user1.token.clone();
+    let member_token = t.user2.token.clone();
+    let non_member_token = t.user3.token.clone();
     let staff_token = t.staff_user.token.clone();
 
-    // unpublished package
+    let scope_name = t.scope.scope.clone();
+    let foo_name = PackageName::try_from("foo").unwrap();
+
+    t.db()
+      .add_user_to_scope(NewScopeMember {
+        scope: &scope_name,
+        user_id: t.user2.user.id,
+        is_admin: false,
+      })
+      .await
+      .unwrap();
+
+    let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
+
+    // deleting a version that does not exist is a 404
     let mut resp = t
       .http()
-      .get("/api/scopes/scope/packages/foo/versions/0.0.1/dependencies/graph")
+      .delete("/api/scopes/scope/packages/foo/versions/0.0.1")
+      .token(Some(&admin_token))
       .call()
       .await
       .unwrap();
@@ -5264,26 +5354,36 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
       .expect_err_code(StatusCode::NOT_FOUND, "packageVersionNotFound")
       .await;
 
-    let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;
-    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
-
-    // Now publish a package that has a few deps
-    let package_name = PackageName::try_from("bar").unwrap();
+    // publish bar@1.2.3, which depends on jsr:@scope/foo@1
+    let bar_name = PackageName::try_from("bar").unwrap();
     let version = Version::try_from("1.2.3").unwrap();
     let task = process_tarball_setup2(
       &t,
       create_mock_tarball("depends_on_ok"),
-      &package_name,
+      &bar_name,
       &version,
       false,
     )
     .await;
     assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
 
+    // foo@1.2.3 is matched by bar's `@1` constraint, so it cannot be deleted,
+    // not even by staff with sudo
     let mut resp = t
       .http()
-      .delete("/api/scopes/scope/packages/foo/versions/0.0.1")
+      .delete("/api/scopes/scope/packages/foo/versions/1.2.3")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionHasDependents")
+      .await;
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.2.3")
       .token(Some(&staff_token))
+      .sudo(true)
       .call()
       .await
       .unwrap();
@@ -5291,35 +5391,203 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
       .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionHasDependents")
       .await;
 
-    let mut resp = t
-      .http()
-      .delete("/api/scopes/scope/packages/bar/versions/1.2.3")
-      .token(Some(&staff_token))
-      .call()
-      .await
-      .unwrap();
-    resp.expect_ok_no_content().await;
-
-    let mut resp = t
-      .http()
-      .delete("/api/scopes/scope/packages/foo/versions/0.0.1")
-      .token(Some(&staff_token))
-      .call()
-      .await
-      .unwrap();
-    resp.expect_ok_no_content().await;
-
-    let package_name = PackageName::try_from("foo").unwrap();
-    let version = Version::try_from("0.0.1").unwrap();
+    // publish foo@2.0.0, which is not matched by bar's `@1` constraint
+    let version2 = Version::try_from("2.0.0").unwrap();
     let task = process_tarball_setup2(
       &t,
-      create_mock_tarball("ok"),
-      &package_name,
-      &version,
+      create_mock_tarball("ok2"),
+      &foo_name,
+      &version2,
       false,
     )
     .await;
-    assert_eq!(task.status, PublishingTaskStatus::Failure, "{:?}", task);
+    assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
+
+    // only scope admins may delete versions
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/2.0.0")
+      .token(Some(&member_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::FORBIDDEN, "actorNotScopeAdmin")
+      .await;
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/2.0.0")
+      .token(Some(&non_member_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::FORBIDDEN, "actorNotScopeMember")
+      .await;
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/2.0.0")
+      .token(Some(&staff_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::FORBIDDEN, "actorNotScopeMember")
+      .await;
+
+    // a version with too many downloads cannot be deleted by a scope admin
+    let time_bucket = Utc::now() - chrono::Duration::hours(48);
+    t.db()
+      .insert_download_entries(vec![VersionDownloadCount {
+        scope: scope_name.clone(),
+        package: foo_name.clone(),
+        version: version2.clone(),
+        time_bucket,
+        kind: DownloadKind::JsrMeta,
+        count: 10,
+      }])
+      .await
+      .unwrap();
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/2.0.0")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionTooManyDownloads")
+      .await;
+
+    // lower the download count below the threshold again
+    t.db()
+      .insert_download_entries(vec![VersionDownloadCount {
+        scope: scope_name.clone(),
+        package: foo_name.clone(),
+        version: version2.clone(),
+        time_bucket,
+        kind: DownloadKind::JsrMeta,
+        count: 5,
+      }])
+      .await
+      .unwrap();
+
+    // the npm tarball for foo@2.0.0 exists before deletion
+    let npm_tarballs = t
+      .db()
+      .list_npm_tarballs_for_version(&scope_name, &foo_name, &version2)
+      .await
+      .unwrap();
+    assert!(!npm_tarballs.is_empty());
+    let npm_tarball_paths = npm_tarballs
+      .iter()
+      .map(|tarball| {
+        crate::s3_paths::npm_tarball_path(
+          &scope_name,
+          &foo_name,
+          &version2,
+          tarball.revision as u32,
+        )
+      })
+      .collect::<Vec<_>>();
+    for path in &npm_tarball_paths {
+      let obj = t.buckets.npm_bucket.download(path.as_str().into()).await;
+      assert!(obj.unwrap().is_some(), "{path} missing before delete");
+    }
+
+    // now a scope admin can delete foo@2.0.0
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/2.0.0")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp.expect_ok_no_content().await;
+
+    let version = t
+      .db()
+      .get_package_version(&scope_name, &foo_name, &version2)
+      .await
+      .unwrap();
+    assert!(version.is_none());
+    for path in &npm_tarball_paths {
+      let obj = t.buckets.npm_bucket.download(path.as_str().into()).await;
+      assert!(obj.unwrap().is_none(), "{path} present after delete");
+    }
+
+    // a version published more than 24 hours ago cannot be deleted by a scope
+    // admin
+    let version = Version::try_from("1.2.3").unwrap();
+    t.db()
+      .set_package_version_created_at_for_test(
+        &scope_name,
+        &foo_name,
+        &version,
+        Utc::now() - chrono::Duration::hours(25),
+      )
+      .await
+      .unwrap();
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.2.3")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionTooOld")
+      .await;
+
+    // delete the dependent bar@1.2.3 (fresh, no dependents, no downloads)
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/bar/versions/1.2.3")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp.expect_ok_no_content().await;
+
+    // foo@1.2.3 is still too old for a scope admin, but staff with sudo
+    // bypasses the age and download restrictions
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.2.3")
+      .token(Some(&admin_token))
+      .call()
+      .await
+      .unwrap();
+    resp
+      .expect_err_code(StatusCode::BAD_REQUEST, "deleteVersionTooOld")
+      .await;
+    let mut resp = t
+      .http()
+      .delete("/api/scopes/scope/packages/foo/versions/1.2.3")
+      .token(Some(&staff_token))
+      .sudo(true)
+      .call()
+      .await
+      .unwrap();
+    resp.expect_ok_no_content().await;
+
+    // the publishing task for a deleted version survives, so the version
+    // cannot be re-published
+    let CreatePublishingTaskResult::Exists((task, _)) = t
+      .db()
+      .create_publishing_task(NewPublishingTask {
+        user_id: Some(t.user1.user.id),
+        package_scope: &scope_name,
+        package_name: &foo_name,
+        package_version: &version,
+        config_file: &PackagePath::try_from("/jsr.json").unwrap(),
+      })
+      .await
+      .unwrap()
+    else {
+      panic!("expected the old publishing task to block re-publishing");
+    };
+    assert_eq!(task.status, PublishingTaskStatus::Success);
   }
 
   #[tokio::test]

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -2163,17 +2163,18 @@ gitlab_id: r.user_gitlab_id,
   #[instrument(name = "Database::delete_package_version", skip(self), err)]
   pub async fn delete_package_version(
     &self,
-    staff_id: &Uuid,
+    actor_id: &Uuid,
+    is_sudo: bool,
     scope: &ScopeName,
     name: &PackageName,
     version: &Version,
-  ) -> Result<()> {
+  ) -> Result<bool> {
     let mut tx = self.pool.begin().await?;
 
     audit_log(
       &mut tx,
-      staff_id,
-      true,
+      actor_id,
+      is_sudo,
       "delete_package_version",
       json!({
       "scope": scope,
@@ -2183,19 +2184,49 @@ gitlab_id: r.user_gitlab_id,
     )
     .await?;
 
-    sqlx::query_as!(
-      PackageVersion,
+    let res = sqlx::query!(
       r#"DELETE FROM package_versions WHERE scope = $1 AND name = $2 AND version = $3"#,
       scope as _,
       name as _,
       version as _
     )
-      .execute(&mut *tx)
-      .await?;
+    .execute(&mut *tx)
+    .await?;
 
     tx.commit().await?;
 
-    Ok(())
+    Ok(res.rows_affected() > 0)
+  }
+
+  #[instrument(
+    name = "Database::list_package_dependent_constraints",
+    skip(self),
+    err
+  )]
+  pub async fn list_package_dependent_constraints(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+  ) -> Result<Vec<String>> {
+    let jsr_name = format!("@{scope}/{name}");
+    let npm_name = crate::npm::NpmMappedJsrPackageName {
+      scope,
+      package: name,
+    }
+    .to_string();
+    let constraints = sqlx::query!(
+      r#"SELECT DISTINCT dependency_constraint
+      FROM package_version_dependencies
+      WHERE (dependency_kind = 'jsr' AND dependency_name = $1)
+        OR (dependency_kind = 'npm' AND dependency_name = $2)"#,
+      jsr_name,
+      npm_name,
+    )
+    .map(|r| r.dependency_constraint)
+    .fetch_all(&self.pool)
+    .await?;
+
+    Ok(constraints)
   }
 
   #[instrument(name = "Database::list_package_files", skip(self), err)]
@@ -3874,6 +3905,55 @@ gitlab_id: r.user_gitlab_id,
     Ok(())
   }
 
+  #[cfg(test)]
+  #[instrument(
+    name = "Database::set_package_version_created_at_for_test",
+    skip(self),
+    err
+  )]
+  pub async fn set_package_version_created_at_for_test(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+    created_at: DateTime<Utc>,
+  ) -> Result<()> {
+    sqlx::query!(
+      r#"UPDATE package_versions SET created_at = $4 WHERE scope = $1 AND name = $2 AND version = $3"#,
+      scope as _,
+      name as _,
+      version as _,
+      created_at,
+    )
+    .execute(&self.pool)
+    .await?;
+
+    Ok(())
+  }
+
+  #[instrument(
+    name = "Database::list_npm_tarballs_for_version",
+    skip(self),
+    err
+  )]
+  pub async fn list_npm_tarballs_for_version(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+  ) -> Result<Vec<NpmTarball>> {
+    query_concat_as!(
+      NpmTarball,
+      "SELECT ", NPM_TARBALL_SELECT, " FROM npm_tarballs
+      WHERE scope = $1 AND name = $2 AND version = $3";
+      scope as _,
+      name as _,
+      version as _,
+    )
+    .fetch_all(&self.pool)
+    .await
+  }
+
   #[instrument(name = "Database::get_npm_tarball", skip(self), err)]
   pub async fn get_npm_tarball(
     &self,
@@ -4101,6 +4181,32 @@ gitlab_id: r.user_gitlab_id,
     )
       .fetch_all(&self.pool)
       .await
+  }
+
+  #[instrument(
+    name = "Database::get_package_version_total_downloads",
+    skip(self),
+    err
+  )]
+  pub async fn get_package_version_total_downloads(
+    &self,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+  ) -> Result<i64> {
+    sqlx::query!(
+      r#"
+      SELECT COALESCE(SUM(count), 0) as "count!"
+      FROM version_download_counts_24h
+      WHERE scope = $1 AND package = $2 AND version = $3
+      "#,
+      scope as _,
+      name as _,
+      version as _,
+    )
+    .map(|r| r.count)
+    .fetch_one(&self.pool)
+    .await
   }
 
   #[instrument(name = "Database::get_package_downloads_24h", skip(self), err)]

--- a/api/testdata/tarballs/ok2/jsr.json
+++ b/api/testdata/tarballs/ok2/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/foo",
+  "version": "2.0.0",
+  "exports": "./mod.ts",
+  "license": "MIT"
+}

--- a/api/testdata/tarballs/ok2/mod.ts
+++ b/api/testdata/tarballs/ok2/mod.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a test module.
+ *
+ * @module
+ */
+
+/**
+ * This is a test constant.
+ */
+export const hello = "Hello, world!";

--- a/api/testdata/tarballs/ok3/jsr.json
+++ b/api/testdata/tarballs/ok3/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/foo",
+  "version": "1.3.0",
+  "exports": "./mod.ts",
+  "license": "MIT"
+}

--- a/api/testdata/tarballs/ok3/mod.ts
+++ b/api/testdata/tarballs/ok3/mod.ts
@@ -1,0 +1,11 @@
+/**
+ * This is a test module.
+ *
+ * @module
+ */
+
+/**
+ * This is a test constant.
+ */
+export const hello = "Hello, world!";
+export const 读取多键1 = 1;

--- a/frontend/docs/api.md
+++ b/frontend/docs/api.md
@@ -154,6 +154,11 @@ The version metadata field is immutable, so it can be cached indefinitely.
 Because of this immutability, the `yanked` field is not included in the version
 metadata. Instead, retrieve yanked status from the package metadata.
 
+Note that in the rare case that a version is
+[deleted](/docs/packages#deleting-a-version), its modules and version metadata
+are removed from the registry and the version disappears from the package
+metadata.
+
 ## npm compatibility registry API
 
 The npm compatibility registry API is used to download npm compatible tarballs

--- a/frontend/docs/faq.md
+++ b/frontend/docs/faq.md
@@ -67,7 +67,7 @@ default view, but it will still be available to users who depend on it.
 [Learn more about yanking.](/docs/packages#yanking-versions)
 
 You may delete a version that was published in the last 24 hours, if it has
-almost no downloads and no other published package depends on it.
+almost no downloads and no dependent package relies on that specific version.
 [Learn more about deleting a version.](/docs/packages#deleting-a-version)
 
 You may archive a package, which will prevent new versions from being published

--- a/frontend/docs/faq.md
+++ b/frontend/docs/faq.md
@@ -59,12 +59,16 @@ foreseeable future - JSR is designed to be very cheap to run.
 
 ## Can I delete a package from JSR?
 
-Source code published to JSR cannot be deleted.
+Source code published to JSR generally cannot be deleted.
 [Learn more about immutability.](/docs/immutability)
 
 You can "yank" a version of a package, which will hide the version from the
 default view, but it will still be available to users who depend on it.
 [Learn more about yanking.](/docs/packages#yanking-versions)
+
+You may delete a version that was published in the last 24 hours, if it has
+almost no downloads and no other published package depends on it.
+[Learn more about deleting a version.](/docs/packages#deleting-a-version)
 
 You may archive a package, which will prevent new versions from being published
 and hide the package from search results and the scope page.

--- a/frontend/docs/immutability.md
+++ b/frontend/docs/immutability.md
@@ -52,8 +52,9 @@ Note that yanking does not remove the contents of the package version from the
 registry. It only superficially hides the version from users in some places.
 
 There is one narrow exception: scope admins can delete a version that was
-published in the last 24 hours, as long as it has almost no downloads and no
-other published package depends on it.
+published in the last 24 hours, as long as it has almost no downloads and
+deleting it does not break any dependent package (dependents must be able to
+resolve their version constraints to another version of the package).
 [Learn more about deleting a version.](/docs/packages#deleting-a-version)
 
 ## What if I need to delete a package?

--- a/frontend/docs/immutability.md
+++ b/frontend/docs/immutability.md
@@ -44,12 +44,17 @@ version number in your config file before publishing a new version.
 
 ## What if I need to delete a package version?
 
-You can't delete a package version after it has been published. However, you can
-publish a new version of your package and yank the old version.
+Generally, you can't delete a package version after it has been published.
+Instead, you can publish a new version of your package and yank the old version.
 [Learn more about yanking.](/docs/packages#yanking-versions)
 
 Note that yanking does not remove the contents of the package version from the
 registry. It only superficially hides the version from users in some places.
+
+There is one narrow exception: scope admins can delete a version that was
+published in the last 24 hours, as long as it has almost no downloads and no
+other published package depends on it.
+[Learn more about deleting a version.](/docs/packages#deleting-a-version)
 
 ## What if I need to delete a package?
 

--- a/frontend/docs/npm-compatibility.md
+++ b/frontend/docs/npm-compatibility.md
@@ -203,3 +203,8 @@ new URL that includes the new revision.
 Because the tarball URL is included in package manager lock files, running
 `npm i` / `yarn` / `pnpm i` will never accidentally download a new revision of
 the tarball.
+
+One exception to tarball URL immutability is
+[version deletion](/docs/packages#deleting-a-version): when a package version is
+deleted, its tarballs are removed from the registry, although caches may still
+serve them for some time.

--- a/frontend/docs/packages.md
+++ b/frontend/docs/packages.md
@@ -212,7 +212,11 @@ accident. A version can only be deleted if all of the following are true:
 
 - The version was published less than 24 hours ago.
 - The version has fewer than 10 downloads.
-- No published version of another package depends on the version.
+- No published package depends on the version, unless the dependents' version
+  constraints can also be satisfied by another (non-yanked) version of the
+  package. For example, with versions `1.1.0` and `1.1.1` published and a
+  dependent using `^1.0.0`, either of the two can be deleted (but not both), as
+  the dependent can resolve to the remaining one.
 
 To delete a version, head to the "Versions" tab on the package page and click
 the "Delete" button next to the version. Only scope admins can delete versions.

--- a/frontend/docs/packages.md
+++ b/frontend/docs/packages.md
@@ -99,9 +99,10 @@ the package.
 
 Code in a package is published as a version. A version is a snapshot of the
 package's code at a point in time. Versions are immutable - once a version is
-published, it cannot be changed or deleted. This ensures that packages are
-reliable and that users can trust that a package will not change out from under
-them. [Learn more about registry immutability.](/docs/immutability)
+published, it cannot be changed or deleted
+([with one narrow exception](#deleting-a-version)). This ensures that packages
+are reliable and that users can trust that a package will not change out from
+under them. [Learn more about registry immutability.](/docs/immutability)
 
 Versions are published using the `jsr publish` or `deno publish` command.
 [Learn more about publishing packages.](/docs/publishing-packages)
@@ -154,9 +155,10 @@ import { foo } from "jsr:@scope/my-package@2.0.0-beta.1";
 
 ### Yanking versions
 
-Package versions cannot be deleted. However, sometimes you may want to prevent
-users from using a specific version of your package, for example because it
-contains a critical bug. In this case you can "yank" the version.
+Package versions generally cannot be deleted
+([with one narrow exception](#deleting-a-version)). However, sometimes you may
+want to prevent users from using a specific version of your package, for example
+because it contains a critical bug. In this case you can "yank" the version.
 
 Yanking a version does multiple things:
 
@@ -201,6 +203,30 @@ for the following import:
 ```ts
 import { foo } from "jsr:foo@1";
 ```
+
+### Deleting a version
+
+As an exception to [registry immutability](/docs/immutability), a version can be
+deleted shortly after publishing — for example when you published something by
+accident. A version can only be deleted if all of the following are true:
+
+- The version was published less than 24 hours ago.
+- The version has fewer than 10 downloads.
+- No published version of another package depends on the version.
+
+To delete a version, head to the "Versions" tab on the package page and click
+the "Delete" button next to the version. Only scope admins can delete versions.
+
+Deleting a version permanently removes its contents from the registry. Note that
+caches may still serve the version's files for some time after deletion. The
+version number of a deleted version stays reserved: the same version can not be
+published again. If a deleted version was the latest version of the package, the
+latest version is recomputed from the remaining versions.
+
+If you need to remove a version that does not meet these requirements — for
+example because it contains a secret or personal information — please contact us
+at [help@jsr.io](mailto:help@jsr.io). Otherwise, use
+[yanking](#yanking-versions).
 
 ## Documentation
 

--- a/frontend/routes/package/(_islands)/DeleteVersionButton.tsx
+++ b/frontend/routes/package/(_islands)/DeleteVersionButton.tsx
@@ -1,0 +1,27 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+
+export function DeleteVersionButton(props: { version: string }) {
+  function onSubmit(e: Event) {
+    if (
+      !confirm(
+        `Are you sure you want to permanently delete version ${props.version}? This cannot be undone, and the version number cannot be re-published.`,
+      )
+    ) {
+      e.preventDefault();
+    }
+  }
+
+  return (
+    <form method="POST" class="z-20" onSubmit={onSubmit}>
+      <input type="hidden" name="version" value={props.version} />
+      <button
+        type="submit"
+        class="button-danger"
+        name="action"
+        value="delete"
+      >
+        Delete
+      </button>
+    </form>
+  );
+}

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -18,6 +18,7 @@ import TbCheck from "tb-icons/TbCheck";
 import TbClockHour3 from "tb-icons/TbClockHour3";
 import TbTrashX from "tb-icons/TbTrashX";
 import { ScopeIAM, scopeIAM } from "../../utils/iam.ts";
+import { DeleteVersionButton } from "./(_islands)/DeleteVersionButton.tsx";
 import { DownloadChart } from "./(_islands)/DownloadChart.tsx";
 import { Card } from "../../components/Card.tsx";
 import { Pagination } from "../../components/Table.tsx";
@@ -138,6 +139,14 @@ export default define.page<typeof handler>(function Versions({
           })}
       </div>
 
+      {iam.canAdmin && versionsArray.length > 0 && (
+        <p class="mt-4 text-sm text-tertiary">
+          Versions can only be deleted within 24 hours of publishing, and only
+          if they have very few downloads and no other package depends on them.
+          Use yanking to discourage use of older versions.
+        </p>
+      )}
+
       <div class="mt-4 ring-1 ring-jsr-cyan-100 dark:ring-jsr-cyan-900 rounded overflow-hidden">
         <Pagination
           pagination={data}
@@ -207,6 +216,14 @@ function Version({
   const interactive = isRedState
     ? (version?.yanked || (!isPublished && isSuccess))
     : !isBlueState;
+
+  // Scope admins can only delete versions published within the last 24 hours
+  // (the API additionally requires few downloads and no dependents). Staff
+  // with sudo can delete any version.
+  const canDelete = iam.hasSudo ||
+    (iam.canAdmin && isPublished &&
+      Date.now() - new Date(version.createdAt).getTime() <
+        24 * 60 * 60 * 1000);
 
   return (
     <Card
@@ -292,18 +309,8 @@ function Version({
             </button>
           </form>
         )}
-        {isPublished && iam.hasSudo && (
-          <form method="POST" class="z-20">
-            <input type="hidden" name="version" value={version.version} />
-            <button
-              type="submit"
-              class="button-danger"
-              name="action"
-              value="delete"
-            >
-              Delete
-            </button>
-          </form>
+        {isPublished && canDelete && (
+          <DeleteVersionButton version={version.version} />
         )}
       </div>
       <ul>

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -142,8 +142,8 @@ export default define.page<typeof handler>(function Versions({
       {iam.canAdmin && versionsArray.length > 0 && (
         <p class="mt-4 text-sm text-tertiary">
           Versions can only be deleted within 24 hours of publishing, and only
-          if they have very few downloads and no other package depends on them.
-          Use yanking to discourage use of older versions.
+          if they have very few downloads and no other package depends on that
+          specific version. Use yanking to discourage use of older versions.
         </p>
       )}
 


### PR DESCRIPTION
Closes #899

This turns the existing staff-only version deletion endpoint into a feature scope admins can use, under strict conditions that keep the registry's immutability guarantees meaningful. A scope admin may delete a version only if **all** of the following hold:

- the version was published **less than 24 hours ago**,
- the version has **fewer than 10 downloads** (summed over `version_download_counts_24h`, all kinds),
- **deleting it does not strand any dependent**: every distinct dependency constraint referencing the package (both `jsr` and npm-mapped names) is matched against the version with semver range semantics, and a matching constraint only blocks deletion if the version is the *sole remaining non-yanked version* satisfying it. Dependents that can resolve to a sibling version are not broken by the deletion, so a broad range (or a `*` wildcard) does not pin every version of a package. Unparseable and dist-tag constraints fail closed.

Staff with sudo bypass the age and download conditions, but the dependents check applies to everyone.

### API changes

- `DELETE /api/scopes/:scope/packages/:package/versions/:version` now requires scope admin access (or staff + sudo) instead of bare staff access, matching what `api.yml` already documented.
- New error codes `deleteVersionTooOld` and `deleteVersionTooManyDownloads`; deleting a nonexistent version now returns 404 instead of succeeding silently.
- Cleanup gaps in the existing delete path are fixed:
  - npm tarball objects in the npm bucket are now deleted (previously orphaned forever),
  - Algolia is refreshed after deletion so score/latest-version stay accurate,
  - the audit log records the actual `is_sudo` instead of a hardcoded `true`.
- The publishing task of a deleted version still survives, so the version number stays burned and cannot be re-published (unchanged behavior).

### Frontend

- The Delete button on the versions tab now shows for scope admins on versions younger than 24 hours (always for staff with sudo), with a confirmation dialog.
- A note under the version list explains the deletion conditions to admins. The UI gate is best-effort; the API enforces the real policy.

### Docs

`immutability.md`, `packages.md` (new "Deleting a version" section), `faq.md`, `npm-compatibility.md`, and `api.md` now describe the narrow exception instead of stating versions can never be deleted.

### Caveats

- Download counts are batch-scraped, so the threshold lags real-time; it is a heuristic, not airtight.
- Edge caches serve version files, `_meta.json`, and tarballs as `immutable`, so a deleted version's artifacts may be served until TTL expiry (pre-existing trait of the staff delete path).
- There is a pre-existing race between the dependents check and the delete (a dependent publishing in between); not closed here.

### Testing

The `delete_version` test was rewritten to cover: 404 on nonexistent versions, dependents blocking (for admins and staff+sudo), deletion when constraints don't match the version (with npm tarball bucket assertions), the download threshold in both directions, the age limit with staff bypass, authorization for members/non-members/staff-without-sudo, and that re-publishing a deleted version stays blocked.
