### PR TITLE
feat(api): link import/export specifiers in the file view

### DIFF
--- a/api/src/api/package.rs
+++ b/api/src/api/package.rs
@@ -1787,18 +1787,29 @@ pub async fn get_source_handler(
     None
   };
 
-  let path_buf = std::path::PathBuf::from(path);
+  let path_buf = std::path::PathBuf::from(&path);
 
   let source = if let Some(file) = file {
     let size = file.len();
 
-    let highlighter = deno_doc::html::comrak::ComrakHighlightWrapperAdapter(
-      Some(Arc::new(crate::tree_sitter::ComrakAdapter {
-        show_line_numbers: true,
-      })),
-    );
-
     let view = if let Ok(file) = String::from_utf8(file.to_vec()) {
+      let links = source_specifier_links(
+        &scope,
+        &package,
+        &version.version,
+        &path,
+        &file,
+        buckets,
+        req.data::<RegistryUrl>().unwrap().0.as_str(),
+      )
+      .await;
+
+      let mut adapter = crate::tree_sitter::ComrakAdapter::new(true);
+      adapter.links = links;
+      let highlighter = deno_doc::html::comrak::ComrakHighlightWrapperAdapter(
+        Some(Arc::new(adapter)),
+      );
+
       let mut out = vec![];
       highlighter.write_pre_tag(&mut out, Default::default())?;
       highlighter.write_code_tag(&mut out, Default::default())?;
@@ -1903,6 +1914,70 @@ pub async fn get_source_handler(
     script: Cow::Borrowed(deno_doc::html::SCRIPT_JS),
     source,
   })
+}
+
+/// Finds the import/export specifiers of the file being viewed, so the
+/// highlighter can render them as links (jsr-io/jsr#17).
+///
+/// The ranges come from the `moduleGraph2` recorded at publish time, so
+/// nothing is re-parsed here. Links are a nicety: anything missing or
+/// unreadable just yields a file view without them.
+async fn source_specifier_links(
+  scope: &ScopeName,
+  package: &PackageName,
+  version: &Version,
+  path: &str,
+  source: &str,
+  buckets: &Buckets,
+  registry_url: &str,
+) -> Vec<crate::tree_sitter::SourceLink> {
+  if !crate::source_links::is_module_path(path) {
+    return Vec::new();
+  }
+
+  let metadata_path =
+    crate::s3_paths::version_metadata(scope, package, version);
+  let metadata =
+    match buckets.modules_bucket.download(metadata_path.into()).await {
+      Ok(Some(bytes)) => {
+        match serde_json::from_slice::<crate::metadata::VersionMetadata>(&bytes)
+        {
+          Ok(metadata) => metadata,
+          Err(err) => {
+            error!("failed to parse version metadata for links: {err}");
+            return Vec::new();
+          }
+        }
+      }
+      Ok(None) => return Vec::new(),
+      Err(err) => {
+        error!("failed to download version metadata for links: {err}");
+        return Vec::new();
+      }
+    };
+
+  let Some(module_info) = metadata.module_graph_2.get(path) else {
+    return Vec::new();
+  };
+
+  let files = metadata
+    .manifest
+    .keys()
+    .map(|path| path.to_string())
+    .collect();
+
+  crate::source_links::specifier_links(
+    module_info,
+    source,
+    &crate::source_links::LinkContext {
+      scope,
+      package,
+      version,
+      current_path: path,
+      files: &files,
+      registry_url,
+    },
+  )
 }
 
 #[instrument(

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -684,9 +684,7 @@ pub fn render_markdown_file(
   path: &str,
 ) -> Option<String> {
   let renderer = deno_doc::html::comrak::create_renderer(
-    Some(Arc::new(super::tree_sitter::ComrakAdapter {
-      show_line_numbers: false,
-    })),
+    Some(Arc::new(super::tree_sitter::ComrakAdapter::new(false))),
     Some(Box::new(match_node_value)),
     Some(Box::new(|html| AMMONIA.clean(&html).to_string())),
   );
@@ -781,9 +779,7 @@ pub fn get_generate_ctx(
     get_url_rewriter(url_rewriter_base, github_repository, has_readme);
 
   let markdown_renderer = deno_doc::html::comrak::create_renderer(
-    Some(Arc::new(super::tree_sitter::ComrakAdapter {
-      show_line_numbers: false,
-    })),
+    Some(Arc::new(super::tree_sitter::ComrakAdapter::new(false))),
     Some(Box::new(match_node_value)),
     Some(Box::new(|html| AMMONIA.clean(&html).to_string())),
   );

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -23,6 +23,7 @@ mod publish;
 mod s3;
 mod s3_paths;
 mod sitemap;
+mod source_links;
 mod tarball;
 mod task_queue;
 mod tasks;

--- a/api/src/source_links.rs
+++ b/api/src/source_links.rs
@@ -1,0 +1,354 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+//! Turns the import/export specifiers recorded in a version's module graph
+//! into clickable links in the file view (jsr-io/jsr#17).
+//!
+//! Every published version stores a `moduleGraph2` in its metadata, and each
+//! entry already carries the source range of every specifier it mentions —
+//! static and dynamic imports, `export ... from`, triple-slash references, the
+//! JSX import source pragma and JSDoc type imports. So the file view does not
+//! have to re-parse anything: it maps those ranges onto byte offsets in the
+//! file it is about to highlight and hands them to the highlighter.
+
+use std::collections::HashSet;
+
+use deno_graph::Position;
+use deno_graph::PositionRange;
+use deno_graph::analysis::DependencyDescriptor;
+use deno_graph::analysis::DynamicArgument;
+use deno_graph::analysis::ModuleInfo;
+use deno_graph::analysis::TypeScriptReference;
+use deno_semver::RangeSetOrTag;
+use url::Url;
+
+use crate::ids::PackageName;
+use crate::ids::ScopeName;
+use crate::ids::Version;
+use crate::tree_sitter::SourceLink;
+
+/// Everything needed to turn a specifier into a URL on this site.
+pub struct LinkContext<'a> {
+  pub scope: &'a ScopeName,
+  pub package: &'a PackageName,
+  pub version: &'a Version,
+  /// Path of the file being viewed, e.g. `/src/mod.ts`.
+  pub current_path: &'a str,
+  /// Paths of the files in this version, used so a relative specifier only
+  /// becomes a link when it actually resolves to a file we can show.
+  pub files: &'a HashSet<String>,
+  pub registry_url: &'a str,
+}
+
+/// Collects the linkable specifiers of one module, sorted by position and with
+/// overlaps removed so the highlighter can walk them in one pass.
+pub fn specifier_links(
+  module_info: &ModuleInfo,
+  source: &str,
+  ctx: &LinkContext,
+) -> Vec<SourceLink> {
+  let lines = LineIndex::new(source);
+  let mut links = Vec::new();
+
+  let mut push = |specifier: &str, range: &PositionRange| {
+    let Some(href) = resolve_href(specifier, ctx) else {
+      return;
+    };
+    let Some(range) = lines.byte_range(range) else {
+      return;
+    };
+    if range.is_empty() {
+      return;
+    }
+    links.push(SourceLink { range, href });
+  };
+
+  for dependency in &module_info.dependencies {
+    match dependency {
+      DependencyDescriptor::Static(dependency) => {
+        push(&dependency.specifier, &dependency.specifier_range);
+        if let Some(types) = &dependency.types_specifier {
+          push(&types.text, &types.range);
+        }
+      }
+      DependencyDescriptor::Dynamic(dependency) => {
+        // only a dynamic import with a plain string argument has a specifier
+        // to link; templates and computed expressions do not
+        if let DynamicArgument::String(specifier) = &dependency.argument {
+          push(specifier, &dependency.argument_range);
+        }
+        if let Some(types) = &dependency.types_specifier {
+          push(&types.text, &types.range);
+        }
+      }
+    }
+  }
+
+  for reference in &module_info.ts_references {
+    let specifier = match reference {
+      TypeScriptReference::Path(specifier) => specifier,
+      TypeScriptReference::Types { specifier, .. } => specifier,
+    };
+    push(&specifier.text, &specifier.range);
+  }
+
+  for specifier in [
+    module_info.self_types_specifier.as_ref(),
+    module_info.jsx_import_source.as_ref(),
+    module_info.jsx_import_source_types.as_ref(),
+  ]
+  .into_iter()
+  .flatten()
+  {
+    push(&specifier.text, &specifier.range);
+  }
+
+  for import in &module_info.jsdoc_imports {
+    push(&import.specifier.text, &import.specifier.range);
+  }
+
+  links.sort_by_key(|link| link.range.start);
+  // ranges from different sources can name the same specifier (a `@ts-types`
+  // override sitting on the import it overrides, say); keep the first
+  links.dedup_by(|later, earlier| later.range.start < earlier.range.end);
+  links
+}
+
+/// Whether a file is one the module graph could have an entry for. Saves
+/// fetching the version metadata when viewing a README or a JSON file.
+pub fn is_module_path(path: &str) -> bool {
+  matches!(
+    path.rsplit_once('.').map(|(_, extension)| extension),
+    Some("js" | "mjs" | "cjs" | "jsx" | "ts" | "mts" | "cts" | "tsx")
+  )
+}
+
+fn resolve_href(specifier: &str, ctx: &LinkContext) -> Option<String> {
+  if specifier.starts_with('.') {
+    return resolve_relative_href(specifier, ctx);
+  }
+
+  let url = Url::parse(specifier).ok()?;
+  match url.scheme() {
+    "node" => Some(format!("https://nodejs.org/api/{}.html", url.path())),
+    "npm" => {
+      let reference =
+        deno_semver::npm::NpmPackageReqReference::from_str(specifier).ok()?;
+      let req = reference.req();
+      Some(format!(
+        "https://www.npmjs.com/package/{}{}",
+        req.name,
+        match req.version_req.inner() {
+          RangeSetOrTag::RangeSet(_) => String::new(),
+          RangeSetOrTag::Tag(tag) => format!("/v/{tag}"),
+        },
+      ))
+    }
+    "jsr" => {
+      let reference =
+        deno_semver::jsr::JsrPackageReqReference::from_str(specifier).ok()?;
+      let req = reference.req();
+
+      // link to the exact version when the specifier pins one, so the reader
+      // lands on the code that is actually imported
+      let version = req
+        .version_req
+        .range()
+        .and_then(|range| Version::new(&range.to_string()).ok())
+        .map(|version| format!("@{version}"))
+        .unwrap_or_default();
+
+      Some(format!("/{}{version}", req.name))
+    }
+    "http" | "https" if specifier.starts_with(ctx.registry_url) => {
+      // a direct registry URL, e.g. https://jsr.io/@scope/name/1.2.3/mod.ts
+      let parts = url.path().splitn(4, '/').collect::<Vec<_>>();
+      let [_, scope, package, rest] = parts[..] else {
+        return None;
+      };
+      Some(format!("/{scope}/{package}@{rest}"))
+    }
+    "http" | "https" => Some(url.to_string()),
+    // `bun:`, `cloudflare:`, `virtual:` and friends have nothing to point at
+    _ => None,
+  }
+}
+
+fn resolve_relative_href(specifier: &str, ctx: &LinkContext) -> Option<String> {
+  let base = Url::parse(&format!("file://{}", ctx.current_path)).ok()?;
+  let resolved = base.join(specifier).ok()?;
+  let path = resolved.path();
+
+  // don't offer a link the file view would 404 on: a specifier can point
+  // outside the package, or rely on resolution jsr does not replay here
+  if !ctx.files.contains(path) {
+    return None;
+  }
+
+  Some(format!(
+    "/@{}/{}/{}{path}",
+    ctx.scope, ctx.package, ctx.version
+  ))
+}
+
+/// Maps the module graph's `(line, character)` positions onto byte offsets.
+///
+/// `character` counts characters, not bytes and not UTF-16 units, so lines
+/// with multi-byte characters before a specifier are walked by character.
+struct LineIndex<'a> {
+  source: &'a str,
+  starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+  fn new(source: &'a str) -> Self {
+    let mut starts = vec![0];
+    starts.extend(source.match_indices('\n').map(|(index, _)| index + 1));
+    Self { source, starts }
+  }
+
+  fn byte_offset(&self, position: &Position) -> Option<usize> {
+    let start = *self.starts.get(position.line)?;
+    let end = self
+      .starts
+      .get(position.line + 1)
+      .copied()
+      .unwrap_or(self.source.len());
+    let line = &self.source[start..end];
+
+    let offset = line
+      .char_indices()
+      .nth(position.character)
+      .map(|(offset, _)| offset)
+      .unwrap_or(line.len());
+    Some(start + offset)
+  }
+
+  fn byte_range(
+    &self,
+    range: &PositionRange,
+  ) -> Option<std::ops::Range<usize>> {
+    let start = self.byte_offset(&range.start)?;
+    let end = self.byte_offset(&range.end)?;
+    (start <= end && end <= self.source.len()).then_some(start..end)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Resolves a specifier as if viewing `/src/mod.ts` of `@scope/pkg@1.2.3`,
+  /// with `files` as the package's file list.
+  fn resolve(specifier: &str, files: &[&str]) -> Option<String> {
+    let scope = ScopeName::new("scope".to_string()).unwrap();
+    let package = PackageName::new("pkg".to_string()).unwrap();
+    let version = Version::new("1.2.3").unwrap();
+    let files: HashSet<String> =
+      files.iter().map(|path| path.to_string()).collect();
+
+    resolve_href(
+      specifier,
+      &LinkContext {
+        scope: &scope,
+        package: &package,
+        version: &version,
+        current_path: "/src/mod.ts",
+        files: &files,
+        registry_url: "https://jsr.io",
+      },
+    )
+  }
+
+  const FILES: &[&str] = &["/src/mod.ts", "/src/util.ts", "/other.ts"];
+
+  #[test]
+  fn line_index_handles_multi_byte_characters() {
+    // `β` is two bytes, so the character index and the byte offset differ
+    let source = "const β = 1;\nimport x from \"./a.ts\";\n";
+    let index = LineIndex::new(source);
+
+    assert_eq!(index.byte_offset(&Position::new(0, 6)), Some(6));
+    // after the two-byte β, character 7 is byte 8
+    assert_eq!(index.byte_offset(&Position::new(0, 7)), Some(8));
+    // line 1 starts right after the newline
+    assert_eq!(index.byte_offset(&Position::new(1, 0)), Some(14));
+    assert_eq!(
+      &source[index.byte_offset(&Position::new(1, 14)).unwrap()..],
+      "\"./a.ts\";\n"
+    );
+    // out of range lines resolve to nothing rather than panicking
+    assert_eq!(index.byte_offset(&Position::new(9, 0)), None);
+  }
+
+  #[test]
+  fn relative_specifiers_link_to_the_file_view() {
+    assert_eq!(
+      resolve("./util.ts", FILES).as_deref(),
+      Some("/@scope/pkg/1.2.3/src/util.ts")
+    );
+    assert_eq!(
+      resolve("../other.ts", FILES).as_deref(),
+      Some("/@scope/pkg/1.2.3/other.ts")
+    );
+    // a specifier that does not name a file in the package is left alone,
+    // rather than becoming a link to a 404
+    assert_eq!(resolve("./missing.ts", FILES), None);
+    assert_eq!(resolve("../../escape.ts", FILES), None);
+  }
+
+  #[test]
+  fn external_specifiers_link_off_site() {
+    assert_eq!(
+      resolve("node:fs", FILES).as_deref(),
+      Some("https://nodejs.org/api/fs.html")
+    );
+    assert_eq!(
+      resolve("npm:chalk@5", FILES).as_deref(),
+      Some("https://www.npmjs.com/package/chalk")
+    );
+    assert_eq!(
+      resolve("jsr:@std/assert@^1.0.0", FILES).as_deref(),
+      Some("/@std/assert")
+    );
+    assert_eq!(
+      resolve("jsr:@std/assert@1.0.2", FILES).as_deref(),
+      Some("/@std/assert@1.0.2")
+    );
+    assert_eq!(
+      resolve("jsr:@std/assert@1.0.2/equals", FILES).as_deref(),
+      Some("/@std/assert@1.0.2")
+    );
+    assert_eq!(
+      resolve("https://deno.land/x/foo/mod.ts", FILES).as_deref(),
+      Some("https://deno.land/x/foo/mod.ts")
+    );
+    // registry URLs point back into the site
+    assert_eq!(
+      resolve("https://jsr.io/@std/assert/1.0.2/mod.ts", FILES).as_deref(),
+      Some("/@std/assert@1.0.2/mod.ts")
+    );
+    // schemes with nowhere to go stay plain text
+    assert_eq!(resolve("bun:test", FILES), None);
+    assert_eq!(resolve("cloudflare:workers", FILES), None);
+    assert_eq!(resolve("lodash", FILES), None);
+  }
+
+  #[test]
+  fn is_module_path_covers_the_view() {
+    for path in [
+      "/mod.ts",
+      "/mod.tsx",
+      "/a.mts",
+      "/a.cts",
+      "/a.js",
+      "/a.mjs",
+      "/a.cjs",
+      "/a.jsx",
+      "/types.d.ts",
+    ] {
+      assert!(is_module_path(path), "{path}");
+    }
+    for path in ["/README.md", "/deno.json", "/a.wasm", "/a.css"] {
+      assert!(!is_module_path(path), "{path}");
+    }
+  }
+}

--- a/api/src/tree_sitter.rs
+++ b/api/src/tree_sitter.rs
@@ -1,13 +1,38 @@
 // Copyright 2024 the JSR authors. All rights reserved. MIT license.
 use std::collections::HashMap;
 use std::io::Write;
+use std::ops::Range;
 use std::sync::OnceLock;
 
 use tree_sitter_highlight::Highlight;
 use tree_sitter_highlight::HighlightConfiguration;
+use tree_sitter_highlight::HighlightEvent;
+
+/// A span of the highlighted source that should be rendered as a link, used by
+/// the file view to make import/export specifiers clickable (jsr-io/jsr#17).
+#[derive(Debug, Clone)]
+pub struct SourceLink {
+  /// Byte range in the source being highlighted, including the quotes around
+  /// the specifier.
+  pub range: Range<usize>,
+  pub href: String,
+}
 
 pub struct ComrakAdapter {
   pub show_line_numbers: bool,
+  /// Ranges to wrap in anchors, sorted by start and non-overlapping. Markdown
+  /// code fences pass none: their offsets are fence-relative, and only the
+  /// file view knows what a specifier resolves to.
+  pub links: Vec<SourceLink>,
+}
+
+impl ComrakAdapter {
+  pub fn new(show_line_numbers: bool) -> Self {
+    Self {
+      show_line_numbers,
+      links: Vec::new(),
+    }
+  }
 }
 
 impl comrak::adapters::SyntaxHighlighterAdapter for ComrakAdapter {
@@ -29,16 +54,13 @@ impl comrak::adapters::SyntaxHighlighterAdapter for ComrakAdapter {
         .highlight(config, source, None, |e| tree_sitter_language_cb(e));
 
       match res {
-        Ok(highlighter) => {
-          let mut renderer = tree_sitter_highlight::HtmlRenderer::new();
-          match renderer
-            .render(highlighter, source, &|highlight| classes(highlight))
-          {
-            Ok(()) => {
+        Ok(events) => {
+          match render_lines(events, source, &self.links) {
+            Ok(rendered) => {
               let mut line_numbers = String::new();
               let mut lines = String::new();
 
-              for (i, line) in renderer.lines().enumerate() {
+              for (i, line) in rendered.iter().enumerate() {
                 let n = i + 1;
 
                 if self.show_line_numbers {
@@ -133,6 +155,147 @@ highlighter! [
 
 pub(crate) fn classes(highlight: Highlight) -> &'static [u8] {
   CLASSES_ATTRIBUTES[highlight.0].as_bytes()
+}
+
+const fn html_escape(c: u8) -> Option<&'static str> {
+  match c {
+    b'>' => Some("&gt;"),
+    b'<' => Some("&lt;"),
+    b'&' => Some("&amp;"),
+    b'\'' => Some("&#39;"),
+    b'"' => Some("&quot;"),
+    _ => None,
+  }
+}
+
+/// Escapes into a byte buffer rather than a `String` so multi-byte characters
+/// survive: the source is UTF-8 and is appended byte by byte.
+fn push_escaped(out: &mut Vec<u8>, text: &[u8]) {
+  for &c in text {
+    // carriage returns are dropped, matching `HtmlRenderer`, so CRLF sources
+    // don't render a stray character at the end of every line
+    if c == b'\r' {
+      continue;
+    }
+    match html_escape(c) {
+      Some(escape) => out.extend_from_slice(escape.as_bytes()),
+      None => out.push(c),
+    }
+  }
+}
+
+/// Renders the highlighter's event stream to one HTML string per source line,
+/// wrapping `links` in anchors along the way.
+///
+/// This replaces `tree_sitter_highlight::HtmlRenderer`, which cannot emit
+/// anchors. With an empty `links` it produces byte-identical output (see
+/// `matches_upstream_renderer`).
+///
+/// An anchor never spans a highlight boundary or a line break: a link that
+/// covers several highlight spans becomes several anchors pointing at the same
+/// href, which keeps the markup well-formed and every part of it clickable.
+fn render_lines(
+  events: impl Iterator<Item = Result<HighlightEvent, tree_sitter_highlight::Error>>,
+  source: &[u8],
+  links: &[SourceLink],
+) -> Result<Vec<String>, tree_sitter_highlight::Error> {
+  fn open_span(out: &mut Vec<u8>, highlight: Highlight) {
+    out.extend_from_slice(b"<span ");
+    out.extend_from_slice(classes(highlight));
+    out.push(b'>');
+  }
+
+  let mut lines: Vec<String> = Vec::new();
+  let mut line: Vec<u8> = Vec::new();
+  let mut highlights: Vec<Highlight> = Vec::new();
+
+  for event in events {
+    match event? {
+      HighlightEvent::HighlightStart(highlight) => {
+        highlights.push(highlight);
+        open_span(&mut line, highlight);
+      }
+      HighlightEvent::HighlightEnd => {
+        highlights.pop();
+        line.extend_from_slice(b"</span>");
+      }
+      HighlightEvent::Source { start, end } => {
+        let mut pos = start;
+        while pos < end {
+          // the chunk runs until whichever comes first: the end of the link we
+          // are inside, the start of the next one, the end of the event, or a
+          // line break
+          let link = links.iter().find(|link| link.range.contains(&pos));
+          let mut next = end;
+          if let Some(link) = link {
+            next = next.min(link.range.end);
+          } else if let Some(link) =
+            links.iter().find(|link| link.range.start > pos)
+          {
+            next = next.min(link.range.start);
+          }
+          let chunk_end =
+            match source[pos..next].iter().position(|byte| *byte == b'\n') {
+              Some(offset) => pos + offset + 1,
+              None => next,
+            };
+
+          let (text, ends_line) = match source[pos..chunk_end].split_last() {
+            Some((b'\n', rest)) => (rest, true),
+            _ => (&source[pos..chunk_end], false),
+          };
+
+          if let Some(link) = link {
+            // `no_color` keeps the syntax highlighting of the specifier; the
+            // stylesheet gives these an underline on hover instead
+            line.extend_from_slice(
+              br#"<a class="no_color specifierLink" href=""#,
+            );
+            push_escaped(&mut line, link.href.as_bytes());
+            line.extend_from_slice(br#"">"#);
+          }
+          push_escaped(&mut line, text);
+          if link.is_some() {
+            line.extend_from_slice(b"</a>");
+          }
+
+          if ends_line {
+            // close every open highlight so each line is standalone markup,
+            // then reopen them on the next one
+            for _ in &highlights {
+              line.extend_from_slice(b"</span>");
+            }
+            line.push(b'\n');
+            lines.push(finish_line(std::mem::take(&mut line)));
+            for highlight in &highlights {
+              open_span(&mut line, *highlight);
+            }
+          }
+
+          pos = chunk_end;
+        }
+      }
+    }
+  }
+
+  // a source that does not end in a newline still gets a final line; one that
+  // does must not gain an empty one
+  if !line.is_empty() {
+    line.push(b'\n');
+    lines.push(finish_line(line));
+  }
+
+  Ok(lines)
+}
+
+/// The highlighter only ever hands us whole code points and the markup we add
+/// is ASCII, so this is infallible in practice; `from_utf8_lossy` keeps a
+/// pathological input from taking the request down.
+fn finish_line(line: Vec<u8>) -> String {
+  match String::from_utf8(line) {
+    Ok(line) => line,
+    Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+  }
 }
 
 pub fn tree_sitter_language_cb(
@@ -451,9 +614,7 @@ mod tests {
   use comrak::adapters::SyntaxHighlighterAdapter;
 
   fn highlight(lang: &str, code: &str) -> String {
-    let adapter = ComrakAdapter {
-      show_line_numbers: false,
-    };
+    let adapter = ComrakAdapter::new(false);
     let mut out = Vec::new();
     adapter
       .write_highlighted(&mut out, Some(lang), code)
@@ -478,5 +639,136 @@ mod tests {
       let html = highlight(lang, code);
       assert!(html.contains("<span"), "{lang} did not highlight: {html}");
     }
+  }
+
+  fn rendered_lines(
+    lang: &str,
+    code: &str,
+    links: &[SourceLink],
+  ) -> Vec<String> {
+    let config = tree_sitter_language_cb(lang).unwrap();
+    let source = code.as_bytes();
+    let mut highlighter = tree_sitter_highlight::Highlighter::new();
+    #[allow(clippy::redundant_closure)]
+    let events = highlighter
+      .highlight(config, source, None, |e| tree_sitter_language_cb(e))
+      .unwrap();
+    render_lines(events, source, links).unwrap()
+  }
+
+  fn upstream_lines(lang: &str, code: &str) -> Vec<String> {
+    let config = tree_sitter_language_cb(lang).unwrap();
+    let source = code.as_bytes();
+    let mut highlighter = tree_sitter_highlight::Highlighter::new();
+    #[allow(clippy::redundant_closure)]
+    let events = highlighter
+      .highlight(config, source, None, |e| tree_sitter_language_cb(e))
+      .unwrap();
+    let mut renderer = tree_sitter_highlight::HtmlRenderer::new();
+    renderer
+      .render(events, source, &|highlight| classes(highlight))
+      .unwrap();
+    renderer.lines().map(|line| line.to_string()).collect()
+  }
+
+  /// Without links, the hand-rolled renderer must be a drop-in replacement for
+  /// the upstream one, which every markdown code fence still goes through.
+  #[test]
+  fn matches_upstream_renderer() {
+    for (lang, code) in [
+      (
+        "ts",
+        "import { a } from \"./a.ts\";\nexport const x: number = 1;\n",
+      ),
+      // no trailing newline
+      ("ts", "const x = 1;"),
+      // CRLF, blank lines, and a string spanning a line break
+      ("ts", "const a = 1;\r\n\r\nconst b = `multi\nline`;\r\n"),
+      // characters that need escaping, and non-ASCII ones that must not be
+      // mangled by the byte-wise escaping
+      ("ts", "const s = \"<a & b>\";\nconst β = 'π';\n"),
+      ("md", "# Title\n\nSome *text*.\n"),
+      ("json", "{\n  \"a\": [1, 2]\n}\n"),
+    ] {
+      assert_eq!(
+        rendered_lines(lang, code, &[]),
+        upstream_lines(lang, code),
+        "mismatch for {lang}: {code:?}"
+      );
+    }
+  }
+
+  #[test]
+  fn wraps_linked_ranges_in_anchors() {
+    let code = "import { a } from \"./a.ts\";\n";
+    let start = code.find("\"./a.ts\"").unwrap();
+    let links = vec![SourceLink {
+      range: start..start + "\"./a.ts\"".len(),
+      href: "/@scope/pkg/1.0.0/a.ts".to_string(),
+    }];
+
+    let lines = rendered_lines("ts", code, &links);
+    let html = lines.join("");
+
+    assert!(
+      html.contains(
+        r#"<a class="no_color specifierLink" href="/@scope/pkg/1.0.0/a.ts">"#
+      ),
+      "{html}"
+    );
+    // the quotes are part of the link text, and are still escaped
+    assert!(html.contains("&quot;./a.ts&quot;</a>"), "{html}");
+    // the rest of the line is untouched
+    assert_eq!(html.matches("<a ").count(), 1, "{html}");
+    assert_eq!(html.matches("</a>").count(), 1, "{html}");
+  }
+
+  /// A link whose range covers several highlight spans becomes one anchor per
+  /// span, so the markup stays properly nested.
+  #[test]
+  fn anchors_never_cross_a_highlight_boundary() {
+    let code = "import { a } from \"./a.ts\";\n";
+    let links = vec![SourceLink {
+      // deliberately covers the whole line, spanning keywords and strings
+      range: 0..code.len() - 1,
+      href: "/somewhere".to_string(),
+    }];
+
+    let html = rendered_lines("ts", code, &links).join("");
+    assert_eq!(
+      html.matches("<a ").count(),
+      html.matches("</a>").count(),
+      "{html}"
+    );
+    // every anchor closes before the span it sits in does
+    let mut depth = 0i32;
+    for token in html.split('<') {
+      if token.starts_with("a ") {
+        depth += 1;
+      } else if token.starts_with("/a>") {
+        depth -= 1;
+      } else if token.starts_with("/span>") {
+        assert_eq!(depth, 0, "anchor left open across a span: {html}");
+      }
+      assert!(depth >= 0, "{html}");
+    }
+    assert_eq!(depth, 0, "{html}");
+  }
+
+  /// A specifier on the last line of a file without a trailing newline still
+  /// gets its anchor, and no phantom line is emitted.
+  #[test]
+  fn links_on_a_final_line_without_a_newline() {
+    let code = "import \"./a.ts\";";
+    let start = code.find("\"./a.ts\"").unwrap();
+    let links = vec![SourceLink {
+      range: start..start + "\"./a.ts\"".len(),
+      href: "/a".to_string(),
+    }];
+
+    let lines = rendered_lines("ts", code, &links);
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(lines[0].contains(r#"href="/a""#), "{lines:?}");
+    assert!(lines[0].ends_with('\n'), "{lines:?}");
   }
 }

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -419,6 +419,18 @@ body .ddoc {
         }
       }
 
+      /* Import/export specifiers in the file view. These keep the syntax
+         colour of the string they sit in (hence `no_color` on the anchor) and
+         only announce themselves as links on hover and focus. */
+      .specifierLink {
+        @apply underline decoration-dotted underline-offset-2
+          decoration-jsr-gray-400 rounded-sm outline-none
+          hover:decoration-solid hover:decoration-jsr-cyan-700
+          focus-visible:ring-2 ring-jsr-cyan-700
+          dark:decoration-jsr-gray-500 dark:hover:decoration-cyan-400
+          dark:ring-cyan-400;
+      }
+
       /*!
        * GitHub Light v0.5.0
        * Copyright (c) 2012 - 2017 GitHub, Inc.


### PR DESCRIPTION
Closes #17.

Import and export specifiers in the file view are now links.

No re-parsing is involved: every published version's `moduleGraph2` metadata already records the source range of every specifier the module mentions — static and dynamic imports, `export … from`, `@ts-types` overrides, triple-slash references, the JSX import source pragma, and JSDoc type imports — so the view maps those ranges onto byte offsets and hands them to the highlighter.

Where each kind points:

| specifier | link |
| --- | --- |
| `./util.ts`, `../options.ts` | that file in this version's file view |
| `jsr:@scope/pkg@1.2.3` | the package page, pinned when the specifier pins a version |
| `npm:chalk@5` | the package on npmjs.com |
| `node:path` | the module on nodejs.org |
| `https://…` | the URL itself; registry URLs resolve back into JSR |

A relative specifier only becomes a link when it names a file that is actually in the version, so the view never offers a link to a 404.

### `/mod.ts` of a demo package

<img width="1483" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/17-source-view.jpg">

The links keep the syntax colour of the string they sit in, and announce themselves with a dotted underline that goes solid on hover (line 9 is hovered here):

<img width="700" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/17-specifiers-hover.png">

### Rendering

`tree_sitter_highlight::HtmlRenderer` can't emit anchors, so the highlighting is rendered here instead. With no links to place it produces byte-identical output — a test pins that against the upstream renderer across several languages, including CRLF input, non-ASCII characters, and a file with no trailing newline.

An anchor never spans a highlight boundary or a line break: a link covering several highlight spans becomes several anchors with the same href, which keeps the markup well-formed (also covered by a test) and every part of it clickable.

### Cost

The file view now fetches the version metadata alongside the file, and only for paths that could be modules (`.ts`, `.tsx`, `.js`, `.mjs`, …), so READMEs, JSON and other assets are unaffected. Anything missing or unreadable there just yields a file view without links.
