### PR TITLE
fix(frontend): show the @deprecated message in symbol listings

### DIFF
--- a/frontend/components/doc/NamespaceSection.tsx
+++ b/frontend/components/doc/NamespaceSection.tsx
@@ -10,6 +10,9 @@ export function NamespaceSection({ items }: { items: NamespaceNodeCtx[] }) {
         const renamedOldName = item.diff_status?.kind === "renamed"
           ? item.diff_status.old_name
           : undefined;
+        // a symbol documented only by `@deprecated <message>` falls back to
+        // that message rather than reading as undocumented
+        const docs = item.docs ?? item.deprecated_doc;
 
         return (
           <div
@@ -67,13 +70,13 @@ export function NamespaceSection({ items }: { items: NamespaceNodeCtx[] }) {
                 </div>
 
                 <div>
-                  {item.docs
+                  {docs
                     ? (
                       <span
                         class="highlightable text-sm leading-5"
                         // jsdoc rendering
                         // deno-lint-ignore react-no-danger
-                        dangerouslySetInnerHTML={{ __html: item.docs }}
+                        dangerouslySetInnerHTML={{ __html: docs }}
                       />
                     )
                     : (


### PR DESCRIPTION
Follow-up to the deno_doc 0.205.0 bump in #1524, which I should have caught there.

denoland/deno_doc#847 taught `namespace_section.hbs` to fall back to the rendered `@deprecated` message when a symbol has no other docs:

```hbs
{{~#if this.docs~}}
  <div class="namespaceItemContentDoc">{{{~this.docs~}}}</div>
{{~else~}}
  {{~#if this.deprecated_doc~}}
    <div class="namespaceItemContentDoc">{{{~this.deprecated_doc~}}}</div>
  {{~/if~}}
{{~/if~}}
```

jsr doesn't render those handlebars templates — it reimplements them as JSX against the serialized ctx — so the upstream fix shipped to deno_doc's own HTML and did nothing here. `NamespaceSection.tsx` still read only `item.docs`, meaning a symbol documented solely by `@deprecated <message>` showed **"No documentation available"** in module and all-symbols listings. Typechecking didn't catch it because `deprecated_doc` is optional.

Teaches the JSX the same fallback. jsr keeps its own "No documentation available" placeholder when neither is present (the template renders nothing there), and `NamespaceNodeSubItemCtx` has no `deprecated_doc`, so subitems are unchanged.

### This is what actually closes #329 on jsr

#329 was closed as completed when denoland/deno_doc#847 landed, and #1520 (which fixed it by post-processing the ctx in `api/src/docs.rs`) was rightly closed in favour of fixing it upstream. But the upstream fix only reaches jsr's UI once the JSX mirrors the template — until this PR, the exact symbol from #329's screenshots still rendered "No documentation available" in the overview. Worth reopening #329 if you'd rather track it to this merge.