### PR TITLE
fix: let the API enqueue email deliveries, and sweep without the queue

### DIFF
--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -558,20 +558,36 @@ pub async fn sweep_pending_emails_handler(req: Request<Body>) -> ApiResult<()> {
   tracing::info!("re-driving {} stale email deliveries", stale.len());
 
   for id in stale {
-    match (&queue.0, email_sender) {
-      (Some(queue), _) => {
+    // Handing the delivery back to Cloud Tasks is preferred: it retries with
+    // backoff and keeps this handler quick. But if the queue cannot be reached
+    // at all — it does not exist yet, or this service may not enqueue to it —
+    // then every delivery is stuck behind the same failure, and a sweeper that
+    // only ever enqueues would never notice. So the fallback is to deliver here
+    // instead, which needs nothing but the Postmark client.
+    let queued = match &queue.0 {
+      Some(queue) => {
         let body = serde_json::to_vec(&SendEmailTask { id }).unwrap();
         // A fresh task id, because the original may still be known to Cloud
         // Tasks and would be rejected as a duplicate.
-        if let Err(err) = queue.task_buffer(None, Some(body.into())).await {
-          error!(delivery_id = %id, "failed to re-drive email delivery: {:?}", err);
+        match queue.task_buffer(None, Some(body.into())).await {
+          Ok(()) => true,
+          Err(err) => {
+            error!(
+              delivery_id = %id,
+              "could not queue email delivery, sending it directly instead: {:?}",
+              err
+            );
+            false
+          }
         }
       }
-      (None, _) => {
-        if let Err(err) = emails::deliver(db, email_sender.as_ref(), id).await {
-          error!(delivery_id = %id, "failed to re-drive email delivery: {:?}", err);
-        }
-      }
+      None => false,
+    };
+
+    if !queued
+      && let Err(err) = emails::deliver(db, email_sender.as_ref(), id).await
+    {
+      error!(delivery_id = %id, "failed to re-drive email delivery: {:?}", err);
     }
   }
 

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -438,6 +438,12 @@ resource "google_cloud_tasks_queue_iam_member" "npm_tarball_build_tasks" {
   member = "serviceAccount:${google_service_account.registry_api.email}"
 }
 
+resource "google_cloud_tasks_queue_iam_member" "email_delivery" {
+  name   = google_cloud_tasks_queue.email_delivery.id
+  role   = "roles/cloudtasks.enqueuer"
+  member = "serviceAccount:${google_service_account.registry_api.email}"
+}
+
 resource "google_service_account_iam_member" "act_as_task_dispatcher" {
   service_account_id = google_service_account.task_dispatcher.name
   role               = "roles/iam.serviceAccountUser"


### PR DESCRIPTION
Inbound support email still produces no reply, even with the tasks service now holding a Postmark token (#1509).

## Cause

The email delivery queue was added in #1501 without the IAM binding that lets the API service account put anything into it. `publishing_tasks` and `npm_tarball_build_tasks` each have a `cloudtasks.enqueuer` binding; `email_delivery` was created without one, so every hand-off fails on permissions.

That failure is logged and swallowed on purpose — an email must not fail the request that triggered it — so nothing surfaced. The delivery rows simply stayed pending.

The sweeper was supposed to be the safety net for exactly this, and could not be: it hands stale deliveries back to the *same* queue, so it hit the same permission error every five minutes and rescued nothing. A net with the same single point of failure as the thing it protects is not a net.

## Fix

- The `cloudtasks.enqueuer` binding for `email_delivery`.
- The sweeper falls back to delivering directly when the queue cannot be reached, which needs nothing beyond the Postmark client it already has.

Cloud Tasks stays the preferred path — it retries with backoff and keeps the handler quick — but it is now an optimisation rather than something the whole system depends on. A future queue outage costs at most five minutes of delay instead of silently stopping all outgoing email.

## After deploying

Everything stranded by this is still pending, so it goes out on the first sweep — within five minutes. That is now **two days of backlogged auto-replies** to everyone who has written in since #1501 landed. To see the size of it first:

```sql
SELECT count(*), min(created_at), max(created_at)
FROM email_deliveries
WHERE sent_at IS NULL AND abandoned_at IS NULL;
```

If any are old enough that a sudden "we received your email" would confuse more than help:

```sql
UPDATE email_deliveries
SET abandoned_at = now(), last_error = 'stranded before the API could enqueue deliveries'
WHERE sent_at IS NULL AND abandoned_at IS NULL AND created_at < '<cutoff>';
```

## Testing

236 API tests pass. Clippy `-D warnings`, `cargo fmt`, `sqlx prepare --check` and `terraform fmt` clean.

The permission failure itself is not reproducible in tests — it needs real Cloud Tasks — which is precisely why the sweeper fallback matters more than a test would here.
