### PR TITLE
fix(api): version the usage snippets

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -4219,7 +4219,8 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     let task = process_tarball_setup(&t, create_mock_tarball("ok")).await;
     assert_eq!(task.status, PublishingTaskStatus::Success, "{:?}", task);
 
-    // index page
+    // index page (pinned version): usage snippets install exactly this
+    // version, and the jsr specifier is pinned to it
     let mut resp = t
       .http()
       .get("/api/scopes/scope/packages/foo/versions/1.2.3/docs")
@@ -4233,11 +4234,38 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
         comrak_css: _,
         script: _,
         breadcrumbs,
-        toc: _,
+        toc,
         main: _,
       } => {
         assert_eq!(version.version, task.package_version);
         assert!(breadcrumbs.is_none(), "{:?}", breadcrumbs);
+        let toc_json = serde_json::to_string(&toc).unwrap();
+        assert!(
+          toc_json.contains("deno add jsr:@scope/foo@1.2.3"),
+          "{toc_json}"
+        );
+        assert!(toc_json.contains("jsr:@scope/foo@1.2.3"), "{toc_json}");
+      }
+      ApiPackageVersionDocs::Redirect { .. } => panic!(),
+    }
+
+    // index page (latest): add commands are unversioned, but the direct jsr
+    // specifier carries a caret constraint on the latest version
+    let mut resp = t
+      .http()
+      .get("/api/scopes/scope/packages/foo/versions/latest/docs")
+      .call()
+      .await
+      .unwrap();
+    let docs: ApiPackageVersionDocs = resp.expect_ok().await;
+    match docs {
+      ApiPackageVersionDocs::Content { toc, .. } => {
+        let toc_json = serde_json::to_string(&toc).unwrap();
+        assert!(
+          !toc_json.contains("deno add jsr:@scope/foo@1.2.3"),
+          "{toc_json}"
+        );
+        assert!(toc_json.contains("jsr:@scope/foo@^1.2.3"), "{toc_json}");
       }
       ApiPackageVersionDocs::Redirect { .. } => panic!(),
     }

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -739,7 +739,7 @@ pub fn get_generate_ctx(
       href_resolver: Arc::new(DocResolver {
         scope: scope.clone(),
         package: package.clone(),
-        version,
+        version: version.clone(),
         version_is_latest,
         registry_url,
         deno_types: DENO_TYPES
@@ -771,6 +771,8 @@ pub fn get_generate_ctx(
           runtime_compat,
           scope,
           package,
+          version,
+          version_is_latest,
         }) as Arc<dyn deno_doc::html::UsageComposer>
       }),
       rewrite_map: Some(rewrite_map),
@@ -1434,6 +1436,8 @@ struct DocUsageComposer {
   runtime_compat: RuntimeCompat,
   scope: ScopeName,
   package: PackageName,
+  version: Version,
+  version_is_latest: bool,
 }
 
 impl deno_doc::html::UsageComposer for DocUsageComposer {
@@ -1448,22 +1452,38 @@ impl deno_doc::html::UsageComposer for DocUsageComposer {
     usage_to_md: deno_doc::html::UsageToMd,
   ) -> IndexMap<UsageComposerEntry, String> {
     let mut map = IndexMap::new();
-    let scoped_name = format!("@{}/{}", self.scope, self.package);
+    // When the user is looking at a pinned, non-latest version, the add
+    // commands install exactly that version instead of the latest one.
+    let scoped_name = if self.version_is_latest {
+      format!("@{}/{}", self.scope, self.package)
+    } else {
+      format!("@{}/{}@{}", self.scope, self.package, self.version)
+    };
 
     let (is_main, path) = current_resolve
       .get_file()
       .map(|short_path| (short_path.is_main, &*short_path.path))
       .unwrap_or((true, ""));
 
-    let url = format!(
-      "@{}/{}{}",
+    let subpath = if is_main {
+      String::new()
+    } else {
+      format!("/{path}")
+    };
+
+    let url = format!("@{}/{}{}", self.scope, self.package, subpath);
+
+    // A direct jsr specifier always carries a version constraint so the
+    // snippet passes Deno's no-unversioned-import lint rule: a caret range on
+    // the latest version (matching what `deno add` writes), and the exact
+    // version when a non-latest version is pinned.
+    let jsr_url = format!(
+      "@{}/{}@{}{}{}",
       self.scope,
       self.package,
-      if is_main {
-        String::new()
-      } else {
-        format!("/{path}")
-      }
+      if self.version_is_latest { "^" } else { "" },
+      self.version,
+      subpath
     );
 
     let import = format!(
@@ -1477,7 +1497,7 @@ impl deno_doc::html::UsageComposer for DocUsageComposer {
           name: "Deno".to_string(),
           icon: Some("/logos/deno.svg".into()),
         },
-        format!("Add Package\n```\ndeno add jsr:{scoped_name}\n```{import}\n<div class='or-bar'>or</div>\n\nImport directly with a jsr specifier\n{}\n", usage_to_md(&format!("jsr:{url}"), Some(self.package.as_str()))),
+        format!("Add Package\n```\ndeno add jsr:{scoped_name}\n```{import}\n<div class='or-bar'>or</div>\n\nImport directly with a jsr specifier\n{}\n", usage_to_md(&format!("jsr:{jsr_url}"), Some(self.package.as_str()))),
       );
     }
 


### PR DESCRIPTION
Two related fixes to the "Use with" snippets, both in `DocUsageComposer`:

- **#721**: when a pinned version is being viewed, the add commands (`deno add`, `pnpm i`, `yarn add`, `vlt install`, `npx jsr add`, `bunx jsr add`) now install exactly that version (`jsr:@scope/pkg@1.2.3`) instead of silently installing the latest.
- **#1226**: the "Import directly with a jsr specifier" snippet now always carries a version constraint, so copied snippets pass Deno's `no-unversioned-import` lint rule: a caret range on the latest version (`jsr:@scope/pkg@^1.2.3`, matching what `deno add` writes), and the exact version when a version is pinned.

The bare "Import symbol" specifier stays unversioned — it's the specifier that `deno add` / the package manager maps.

Added assertions to `test_package_docs` covering both the pinned and `latest` cases.

Note: since #1473 docs are only served for the latest version, so the pinned-version case currently only materializes on pinned-latest URLs — the fix is correct for both and future-proof if that restriction is ever lifted.

Fixes #721.
Fixes #1226.

## Screenshots

Production today (unversioned jsr specifier):

<img src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/1226-before-prod.png" width="420" alt="before: import from jsr:@luca/flag without a version">

After — latest version page (caret constraint, unversioned add command) and pinned version page (exact version everywhere):

| Latest | Pinned |
|--|--|
| <img src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/1226-after-latest.png" alt="after: jsr specifier with caret range"> | <img src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/721-after-pinned.png" alt="after: exact version in add command and jsr specifier"> |
