### PR TITLE
feat: show module JSDoc examples on the package overview page

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -824,21 +824,25 @@ pub fn render_docs_html(
 
       let render_ctx = RenderContext::new(ctx, doc_nodes, UrlResolveKind::Root);
 
-      let mut index_module_doc = match readme_source {
-        ReadmeSource::JSDoc => ctx
-          .main_entrypoint
-          .as_ref()
-          .map(|entrypoint| {
-            deno_doc::html::jsdoc::ModuleDocCtx::new(
-              &render_ctx,
-              entrypoint,
-              false,
-              false,
-            )
-          })
-          .unwrap_or_default(),
-        ReadmeSource::Readme => Default::default(),
-      };
+      let mut index_module_doc = ctx
+        .main_entrypoint
+        .as_ref()
+        .map(|entrypoint| {
+          deno_doc::html::jsdoc::ModuleDocCtx::new(
+            &render_ctx,
+            entrypoint,
+            false,
+            false,
+          )
+        })
+        .unwrap_or_default();
+
+      // When the README is the overview's prose, drop the module JSDoc body
+      // so the README injection below kicks in — but keep the sections, which
+      // hold the module's `@example`s.
+      if matches!(readme_source, ReadmeSource::Readme) {
+        index_module_doc.sections.docs = None;
+      }
 
       if index_module_doc.sections.docs.is_none() {
         let markdown = readme


### PR DESCRIPTION
The overview page already rendered module-level `@example` tags when the module JSDoc was the overview's prose source, but dropped them entirely when the README was (readme source setting, or JSDoc fallback to README). Build the module doc context in both modes and only swap out the prose, so a module's examples (and its `@deprecated` banner) show up regardless of the readme source setting.

Fixes #895.

## Screenshots

A package with readme source set to README whose module JSDoc has an `@example` (local dev registry):

| Before | After |
|--|--|
| ![before: README only, examples dropped](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/895-before.png) | ![after: README plus Examples section](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/895-after.png) |

(The after shot also shows highlighted TOML/YAML fences from #1519 — same local stack.)
