### PR TITLE
fix(api): let staff reply to a ticket nobody has claimed

### DIFF
--- a/api/.sqlx/query-9285cef0b61fce21343e353c512e140ef880c3be8ed33191c40e45e8ae6bc0ab.json
+++ b/api/.sqlx/query-9285cef0b61fce21343e353c512e140ef880c3be8ed33191c40e45e8ae6bc0ab.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT creator = $2 as \"is_creator!\" FROM tickets WHERE id = $1",
+  "query": "SELECT COALESCE(creator = $2, false) as \"is_creator!\" FROM tickets WHERE id = $1",
   "describe": {
     "columns": [
       {
@@ -19,5 +19,5 @@
       null
     ]
   },
-  "hash": "7aec305f8d3cf75fe4b6b47f67386e30f16668093448b612cb77a9e4b7e640fd"
+  "hash": "9285cef0b61fce21343e353c512e140ef880c3be8ed33191c40e45e8ae6bc0ab"
 }

--- a/api/src/api/hooks.rs
+++ b/api/src/api/hooks.rs
@@ -1175,6 +1175,35 @@ mod integration {
   }
 
   #[tokio::test]
+  async fn staff_can_reply_to_a_ticket_nobody_has_claimed() {
+    let mut t = TestSetup::new().await;
+
+    deliver(&mut t, inbound("<a@example.com>", "Help", json!([]))).await;
+    let ticket = all_tickets(&mut t).await.remove(0);
+    assert_eq!(ticket.status, TicketStatus::Open);
+
+    // The ticket has no creator until it is claimed, so anything comparing the
+    // author against it has to cope with a NULL on the other side. This is the
+    // ordinary path for answering support mail, and it used to 500.
+    let staff_token = t.staff_user.token.clone();
+    let mut resp = t
+      .http()
+      .post(format!("/api/tickets/{}", ticket.id))
+      .token(Some(&staff_token))
+      .body_json(json!({ "message": "Have you tried publishing again?" }))
+      .call()
+      .await
+      .unwrap();
+    let reply: crate::api::ApiTicketMessage = resp.expect_ok().await;
+    assert_eq!(reply.message, "Have you tried publishing again?");
+    assert_eq!(reply.direction, crate::db::TicketMessageDirection::Outbound);
+
+    // Staff spoke last, so the reporter is the one now owed a response.
+    let after = all_tickets(&mut t).await.remove(0);
+    assert_eq!(after.status, TicketStatus::WaitingOnUser);
+  }
+
+  #[tokio::test]
   async fn wrong_webhook_password_is_rejected() {
     let mut t = TestSetup::new().await;
 

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -4765,8 +4765,11 @@ gitlab_id: r.user_gitlab_id,
   ) -> Result<(TicketMessage, UserPublic)> {
     let mut tx = self.pool.begin().await?;
 
+    // COALESCE, because a ticket opened by email has no creator until somebody
+    // claims it, and `NULL = $2` is NULL rather than false. Without it, every
+    // staff reply to an unclaimed ticket fails to decode and 500s.
     let author_is_creator = sqlx::query_scalar!(
-      r#"SELECT creator = $2 as "is_creator!" FROM tickets WHERE id = $1"#,
+      r#"SELECT COALESCE(creator = $2, false) as "is_creator!" FROM tickets WHERE id = $1"#,
       id as _,
       author as _,
     )

--- a/api/src/emails/templates/support_ticket_auto_reply.html.hbs
+++ b/api/src/emails/templates/support_ticket_auto_reply.html.hbs
@@ -6,7 +6,7 @@
 	Thanks for getting in touch. We have opened support ticket <b>{{ ticket_number }}</b> for your email, and someone will get back to you as soon as possible.
 </p>
 <p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
-	You can keep replying to this email &mdash; your replies are added to the ticket automatically.
+	You can keep replying to this email. Your replies are added to the ticket automatically.
 </p>
 <p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
 	If you would rather follow the ticket on the web, you can link it to a {{ registry_name }} account:

--- a/api/src/emails/templates/support_ticket_auto_reply.txt.hbs
+++ b/api/src/emails/templates/support_ticket_auto_reply.txt.hbs
@@ -3,7 +3,7 @@ Hey{{#if name}} {{ name }}{{/if}},
 
 Thanks for getting in touch. We have opened support ticket {{ ticket_number }} for your email, and someone will get back to you as soon as possible.
 
-You can keep replying to this email — your replies are added to the ticket automatically.
+You can keep replying to this email. Your replies are added to the ticket automatically.
 
 If you would rather follow the ticket on the web, you can link it to a {{ registry_name }} account here:
 

--- a/api/src/emails/templates/support_ticket_created.html.hbs
+++ b/api/src/emails/templates/support_ticket_created.html.hbs
@@ -26,7 +26,7 @@
 	You will receive emails whenever a new message is posted to the ticket.
 </p>
 <p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
-	You can reply to the ticket via the link above, or simply reply to this email &mdash; your replies are added to the ticket automatically.
+	You can reply to the ticket via the link above, or simply reply to this email. Your replies are added to the ticket automatically.
 </p>
 <p style="margin-bottom: 5px; margin-top: 8px; font-size: 16px; line-height: 24px; color: #52525b">
 	Cheers,

--- a/api/src/emails/templates/support_ticket_created.txt.hbs
+++ b/api/src/emails/templates/support_ticket_created.txt.hbs
@@ -5,7 +5,7 @@ You have created a support ticket on {{ registry_name }}.
 
 You will receive emails to this address whenever a new message is posted to the ticket.
 
-You can also view the ticket on {{ registry_url }}ticket/{{ ticket_id }}. You can reply to the ticket from there, or simply reply to this email — your replies are added to the ticket automatically.
+You can also view the ticket on {{ registry_url }}ticket/{{ ticket_id }}. You can reply to the ticket from there, or simply reply to this email. Your replies are added to the ticket automatically.
 
 Cheers,
 {{ registry_name }}

--- a/api/src/emails/templates/support_ticket_message.html.hbs
+++ b/api/src/emails/templates/support_ticket_message.html.hbs
@@ -16,7 +16,7 @@
 </p>
 
 <p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
-	You can reply to the ticket via the link above, or simply reply to this email &mdash; your replies are added to the ticket automatically.
+	You can reply to the ticket via the link above, or simply reply to this email. Your replies are added to the ticket automatically.
 </p>
 <p style="margin-bottom: 5px; margin-top: 8px; font-size: 16px; line-height: 24px; color: #52525b">
 	Cheers,

--- a/api/src/emails/templates/support_ticket_message.txt.hbs
+++ b/api/src/emails/templates/support_ticket_message.txt.hbs
@@ -7,7 +7,7 @@ You have received a reply to your support ticket on {{ registry_name }}:
 {{content}}
 ---
 
-To view the ticket, you can go to {{ registry_url }}ticket/{{ ticket_id }}. You can reply to the ticket from there, or simply reply to this email — your replies are added to the ticket automatically.
+To view the ticket, you can go to {{ registry_url }}ticket/{{ ticket_id }}. You can reply to the ticket from there, or simply reply to this email. Your replies are added to the ticket automatically.
 
 Cheers,
 {{ registry_name }}


### PR DESCRIPTION
**Replying to a ticket that arrived by email fails with a 500 and the reply is discarded.** That is the ordinary way support mail gets answered, so answering inbound email does not currently work at all.

Found while building something else; the new test was simply the first thing to exercise this path.

## Cause

`ticket_add_message` works out whether the author is the person who opened the ticket, to decide which way the message is going and who is owed a response. It asked the database:

```sql
SELECT creator = $1 as "is_creator!" FROM tickets WHERE id = $2
```

A ticket opened by email has no creator until somebody claims it, and `NULL = $1` is NULL rather than false — so the query returned NULL into a column the caller had asserted was non-null. Every such reply failed to decode and 500'd.

It went unnoticed because the flow it breaks is the one combination the tests did not cover: replies were only ever exercised on tickets opened through the web UI, which always have a creator.

## Fix

`COALESCE(creator = $1, false)` — a ticket with no creator has no author who is its creator.

The regression test replies to an unclaimed ticket as staff and checks the reply lands and moves the ticket to `waiting_on_user`. I confirmed it fails against the old query before fixing it, rather than assuming.

## Also here

Removed the em dashes from the ticket emails, which read badly in a plain-text mail client. Split into two sentences rather than swapped for a hyphen, which would only be a worse version of the same construction. Affects all three ticket email templates, text and HTML.

## Testing

237 API tests pass. Clippy `-D warnings`, `cargo fmt`, `sqlx prepare --check` clean.
