### PR TITLE
feat(api): serve pages for non-exported symbols the public API refers to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.205.0"
+version = "0.206.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d80bf35d7150d36768fc1f4e6bb71444f39924263b71a343e1a7b4efa64b9d8"
+checksum = "0a2af46876eb43b3334539f548c8c106f9ad86d330ca5661c04fcdb27fd8e463"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -98,7 +98,7 @@ async-compression = { version = "0.4", features = ["futures-io", "gzip"] }
 deno_graph = "=0.110.2"
 deno_ast = { version = "0.53.0", features = ["view"] }
 # sync with frontend/deno.json
-deno_doc = { version = "=0.205.0", features = ["comrak"] }
+deno_doc = { version = "=0.206.0", features = ["comrak"] }
 deno_error = "0.7.0"
 comrak = { version = "0.29.0", default-features = false }
 ammonia = "4.0.0"

--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -1069,13 +1069,16 @@ fn generate_symbol_page(
 
   let doc_nodes = 'outer: loop {
     let next_part = name_parts.next()?;
+    // Symbols that aren't exported get a page too: the public API refers to
+    // them, so their signatures link here and this page is what those links
+    // point at (jsr-io/jsr#165). deno_doc keeps them out of the listings and
+    // of symbol search, since they can't be imported.
+    //
+    // `@internal` is different: the author asked for the symbol to be hidden,
+    // so it gets no page, and deno_doc emits no link to one either.
     let mut nodes = doc_nodes
       .iter()
-      .filter(|node| {
-        !node.declarations.iter().all(|decl| {
-          decl.declaration_kind == deno_doc::node::DeclarationKind::Private
-        }) && node.get_name() == next_part
-      })
+      .filter(|node| !node.is_hidden() && node.get_name() == next_part)
       .flat_map(|node| resolve_doc_node_references(ctx, node.clone()))
       .collect::<Vec<_>>();
 


### PR DESCRIPTION
Closes #165. The other half is denoland/deno_doc#851, released in **deno_doc 0.206.0**, which this bumps to.

A type the public API refers to but doesn't export is already in the stored doc nodes, documented, with `DeclarationKind::Private`. The symbol page handler filtered exactly those out, so the links deno_doc now emits for them would 404.

Two changes to that filter:

- non-exported symbols get a page — that page is what the reference in the signature points at;
- `@internal` symbols now get none. The author asked for those to be hidden, and they were previously reachable by URL.

The `@internal` check uses `DocNodeWithContext::is_hidden()` from the release, rather than reimplementing the tag lookup here.

### The two cases, side by side

`parse()` returns a non-exported `RawResult` — linked, and the page behind it documents the type:

<img width="1404" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/165-v2-parse-links.jpg">

<img width="1483" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/165-rawresult-page.jpg">

`probe()` returns a type that is *also* `@internal` — the author opted out, so it stays plain text with no page, exactly as before:

<img width="1404" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/docs-gen-sweep-2/165-v2-probe-optedout.jpg">

### What's reachable where

Verified against a package published to a local instance on this branch:

| symbol | exported | `@internal` | page | linked from signature | listings / search |
| --- | --- | --- | --- | --- | --- |
| `parse`, `Options` | ✅ | — | ✅ | — | ✅ |
| `RawResult`, `Origin` | ❌ | — | ✅ | ✅ | ❌ |
| `HiddenHelper` | ✅ | ✅ | ❌ (404) | — | ❌ |
| `OptedOut` | ❌ | ✅ | ❌ (404) | ❌ | ❌ |

The search index for that package contains exactly `Options`, `Options.separator` and `parse` — no occurrence of the non-exported or hidden names. So these pages are reachable only by following a reference from a signature that already mentions the type; they're never advertised as API.

### deno_doc bump

0.206.0 over 0.205.0 is exactly denoland/deno_doc#851 plus the version commit — no template or ctx-struct changes, so there is nothing to mirror into the JSX.
