### PR TITLE
feat: show the number of documented symbols on the Docs tab

### DIFF
--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -234,7 +234,7 @@ async fn analyze_package_inner(
   .await
   .map_err(PublishError::NpmTarballError)?;
 
-  let (meta, readme_path) = {
+  let (mut meta, readme_path) = {
     let readme = files
       .iter()
       .find(|file| file.0.case_insensitive().is_readme());
@@ -276,6 +276,7 @@ async fn analyze_package_inner(
     registry_url.to_string(),
     None,
   );
+  meta.symbol_count = Some(count_symbols(&ctx));
   let search_index = deno_doc::html::generate_search_index(&ctx);
   let doc_search_json = if let serde_json::Value::Object(mut obj) = search_index
   {
@@ -345,7 +346,39 @@ fn generate_score(
     ),
     all_fast_check,
     has_provenance: false, // Provenance score is updated after version publish
+    // filled in once the render context exists, see `count_symbols`
+    symbol_count: None,
   }
+}
+
+/// Counts the symbols the generated docs actually list for a package: every
+/// exported symbol of every entrypoint, plus namespace members, minus the ones
+/// hidden from the listings (`@internal` and non-exported types).
+///
+/// Deduplicated per `(file, qualified name)` the same way the search index is,
+/// so a symbol re-exported from several entrypoints counts once per entrypoint
+/// it is documented under, and never twice within one. Class/interface members
+/// are not counted: they are part of their parent symbol, not separate entries
+/// in the listings.
+fn count_symbols(ctx: &deno_doc::html::GenerateCtx) -> u32 {
+  let mut seen = HashSet::new();
+
+  for (short_path, nodes) in &ctx.doc_nodes {
+    for node in deno_doc::html::partition::flatten_namespace(
+      ctx,
+      nodes.iter().map(std::borrow::Cow::Borrowed),
+    ) {
+      if node.is_internal(ctx) {
+        continue;
+      }
+      seen.insert((
+        short_path.path.clone(),
+        node.get_qualified_name().to_string(),
+      ));
+    }
+  }
+
+  seen.len() as u32
 }
 
 /// Cap on how many undocumented entrypoints are recorded in

--- a/api/src/api.yml
+++ b/api/src/api.yml
@@ -2583,6 +2583,14 @@ components:
           type: string
           enum: ["readme", "jsdoc"]
           description: The source of the package readme.
+        symbolCount:
+          type: integer
+          nullable: true
+          description: >-
+            The number of symbols documented by the latest version of the
+            package. Null for packages with no published version, and for
+            packages whose latest version was published before this count was
+            recorded.
       required:
         - scope
         - name
@@ -2751,6 +2759,12 @@ components:
           type: string
           format: date-time
           description: The date and time when the package version was last updated.
+        symbolCount:
+          type: integer
+          nullable: true
+          description: >-
+            The number of symbols documented by this version. Null for versions
+            published before this count was recorded.
       required:
         - scope
         - package
@@ -2812,6 +2826,12 @@ components:
           type: string
           format: date-time
           description: The date and time when the package version was last updated.
+        symbolCount:
+          type: integer
+          nullable: true
+          description: >-
+            The number of symbols documented by this version. Null for versions
+            published before this count was recorded.
       required:
         - scope
         - package

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -464,6 +464,9 @@ pub struct ApiPackage {
   pub when_featured: Option<DateTime<Utc>>,
   pub is_archived: bool,
   pub readme_source: ApiReadmeSource,
+  /// Symbols documented by the latest version, or `None` for packages whose
+  /// latest version predates the count being recorded.
+  pub symbol_count: Option<u32>,
 }
 
 impl From<PackageWithGitHubRepoAndMeta> for ApiPackage {
@@ -487,6 +490,12 @@ impl From<PackageWithGitHubRepoAndMeta> for ApiPackage {
         .latest_version
         .as_ref()
         .map(|_| score.score_percentage()),
+      // a package with no published version has no docs to count symbols in
+      symbol_count: if package.latest_version.is_some() {
+        meta.symbol_count
+      } else {
+        None
+      },
       latest_version: package.latest_version,
       when_featured: package.when_featured,
       is_archived: package.is_archived,
@@ -631,6 +640,9 @@ pub struct ApiPackageVersion {
   pub readme_path: Option<PackagePath>,
   pub updated_at: DateTime<Utc>,
   pub created_at: DateTime<Utc>,
+  /// Symbols documented by this specific version, or `None` for versions
+  /// published before the count was recorded.
+  pub symbol_count: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -686,6 +698,7 @@ impl From<PackageVersion> for ApiPackageVersion {
       readme_path: value.readme_path,
       updated_at: value.updated_at,
       created_at: value.created_at,
+      symbol_count: value.meta.symbol_count,
     }
   }
 }
@@ -704,6 +717,7 @@ impl From<PackageVersionWithNewerVersionsCount> for ApiPackageVersion {
       readme_path: value.readme_path,
       updated_at: value.updated_at,
       created_at: value.created_at,
+      symbol_count: value.meta.symbol_count,
     }
   }
 }

--- a/crates/jsr_types/src/models.rs
+++ b/crates/jsr_types/src/models.rs
@@ -518,6 +518,11 @@ pub struct PackageVersionMeta {
   pub percentage_documented_symbols: f32,
   pub all_fast_check: bool, // mean no slow types
   pub has_provenance: bool,
+  /// Number of distinct symbols the generated docs list for this version, used
+  /// to show the package's API surface area in the nav (jsr-io/jsr#1206).
+  /// `None` on versions published before this was recorded, which render
+  /// without the chip rather than claiming zero symbols.
+  pub symbol_count: Option<u32>,
 }
 
 #[cfg(feature = "sqlx")]

--- a/frontend/routes/package/(_components)/PackageNav.tsx
+++ b/frontend/routes/package/(_components)/PackageNav.tsx
@@ -26,6 +26,10 @@ interface PackageNavProps {
   versionCount: number;
   dependencyCount: number;
   dependentCount: number;
+  /** Symbols documented by the version being viewed. Null for versions
+   * published before the count was recorded, which show no chip rather than
+   * claiming the package has no symbols. */
+  symbolCount?: number | null;
   iam: ScopeIAM;
   latestVersion: string | null;
 }
@@ -37,6 +41,7 @@ export function PackageNav({
   versionCount,
   dependencyCount,
   dependentCount,
+  symbolCount,
   latestVersion,
 }: PackageNavProps) {
   const base = `/@${params.scope}/${params.package}`;
@@ -53,6 +58,7 @@ export function PackageNav({
         <NavItem
           href={`${versionedBase}/doc`}
           active={currentTab === "Docs"}
+          chip={symbolCount ?? undefined}
         >
           Docs
         </NavItem>

--- a/frontend/routes/package/dependencies/graph.tsx
+++ b/frontend/routes/package/dependencies/graph.tsx
@@ -26,6 +26,8 @@ export default define.page<typeof handler>(
           versionCount={data.package.versionCount}
           dependencyCount={data.package.dependencyCount}
           dependentCount={data.package.dependentCount}
+          symbolCount={data.selectedVersion?.symbolCount ??
+            data.package.symbolCount}
           iam={iam}
           params={params as unknown as Params}
           latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependencies/index.tsx
+++ b/frontend/routes/package/dependencies/index.tsx
@@ -73,6 +73,8 @@ export default define.page<typeof handler>(function Deps(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/dependents.tsx
+++ b/frontend/routes/package/dependents.tsx
@@ -26,6 +26,7 @@ export default define.page<typeof handler>(function Dep(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/diff/[file].tsx
+++ b/frontend/routes/package/diff/[file].tsx
@@ -31,6 +31,8 @@ export default define.page<typeof handler>(function File({
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/diff/[symbol].tsx
+++ b/frontend/routes/package/diff/[symbol].tsx
@@ -28,6 +28,8 @@ export default define.page<typeof handler>(function Symbol(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/diff/all_symbols.tsx
+++ b/frontend/routes/package/diff/all_symbols.tsx
@@ -28,6 +28,8 @@ export default define.page<typeof handler>(function AllSymbols(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[file].tsx
+++ b/frontend/routes/package/doc/[file].tsx
@@ -27,6 +27,8 @@ export default define.page<typeof handler>(function File({
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/[symbol].tsx
+++ b/frontend/routes/package/doc/[symbol].tsx
@@ -25,6 +25,8 @@ export default define.page<typeof handler>(function Symbol(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/doc/all_symbols.tsx
+++ b/frontend/routes/package/doc/all_symbols.tsx
@@ -26,6 +26,8 @@ export default define.page<typeof handler>(function AllSymbols(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -26,6 +26,8 @@ export default define.page<typeof handler>(function PackagePage(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/publish.tsx
+++ b/frontend/routes/package/publish.tsx
@@ -28,6 +28,7 @@ export default define.page<typeof handler>(function PackagePage({
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.package.symbolCount}
         iam={data.iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/score.tsx
+++ b/frontend/routes/package/score.tsx
@@ -31,6 +31,7 @@ export default define.page<typeof handler>(function Score(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/settings.tsx
+++ b/frontend/routes/package/settings.tsx
@@ -25,6 +25,7 @@ export default define.page<typeof handler>(
           versionCount={data.package.versionCount}
           dependencyCount={data.package.dependencyCount}
           dependentCount={data.package.dependentCount}
+          symbolCount={data.package.symbolCount}
           iam={data.iam}
           params={params as unknown as Params}
           latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/source.tsx
+++ b/frontend/routes/package/source.tsx
@@ -54,6 +54,8 @@ export default define.page<typeof handler>(function PackagePage(
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.selectedVersion?.symbolCount ??
+          data.package.symbolCount}
         iam={iam}
         params={params as unknown as Params}
         latestVersion={data.package.latestVersion}

--- a/frontend/routes/package/versions.tsx
+++ b/frontend/routes/package/versions.tsx
@@ -105,6 +105,7 @@ export default define.page<typeof handler>(function Versions({
         versionCount={data.package.versionCount}
         dependencyCount={data.package.dependencyCount}
         dependentCount={data.package.dependentCount}
+        symbolCount={data.package.symbolCount}
         latestVersion={data.package.latestVersion}
       />
 

--- a/frontend/routes/status.tsx
+++ b/frontend/routes/status.tsx
@@ -32,6 +32,7 @@ export default define.page<typeof handler>(function PackageListPage({
           versionCount={data.package.versionCount}
           dependencyCount={data.package.dependencyCount}
           dependentCount={data.package.dependentCount}
+          symbolCount={data.package.symbolCount}
           iam={iam}
           params={{ scope: data.package.scope, package: data.package.name }}
           latestVersion={data.package.latestVersion}

--- a/frontend/utils/api_types.ts
+++ b/frontend/utils/api_types.ts
@@ -134,6 +134,9 @@ export interface Package {
   whenFeatured: string | null;
   isArchived: boolean;
   readmeSource: ReadmeSource;
+  /** Null for packages with no published version, and for packages whose
+   * latest version predates this count being recorded. */
+  symbolCount: number | null;
 }
 
 export type ReadmeSource = "readme" | "jsdoc";
@@ -150,6 +153,8 @@ export interface PackageVersion {
   readmePath: string;
   updatedAt: string;
   createdAt: string;
+  /** Null for versions published before this count was recorded. */
+  symbolCount: number | null;
 }
 
 export interface PackageVersionWithUser extends PackageVersion {


### PR DESCRIPTION
Closes #1206.

The Docs tab now carries a chip with the number of documented symbols, next to the existing version / dependency / dependent counts, so the size of a package's API surface is visible at a glance.

<img width="800" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/1206-nav-chip.png">

<img width="1483" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/1358-1206-package-overview.jpg">

### Where the count comes from

Doc nodes are generated at publish time and stored per version, so counting per page load would mean loading and flattening all of them on every request. Instead the count is computed during publish-time analysis, from the same render context the search index is already built from, and stored on the version's `meta` — which is JSONB, so there is no migration.

It counts what the docs actually list: exported symbols per entrypoint plus namespace members, minus `@internal` and non-exported types, deduplicated per `(file, qualified name)` the same way the search index is. Class and interface members aren't counted separately — they belong to their parent symbol rather than being their own listing entries.

### Versions published before this

There is no backfill, so their count is `null` rather than `0`, and the nav renders no chip for them instead of claiming the package has no symbols. Versions get a count as they are published; a backfill could be added later by re-running analysis, but that's a much heavier operation than this change warrants.

The count is exposed on both `Package` (from the latest version) and `PackageVersion`, and the nav prefers the version being viewed so a pinned old version doesn't show the latest version's number.
