### PR TITLE
fix(api): keep markdown heading permalink icons intact through sanitization

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -287,8 +287,12 @@ lazy_static::lazy_static! {
     let mut ammonia_builder = ammonia::Builder::default();
 
     ammonia_builder
-      .add_tags(["video", "button", "svg", "path", "rect", "section"])
+      .add_tags([
+        "video", "button", "svg", "path", "rect", "section", "g", "defs",
+        "clipPath",
+      ])
       .add_generic_attributes(["id", "align"])
+      .add_tag_attributes("g", ["clip-path", "fill", "opacity", "transform"])
       .add_tag_attributes("button", ["data-copy"])
       .add_tag_attributes(
         "svg",
@@ -325,7 +329,15 @@ lazy_static::lazy_static! {
       // comrak footnote output
       .add_allowed_classes("section", ["footnotes"])
       .add_allowed_classes("sup", ["footnote-ref"])
-      .add_allowed_classes("a", ["footnote-backref"])
+      .add_allowed_classes("a", ["footnote-backref", "anchor"])
+      // deno_doc heading permalinks
+      .add_tag_attributes("a", ["aria-label", "tabindex"])
+      .add_allowed_classes("h1", ["anchorable"])
+      .add_allowed_classes("h2", ["anchorable"])
+      .add_allowed_classes("h3", ["anchorable"])
+      .add_allowed_classes("h4", ["anchorable"])
+      .add_allowed_classes("h5", ["anchorable"])
+      .add_allowed_classes("h6", ["anchorable"])
       .add_allowed_classes(
         "div",
         [
@@ -1635,6 +1647,46 @@ impl deno_doc::html::UsageComposer for DocUsageComposer {
 mod tests {
   use super::*;
   use deno_doc::html::ShortPath;
+
+  #[test]
+  fn renders_heading_permalinks_through_the_sanitizer() {
+    // deno_doc emits heading permalinks as an `anchorable` heading wrapping an
+    // `anchor` link around its bundled link.svg. The allowlist has to keep the
+    // classes the CSS hangs off of, and it has to keep <defs>/<clipPath> so the
+    // clip rect stays inside a definition instead of painting over the icon
+    // (#1530).
+    let html = render_markdown_file(
+      "## Install\n",
+      &ScopeName::new("scope".to_string()).unwrap(),
+      &PackageName::new("pkg".to_string()).unwrap(),
+      &Version::new("1.0.0").unwrap(),
+      None,
+      "/README.md",
+    )
+    .unwrap();
+
+    assert!(
+      html.contains(r#"<h2 id="install" class="anchorable">"#),
+      "{html}"
+    );
+    assert!(html.contains(r##"href="#install""##), "{html}");
+    assert!(html.contains(r#"class="anchor""#), "{html}");
+    assert!(html.contains(r#"aria-label="Anchor""#), "{html}");
+    assert!(html.contains(r#"tabindex="-1""#), "{html}");
+    // the icon's clip plumbing survives, so the white rect stays unpainted
+    assert!(html.contains("<g clip-path="), "{html}");
+    assert!(html.contains("<defs>"), "{html}");
+    assert!(html.contains("<clipPath "), "{html}");
+    let (_, after_rect) = html.split_once("<rect ").expect("{html}");
+    assert!(
+      after_rect
+        .split("</svg>")
+        .next()
+        .unwrap()
+        .contains("</clipPath>"),
+      "the clip rect escaped its <clipPath>: {html}"
+    );
+  }
 
   #[test]
   fn render_markdown_file_test() {

--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -392,7 +392,7 @@ body .ddoc {
       @apply bg-jsr-cyan-100/50 dark:bg-jsr-cyan-900/50;
     }
 
-    a:not(.no_color) {
+    a:not(.no_color, .anchor) {
       @apply text-jsr-cyan-700 hover:text-jsr-cyan-900 underline
         decoration-jsr-cyan-700/50 underline-offset-2 outline-none
         focus-visible:ring-2 ring-jsr-cyan-700 ring-offset-2 rounded-sm


### PR DESCRIPTION
Fixes #1530.

## What was wrong

The ammonia allowlist in `api/src/docs.rs` permits `svg`, `path` and `rect`, but not `g`, `defs` or `clipPath`. Ammonia *unwraps* a disallowed tag rather than dropping its subtree, so the clip rect in the `link.svg` that `deno_doc` bundles escaped its `<clipPath>` and became an ordinary painted 14x14 white rectangle, drawn after the icon path and covering it — a white square in dark mode, an invisible icon in light mode.

Reproduced through the real render path (`## Install` in, sanitized HTML out):

```html
<h2 id="install"><a href="#install" class="" rel="nofollow"><svg …>
  <path … fill="currentColor"></path>
  <rect width="14" height="14" fill="white"></rect>
</svg></a>Install</h2>
```

That output also shows the second half of the bug: the `anchorable` and `anchor` classes are gone (`h*` had no allowed classes, `a` allowed only `footnote-backref`), along with `aria-label` and `tabindex`. The CSS added in #1502 to reveal the permalink on hover therefore had nothing to match.

And a third one, which only becomes visible once the classes survive: `.markdown a:not(.no_color)` (specificity 0-2-1) out-specifies `.anchor` (0-1-0), so the icon would render cyan and underlined.

## The fix

- Allow `g`, `defs` and `clipPath`, plus `clip-path` on `g`.
- Allow `anchor` on `a`, `anchorable` on `h1`–`h6`, and `aria-label`/`tabindex` on `a`.
- Exclude `.anchor` from the markdown link styling.

Allowing `<defs>` is deliberately preferred over dropping its content: anything that survives the allowlist inside a definition is inert by construction, so this closes the whole "definition content leaks out and paints" class of bug rather than just this one icon.

## Verification

Output now matches what `deno_doc` intended — `<h2 id="install" class="anchorable">`, `class="anchor"`, `<g clip-path=…>`, and the rect back inside `</clipPath>`. Covered by a new `renders_heading_permalinks_through_the_sanitizer` test that goes through the real render path, so it keeps up with whatever markup the `deno_doc` of the day emits. `cargo test` 241/241, `cargo fmt --check` and `cargo clippy --all-targets` clean.
