### PR TITLE
fix(frontend): return to the ticket after signing in to claim it

### DIFF
--- a/frontend/islands/ClaimTicket.tsx
+++ b/frontend/islands/ClaimTicket.tsx
@@ -6,10 +6,14 @@ import { api, path } from "../utils/api.ts";
 /// rather than an account. Claiming binds it to the signed-in account, so it
 /// shows up alongside their other tickets instead of only in their inbox.
 export function ClaimTicket(
-  { ticketId, claimToken, signedIn }: {
+  { ticketId, claimToken, signedIn, returnTo }: {
     ticketId: string;
     claimToken: string;
     signedIn: boolean;
+    /// Where to come back to after signing in — this page, claim token and all.
+    /// Passed in rather than read from `location`, which does not exist when
+    /// this is rendered on the server.
+    returnTo: string;
   },
 ) {
   const [error, setError] = useState<string | null>(null);
@@ -53,7 +57,12 @@ export function ClaimTicket(
         )
         : (
           <p>
-            <a class="link" href="/login">Sign in</a>{" "}
+            <a
+              class="link"
+              href={`/login?redirect=${encodeURIComponent(returnTo)}`}
+            >
+              Sign in
+            </a>{" "}
             to link it to your account. You can also just reply to our email —
             that works either way.
           </p>

--- a/frontend/routes/ticket.tsx
+++ b/frontend/routes/ticket.tsx
@@ -25,6 +25,7 @@ import type {
 export default define.page<typeof handler>(function Ticket({
   data,
   state,
+  url,
 }) {
   const ticket = data.ticket;
   // The reporter of an unclaimed ticket reaches this page with the token from
@@ -80,6 +81,10 @@ export default define.page<typeof handler>(function Ticket({
           ticketId={ticket.id}
           claimToken={data.claimToken}
           signedIn={state.user !== null}
+          // Carries the claim token through the login round trip, so the
+          // reporter lands back here able to claim rather than on the home page
+          // with the link they followed spent.
+          returnTo={`${url.pathname}${url.search}`}
         />
       )}
 


### PR DESCRIPTION
The sign-in link on an unclaimed ticket went to a bare `/login`, so somebody following the claim link out of their auto-reply signed in and landed on the home page. The ticket they were trying to reach was gone — and so was the claim token that would have let them reach it again, since it lives only in that link and in the email it came from. Getting back meant digging the email out again.

The link now carries `?redirect=` back to this page, query string included, the same way the header's sign-in link does (`components/Header.tsx`). The reporter returns to the ticket already signed in, with the claim button waiting.

Two details:

- **The return path is passed in from the route** rather than read from `location`, which does not exist while the island is server-rendered.
- **The claim token rides along in the redirect**, which is what makes the flow work at all. `sanitize_redirect_url` keeps the query string and forces a same-origin relative path, so it survives intact and cannot be pointed elsewhere. It does mean the token is briefly stored in `oauth_states.redirect_url` — no worse than it already being in the browser's history for that page, and those rows are cleaned up daily by `clean_oauth_states`.

## Testing

`deno task lint:frontend` and `deno fmt` clean.

Not verified in a browser — local dev still 404s on every route for me, which is a separate problem. The change is small and follows the existing header pattern, but the flow itself is worth clicking through once after deploy: open a claim link signed out, sign in, and check you land back on the ticket with the claim button rather than on the home page.
