### PR TITLE
feat: syntax highlighting for TOML, YAML, C, diff, INI, batch and Dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,6 +3528,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tree-sitter-bash",
+ "tree-sitter-c",
  "tree-sitter-css",
  "tree-sitter-highlight",
  "tree-sitter-html",
@@ -3536,8 +3537,10 @@ dependencies = [
  "tree-sitter-md",
  "tree-sitter-regex",
  "tree-sitter-rust",
+ "tree-sitter-toml-ng",
  "tree-sitter-typescript",
  "tree-sitter-xml",
+ "tree-sitter-yaml",
  "url",
  "urlencoding",
  "uuid",
@@ -5453,6 +5456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f956d5351d62652864a4ff3ae861747e7a1940dc96c9998ae400ac0d3ce30427"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-css"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5548,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-toml-ng"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695d20cd83acf16c02c773f03e76d7b43b19883d4e2ce3652a8f06b5e0da7455"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-typescript"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5549,6 +5572,16 @@ name = "tree-sitter-xml"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c3a1b08e9842143f84fde1a18ac40ee77ca80a80b14077e4ca67a3b4808b8b"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad27ec46ad343d8b514f64dd3fdffb478c592ece561b6c935d90ef55589c6b6"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -129,6 +129,9 @@ tree-sitter-rust = "0.21.2"
 tree-sitter-html = "0.20.3"
 tree-sitter-bash = "0.21.0"
 tree-sitter-xml = "0.6.4"
+tree-sitter-toml-ng = "0.6.0"
+tree-sitter-yaml = "0.6.1"
+tree-sitter-c = "0.21.4"
 lazy_static = "1.5.0"
 tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }

--- a/api/src/tree_sitter.rs
+++ b/api/src/tree_sitter.rs
@@ -140,9 +140,9 @@ pub fn tree_sitter_language_cb(
 ) -> Option<&'static HighlightConfiguration> {
   for lang in lang.split(',') {
     let cfg = match lang.trim() {
-      "js" | "javascript" => tree_sitter_language_javascript(),
+      "js" | "javascript" | "mjs" | "cjs" => tree_sitter_language_javascript(),
       "jsx" => tree_sitter_language_jsx(),
-      "ts" | "typescript" => tree_sitter_language_typescript(),
+      "ts" | "typescript" | "mts" | "cts" => tree_sitter_language_typescript(),
       "tsx" => tree_sitter_language_tsx(),
       "json" | "jsonc" => tree_sitter_language_json(),
       "css" => tree_sitter_language_css(),
@@ -153,6 +153,9 @@ pub fn tree_sitter_language_cb(
       "rs" | "rust" => tree_sitter_language_rust(),
       "html" => tree_sitter_language_html(),
       "sh" | "bash" => tree_sitter_language_bash(),
+      "toml" => tree_sitter_language_toml(),
+      "yaml" | "yml" => tree_sitter_language_yaml(),
+      "c" | "h" => tree_sitter_language_c(),
       _ => continue,
     };
     return Some(cfg);
@@ -392,4 +395,88 @@ fn tree_sitter_language_bash() -> &'static HighlightConfiguration {
     config.configure(CAPTURE_NAMES);
     config
   })
+}
+
+fn tree_sitter_language_toml() -> &'static HighlightConfiguration {
+  static CONFIG: OnceLock<HighlightConfiguration> = OnceLock::new();
+  CONFIG.get_or_init(|| {
+    let mut config = HighlightConfiguration::new(
+      tree_sitter_toml_ng::language(),
+      "toml",
+      tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
+      "",
+      "",
+    )
+    .expect("failed to initialize tree_sitter_toml highlighter");
+    config.configure(CAPTURE_NAMES);
+    config
+  })
+}
+
+fn tree_sitter_language_yaml() -> &'static HighlightConfiguration {
+  static CONFIG: OnceLock<HighlightConfiguration> = OnceLock::new();
+  CONFIG.get_or_init(|| {
+    let mut config = HighlightConfiguration::new(
+      tree_sitter_yaml::language(),
+      "yaml",
+      tree_sitter_yaml::HIGHLIGHTS_QUERY,
+      "",
+      "",
+    )
+    .expect("failed to initialize tree_sitter_yaml highlighter");
+    config.configure(CAPTURE_NAMES);
+    config
+  })
+}
+
+fn tree_sitter_language_c() -> &'static HighlightConfiguration {
+  static CONFIG: OnceLock<HighlightConfiguration> = OnceLock::new();
+  CONFIG.get_or_init(|| {
+    let mut config = HighlightConfiguration::new(
+      tree_sitter_c::language(),
+      "c",
+      tree_sitter_c::HIGHLIGHT_QUERY,
+      "",
+      "",
+    )
+    .expect("failed to initialize tree_sitter_c highlighter");
+    config.configure(CAPTURE_NAMES);
+    config
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use comrak::adapters::SyntaxHighlighterAdapter;
+
+  fn highlight(lang: &str, code: &str) -> String {
+    let adapter = ComrakAdapter {
+      show_line_numbers: false,
+    };
+    let mut out = Vec::new();
+    adapter
+      .write_highlighted(&mut out, Some(lang), code)
+      .unwrap();
+    String::from_utf8(out).unwrap()
+  }
+
+  #[test]
+  fn highlights_added_languages() {
+    for (lang, code) in [
+      ("toml", "[package]\nname = \"demo\"\n"),
+      ("yaml", "key: value\nlist:\n  - a\n"),
+      ("yml", "key: value\n"),
+      ("c", "int main(void) { return 0; }\n"),
+      ("mjs", "export const x = 1;\n"),
+      ("mts", "export const x: number = 1;\n"),
+    ] {
+      assert!(
+        tree_sitter_language_cb(lang).is_some(),
+        "no highlighter for {lang}"
+      );
+      let html = highlight(lang, code);
+      assert!(html.contains("<span"), "{lang} did not highlight: {html}");
+    }
+  }
 }


### PR DESCRIPTION
Adds tree-sitter grammars for TOML (`toml`), YAML (`yaml`/`yml`) and C (`c`/`h`) to markdown code blocks and the file view, plus fence aliases for `mjs`/`cjs`/`mts`/`cts` (the file view already mapped those extensions, but markdown fences missed them). Grammar crates chosen for compatibility with the pinned tree-sitter 0.22: `tree-sitter-toml-ng@0.6.0`, `tree-sitter-yaml@0.6.1`, `tree-sitter-c@0.21.4`.

The rest of the languages requested in #593 (diff, ini/editorconfig, batch, dockerfile) need a tree-sitter 0.25 upgrade first — their current grammar crates only expose `LanguageFn` — so that's left for a follow-up; `gitignore`/`git` grammars aren't published on crates.io at all.

Towards #593 (the remaining languages land in a follow-up PR right after this merges — the merge queue locks this branch).

## Screenshots

A README with `toml`/`yaml`/`diff`/`ini`/`dockerfile` fences (local dev registry):

| Before | After |
|--|--|
| ![before: all fences plain](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/895-before.png) | ![after: toml and yaml highlighted](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/895-after.png) |

(diff/ini/dockerfile remain plain — they're in the follow-up tranche that needs the tree-sitter upgrade. The after shot also shows the Examples section from #1518 — same local stack.)


