### PR TITLE
fix(api): show npm-ecosystem usage instructions for browser/workerd-only packages

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -202,8 +202,9 @@ pub async fn download_doc_nodes(
 }
 
 /// Cache for fully-built GenerateCtx. Keyed by
-/// `scope/package/version/is_latest/has_readme` so concurrent requests
-/// for the same doc page share a single GenerateCtx without rebuilding.
+/// `scope/package/version/is_latest/has_readme/runtime_compat` so concurrent
+/// requests for the same doc page share a single GenerateCtx without
+/// rebuilding.
 #[derive(Clone)]
 pub struct GenerateCtxCache {
   cache: moka::future::Cache<String, Arc<GenerateCtx>>,
@@ -232,8 +233,13 @@ impl GenerateCtxCache {
     registry_url: &str,
     bucket: &crate::s3::Buckets,
   ) -> Result<Option<Arc<GenerateCtx>>, DocNodeCacheError> {
-    let key =
-      format!("@{scope}/{package}/{version}/{version_is_latest}/{has_readme}");
+    // runtime_compat is part of the key because the usage instructions baked
+    // into the GenerateCtx depend on it, and it is editable in the package
+    // settings.
+    let key = format!(
+      "@{scope}/{package}/{version}/{version_is_latest}/{has_readme}/{:?}",
+      runtime_compat
+    );
 
     if let Some(cached) = self.cache.get(&key).await {
       return Ok(Some(cached));
@@ -1481,7 +1487,13 @@ impl deno_doc::html::UsageComposer for DocUsageComposer {
       );
     }
 
-    if !self.runtime_compat.node.is_some_and(|compat| !compat) {
+    // Packages that only target browsers or Cloudflare Workers are still
+    // installed through npm-ecosystem package managers (via a bundler), so an
+    // explicit browser/workerd "yes" shows these tabs even when node is "no".
+    if !self.runtime_compat.node.is_some_and(|compat| !compat)
+      || self.runtime_compat.browser.is_some_and(|compat| compat)
+      || self.runtime_compat.workerd.is_some_and(|compat| compat)
+    {
       map.insert(
         UsageComposerEntry {
           name: "pnpm".to_string(),


### PR DESCRIPTION
A package that explicitly marks only browsers (or Cloudflare Workers) as supported — with `node: false` — got no pnpm/Yarn/vlt/npm tabs at all, even though browser-only libraries are still installed through npm-ecosystem package managers via a bundler. The reporter had to mark Node compat as "unknown" to get install instructions to show.

The npm-family tabs now also show when `browser` or `workerd` is explicitly `true`, regardless of `node`.

Also folds `runtime_compat` into the `GenerateCtxCache` key: the usage instructions baked into a cached `GenerateCtx` depend on it, and it is editable in the package settings, so editing runtime compat could serve stale tabs until cache eviction.

Fixes #799.

## Screenshots

A browser-only package (`runtimeCompat: { browser: true, deno: false, node: false, workerd: false, bun: false }`) on a local dev registry.

| Before | After |
|--|--|
| ![before: no usage instructions at all](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/799-before.png) | ![after: pnpm/Yarn/vlt/npm tabs shown](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/799-after.png) |
