### PR TITLE
fix(api): render markdown footnotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.204.0"
+version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c121a45c4001f3b89cc7af2e3cab71514db6807ded0c9a0317b118d3d3fe87"
+checksum = "4d80bf35d7150d36768fc1f4e6bb71444f39924263b71a343e1a7b4efa64b9d8"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -98,7 +98,7 @@ async-compression = { version = "0.4", features = ["futures-io", "gzip"] }
 deno_graph = "=0.110.2"
 deno_ast = { version = "0.53.0", features = ["view"] }
 # sync with frontend/deno.json
-deno_doc = { version = "=0.204.0", features = ["comrak"] }
+deno_doc = { version = "=0.205.0", features = ["comrak"] }
 deno_error = "0.7.0"
 comrak = { version = "0.29.0", default-features = false }
 ammonia = "4.0.0"

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -1660,26 +1660,28 @@ mod tests {
   }
 
   #[test]
-  fn ammonia_keeps_footnote_markup() {
-    // the shape comrak emits with its footnotes extension enabled
-    let html = r##"<p>claim<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p><section class="footnotes" data-footnotes><ol><li id="fn-1"><p>the source <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p></li></ol></section>"##;
-    // the relative-URL evaluator requires the rendering thread-locals
-    CURRENT_FILE.set(Some(None));
-    URL_REWRITER.set(Some(Arc::new(|_, url: &str| url.to_string())));
-    let cleaned = AMMONIA.clean(html).to_string();
-    CURRENT_FILE.set(None);
-    URL_REWRITER.set(None);
-    assert!(
-      cleaned.contains(r#"<section class="footnotes">"#),
-      "{cleaned}"
-    );
-    assert!(
-      cleaned.contains(r#"<sup class="footnote-ref">"#),
-      "{cleaned}"
-    );
-    assert!(cleaned.contains(r#"class="footnote-backref""#), "{cleaned}");
-    assert!(cleaned.contains(r##"href="#fn-1""##), "{cleaned}");
-    assert!(cleaned.contains(r#"id="fn-1""#), "{cleaned}");
+  fn renders_footnotes_through_the_sanitizer() {
+    // goes through the real render path, so this keeps up with whatever markup
+    // the deno_doc of the day emits rather than a hand-written fixture
+    let html = render_markdown_file(
+      "claim[^1]\n\n[^1]: the source",
+      &ScopeName::new("scope".to_string()).unwrap(),
+      &PackageName::new("pkg".to_string()).unwrap(),
+      &Version::new("1.0.0").unwrap(),
+      None,
+      "/README.md",
+    )
+    .unwrap();
+
+    // the footnote section wrapper and both link classes survive the allowlist
+    assert!(html.contains(r#"<section class="footnotes">"#), "{html}");
+    assert!(html.contains(r#"<sup class="footnote-ref">"#), "{html}");
+    assert!(html.contains(r#"class="footnote-backref""#), "{html}");
+    // and so do the anchors that make the jump there and back work
+    assert!(html.contains(r##"href="#fn-1""##), "{html}");
+    assert!(html.contains(r#"id="fn-1""#), "{html}");
+    assert!(html.contains(r##"href="#fnref-1""##), "{html}");
+    assert!(html.contains(r#"id="fnref-1""#), "{html}");
   }
 
   #[test]

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -287,7 +287,7 @@ lazy_static::lazy_static! {
     let mut ammonia_builder = ammonia::Builder::default();
 
     ammonia_builder
-      .add_tags(["video", "button", "svg", "path", "rect"])
+      .add_tags(["video", "button", "svg", "path", "rect", "section"])
       .add_generic_attributes(["id", "align"])
       .add_tag_attributes("button", ["data-copy"])
       .add_tag_attributes(
@@ -322,6 +322,10 @@ lazy_static::lazy_static! {
       .add_tag_attributes("video", ["src", "controls"])
       .add_allowed_classes("pre", ["highlight"])
       .add_allowed_classes("button", ["copyButton"])
+      // comrak footnote output
+      .add_allowed_classes("section", ["footnotes"])
+      .add_allowed_classes("sup", ["footnote-ref"])
+      .add_allowed_classes("a", ["footnote-backref"])
       .add_allowed_classes(
         "div",
         [
@@ -1653,6 +1657,29 @@ mod tests {
     );
     // code fences go through the tree-sitter highlighter
     assert!(html.contains("<span class="), "{html}");
+  }
+
+  #[test]
+  fn ammonia_keeps_footnote_markup() {
+    // the shape comrak emits with its footnotes extension enabled
+    let html = r##"<p>claim<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p><section class="footnotes" data-footnotes><ol><li id="fn-1"><p>the source <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p></li></ol></section>"##;
+    // the relative-URL evaluator requires the rendering thread-locals
+    CURRENT_FILE.set(Some(None));
+    URL_REWRITER.set(Some(Arc::new(|_, url: &str| url.to_string())));
+    let cleaned = AMMONIA.clean(html).to_string();
+    CURRENT_FILE.set(None);
+    URL_REWRITER.set(None);
+    assert!(
+      cleaned.contains(r#"<section class="footnotes">"#),
+      "{cleaned}"
+    );
+    assert!(
+      cleaned.contains(r#"<sup class="footnote-ref">"#),
+      "{cleaned}"
+    );
+    assert!(cleaned.contains(r#"class="footnote-backref""#), "{cleaned}");
+    assert!(cleaned.contains(r##"href="#fn-1""##), "{cleaned}");
+    assert!(cleaned.contains(r#"id="fn-1""#), "{cleaned}");
   }
 
   #[test]

--- a/frontend/components/doc/ModuleDoc.tsx
+++ b/frontend/components/doc/ModuleDoc.tsx
@@ -4,10 +4,7 @@ import { Deprecated } from "./Deprecated.tsx";
 import { SymbolContent } from "./SymbolContent.tsx";
 
 export function ModuleDoc({ content }: { content: ModuleDocCtx }) {
-  // `symbols_trimmed` is missing from @deno/doc@0.204.0's html-types; drop
-  // this extension once the published types include it.
-  const symbolsTrimmed =
-    (content as ModuleDocCtx & { symbols_trimmed?: boolean }).symbols_trimmed;
+  const symbolsTrimmed = content.symbols_trimmed;
 
   return (
     <section>

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -14,7 +14,7 @@
     }
   },
   "imports": {
-    "@deno/doc": "jsr:@deno/doc@^0.204.0",
+    "@deno/doc": "jsr:@deno/doc@^0.205.0",
     "@fresh/plugin-tailwind": "jsr:@fresh/plugin-tailwind@^1.0.0",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.1.2",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.3.0",

--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -2,7 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@deno/cache-dir@0.25": "0.25.0",
-    "jsr:@deno/doc@0.204": "0.204.0",
+    "jsr:@deno/doc@0.205": "0.205.0",
     "jsr:@deno/esbuild-plugin@^1.2.0": "1.2.1",
     "jsr:@deno/gfm@0.11": "0.11.0",
     "jsr:@deno/graph@0.100": "0.100.1",
@@ -29,7 +29,6 @@
     "jsr:@std/fmt@^1.0.7": "1.0.10",
     "jsr:@std/fmt@^1.0.8": "1.0.10",
     "jsr:@std/front-matter@1": "1.0.9",
-    "jsr:@std/fs@1": "1.0.24",
     "jsr:@std/fs@^1.0.19": "1.0.24",
     "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/fs@^1.0.6": "1.0.24",
@@ -113,8 +112,8 @@
         "jsr:@std/path@^1.0.8"
       ]
     },
-    "@deno/doc@0.204.0": {
-      "integrity": "2098f4924af3b193984fd0a195321bc12a996a90a428fb93d27746bb4efb5009",
+    "@deno/doc@0.205.0": {
+      "integrity": "86e01dd7f2bc8b5d9059b3458cfce10a9e8a9f06245be612d82e09f21373c36e",
       "dependencies": [
         "jsr:@deno/cache-dir",
         "jsr:@deno/graph@0.100"
@@ -260,7 +259,6 @@
     "@std/fs@1.0.24": {
       "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
-        "jsr:@std/internal",
         "jsr:@std/path@^1.1.5"
       ]
     },
@@ -3021,7 +3019,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@deno/doc@0.204",
+      "jsr:@deno/doc@0.205",
       "jsr:@deno/gfm@0.11",
       "jsr:@fresh/core@^2.3.3",
       "jsr:@fresh/plugin-tailwind@1",


### PR DESCRIPTION
jsr half of #291. deno_doc 0.205.0 (denoland/deno_doc#849) turns comrak's `footnotes` extension on, so this bumps to it and widens the ammonia allowlist to let the markup it emits through — the allowlist stripped the `<section>` wrapper and the `footnote-ref`/`footnote-backref` classes, which would have mangled every rendered footnote. The `#fn-*`/`#fnref-*` anchors already survive: `id` is an allowed generic attribute and fragment hrefs pass the URL rewriter untouched.

- `api`: `=0.204.0` → `=0.205.0`, plus `section` + the three footnote classes on the sanitizer. Everything that renders markdown through `AMMONIA` gets footnotes — JSDoc, READMEs, and the markdown source view from #1523.
- Test renders `claim[^1]` through `render_markdown_file` (the real render path, sanitizer included) rather than a hand-written fixture, so it tracks whatever markup the deno_doc of the day emits, and asserts both the classes and the anchor pair that makes the jump there and back work.
- `frontend`: the pin moves with the api's (they're kept in sync), which also lets `ModuleDoc` drop its `symbols_trimmed` cast — 0.205.0's html-types declare the field (denoland/deno_doc#845).

Footnote styling ships in deno_doc's `comrak.gen.css`, which the frontend already serves as `comrakCss`, so no css change here.

Fixes #291.