### PR TITLE
feat: render markdown files in the source view

### DIFF
--- a/api/src/api.yml
+++ b/api/src/api.yml
@@ -3556,6 +3556,10 @@ components:
               type: string
               nullable: true
               description: HTML-rendered source code view. Null for binary files.
+            rendered:
+              type: string
+              nullable: true
+              description: Rendered HTML, present for markdown files.
           required:
             - kind
             - size

--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1738,7 +1738,7 @@ pub async fn get_source_handler(
 
   let db = req.data::<Database>().unwrap();
   let buckets = req.data::<Buckets>().unwrap();
-  let _ = db
+  let (_, repo, _) = db
     .get_package(&scope, &package)
     .await?
     .ok_or(ApiError::PackageNotFound)?;
@@ -1822,7 +1822,31 @@ pub async fn get_source_handler(
       None
     };
 
-    ApiSource::File { size, view }
+    // Markdown files additionally get a rendered form so the frontend can
+    // offer a GitHub-style preview next to the source.
+    let rendered = if path_buf
+      .extension()
+      .is_some_and(|ext| matches!(&*ext.to_string_lossy(), "md" | "markdown"))
+    {
+      std::str::from_utf8(&file).ok().and_then(|md| {
+        crate::docs::render_markdown_file(
+          md,
+          &scope,
+          &package,
+          &version.version,
+          repo,
+          path_buf.to_string_lossy().as_ref(),
+        )
+      })
+    } else {
+      None
+    };
+
+    ApiSource::File {
+      size,
+      view,
+      rendered,
+    }
   } else {
     let files = db
       .list_package_files(&scope, &package, &version.version)
@@ -5148,12 +5172,18 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     let mut resp = t.http().get(url).call().await.unwrap();
     let body = resp.expect_ok::<ApiPackageVersionSource>().await;
 
-    let ApiSource::File { size, view } = body.source else {
+    let ApiSource::File {
+      size,
+      view,
+      rendered,
+    } = body.source
+    else {
       panic!();
     };
 
     assert_eq!(size, 124);
     assert!(view.is_some());
+    assert!(rendered.is_none());
 
     let url = format!(
       "/api/scopes/{}/packages/{}/versions/{}/source?path=/bin.bin",
@@ -5162,12 +5192,18 @@ ggHohNAjhbzDaY2iBW/m3NC5dehGUP4T2GBo/cwGhg==
     let mut resp = t.http().get(url).call().await.unwrap();
     let body = resp.expect_ok::<ApiPackageVersionSource>().await;
 
-    let ApiSource::File { size, view } = body.source else {
+    let ApiSource::File {
+      size,
+      view,
+      rendered,
+    } = body.source
+    else {
       panic!();
     };
 
     assert_eq!(size, 1000);
     assert!(view.is_none());
+    assert!(rendered.is_none());
   }
 
   #[tokio::test]

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -726,8 +726,15 @@ pub struct ApiSourceDirEntry {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ApiSource {
-  Dir { entries: Vec<ApiSourceDirEntry> },
-  File { size: usize, view: Option<String> },
+  Dir {
+    entries: Vec<ApiSourceDirEntry>,
+  },
+  File {
+    size: usize,
+    view: Option<String>,
+    /// Rendered HTML, present for markdown files.
+    rendered: Option<String>,
+  },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -660,6 +660,71 @@ fn get_url_rewriter(
   })
 }
 
+/// Renders a standalone markdown file from a package (e.g. a non-README `.md`
+/// opened in the source view) to sanitized HTML, without building a full
+/// `GenerateCtx`. `path` is the package-root-relative path of the file (with
+/// a leading slash); relative links resolve against the file's directory, the
+/// same way README links do.
+pub fn render_markdown_file(
+  md: &str,
+  scope: &ScopeName,
+  package: &PackageName,
+  version: &Version,
+  github_repository: Option<GithubRepository>,
+  path: &str,
+) -> Option<String> {
+  let renderer = deno_doc::html::comrak::create_renderer(
+    Some(Arc::new(super::tree_sitter::ComrakAdapter {
+      show_line_numbers: false,
+    })),
+    Some(Box::new(match_node_value)),
+    Some(Box::new(|html| AMMONIA.clean(&html).to_string())),
+  );
+
+  let url_rewriter = get_url_rewriter(
+    format!("/@{scope}/{package}/{version}"),
+    github_repository,
+    false,
+  );
+
+  let specifier = ModuleSpecifier::parse(&format!("file://{path}")).ok()?;
+  let short_path = ShortPath::new(specifier, None, None, None);
+
+  let anchorizer: deno_doc::html::jsdoc::Anchorizer = {
+    let seen = std::sync::Mutex::new(std::collections::HashMap::new());
+    Arc::new(move |content: String, level: u8| {
+      let mut slug = String::new();
+      for ch in content.chars() {
+        if ch.is_alphanumeric() {
+          slug.extend(ch.to_lowercase());
+        } else if (ch.is_whitespace() || ch == '-') && !slug.ends_with('-') {
+          slug.push('-');
+        }
+      }
+      let mut seen = seen.lock().unwrap();
+      let count = seen
+        .entry((slug.clone(), level))
+        .and_modify(|count| *count += 1)
+        .or_insert(0);
+      if *count > 0 {
+        format!("{slug}-{count}")
+      } else {
+        slug
+      }
+    })
+  };
+
+  CURRENT_FILE.set(Some(Some(short_path)));
+  URL_REWRITER.set(Some(url_rewriter));
+
+  let rendered = renderer(md, false, None, anchorizer);
+
+  CURRENT_FILE.set(None);
+  URL_REWRITER.set(None);
+
+  rendered
+}
+
 /// Maximum number of symbol rows rendered in module symbol listings (the
 /// per-entrypoint overview and the "all symbols" page). Namespace-heavy
 /// packages (e.g. zod, which re-exports its whole API under several
@@ -1530,6 +1595,29 @@ impl deno_doc::html::UsageComposer for DocUsageComposer {
 mod tests {
   use super::*;
   use deno_doc::html::ShortPath;
+
+  #[test]
+  fn render_markdown_file_test() {
+    let html = render_markdown_file(
+      "# Hi\n\nSee the [guide](./other.md) and ![img](image.png)\n\n```ts\nconst x: number = 1;\n```\n",
+      &ScopeName::new("scope".to_string()).unwrap(),
+      &PackageName::new("pkg".to_string()).unwrap(),
+      &Version::new("1.0.0").unwrap(),
+      None,
+      "/docs/guide.md",
+    )
+    .unwrap();
+    assert!(
+      html.contains(r#"href="/@scope/pkg/1.0.0/docs/./other.md""#),
+      "{html}"
+    );
+    assert!(
+      html.contains(r#"src="/@scope/pkg/1.0.0/docs/image.png""#),
+      "{html}"
+    );
+    // code fences go through the tree-sitter highlighter
+    assert!(html.contains("<span class="), "{html}");
+  }
 
   #[test]
   fn url_resolver_test() {

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -21,6 +21,13 @@ export default define.page<typeof handler>(function PackagePage(
   const sourceRoot =
     `/@${params.scope}/${params.package}/${data.selectedVersion.version}`;
 
+  const rendered =
+    (data.source?.source.kind === "file" && data.source.source.rendered) ||
+    null;
+  const showPreview = rendered !== null && !data.showCode;
+  const selfPath = sourceRoot +
+    (data.sourcePath === "/" ? "" : data.sourcePath);
+
   return (
     <div class="mb-20">
       {data.source && (
@@ -100,6 +107,30 @@ export default define.page<typeof handler>(function PackagePage(
                 );
               })}
             </div>
+            {rendered !== null && (
+              <div class="ml-auto flex items-center rounded-md ring-1 ring-jsr-cyan-100 dark:ring-jsr-cyan-900 overflow-hidden text-sm">
+                <a
+                  href={selfPath}
+                  class={`px-2.5 py-0.5 ${
+                    showPreview
+                      ? "bg-jsr-cyan-100 dark:bg-jsr-cyan-900 font-semibold"
+                      : "hover:bg-jsr-cyan-100/50 dark:hover:bg-jsr-cyan-900/50"
+                  }`}
+                >
+                  Preview
+                </a>
+                <a
+                  href={`${selfPath}?code`}
+                  class={`px-2.5 py-0.5 ${
+                    showPreview
+                      ? "hover:bg-jsr-cyan-100/50 dark:hover:bg-jsr-cyan-900/50"
+                      : "bg-jsr-cyan-100 dark:bg-jsr-cyan-900 font-semibold"
+                  }`}
+                >
+                  Code
+                </a>
+              </div>
+            )}
           </nav>
 
           {data.source
@@ -118,7 +149,17 @@ export default define.page<typeof handler>(function PackagePage(
                   </ListDisplay>
                 )
                 : (
-                  data.source.source.view
+                  showPreview
+                    ? (
+                      <div class="ddoc px-5 py-4">
+                        <div
+                          class="markdown"
+                          // deno-lint-ignore react-no-danger
+                          dangerouslySetInnerHTML={{ __html: rendered }}
+                        />
+                      </div>
+                    )
+                    : data.source.source.view
                     ? (
                       <div class="ddoc">
                         <div
@@ -235,6 +276,7 @@ export const handler = define.handlers({
         source,
         sourcePath,
         member: scopeMember,
+        showCode: ctx.url.searchParams.has("code"),
       },
       headers: { ...(ctx.params.version ? { "X-Robots-Tag": "noindex" } : {}) },
     };

--- a/frontend/utils/api_types.ts
+++ b/frontend/utils/api_types.ts
@@ -196,6 +196,7 @@ export interface SourceFile {
   kind: "file";
   size: number;
   view: string | null;
+  rendered: string | null;
 }
 
 export interface PackageVersionSource {


### PR DESCRIPTION
Markdown files in the Files view now render like on GitHub, with a **Preview / Code** toggle in the file navigation bar (preview is the default; `?code` shows the highlighted source). The API returns rendered HTML alongside the highlighted source for `.md`/`.markdown` files, using the same comrak pipeline, ammonia sanitizer and relative-link resolution as README rendering — links resolve against the file's directory, and packages with a linked GitHub repository keep their existing link rewriting.

Fixes #709.

## Screenshots

Production today (markdown files show raw source only):

![before: raw markdown source on jsr.io](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/709-before-prod.png)

After (local dev registry) — preview by default, with a toggle:

| Preview | Code |
|--|--|
| ![after: rendered markdown with Preview/Code toggle](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/709-after-preview.png) | ![after: highlighted source via the Code toggle](https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep/709-after-code.png) |