### PR TITLE
fix(api): don't rewrite registry links in JSDoc to the repository

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -619,6 +619,15 @@ fn get_url_rewriter(
       return url.to_string();
     }
 
+    // So are registry URLs. `{@link [module].symbol}` in a JSDoc comment is
+    // resolved by deno_doc into `/@scope/package/doc/...` before the rewriter
+    // sees it, and rewriting that against the repository turns a working link
+    // into a 404 (jsr-io/jsr#1175). A `/@scope/...` path is unambiguously a
+    // registry URL, so leave it be whether deno_doc or the author wrote it.
+    if url.starts_with("/@") {
+      return url.to_string();
+    }
+
     let base = if let Some(github_repository) = &github_repository {
       if url.rsplit_once('.').is_some_and(|(_path, extension)| {
         matches!(
@@ -1965,5 +1974,42 @@ mod tests {
     );
     // Protocol-relative URLs are left untouched.
     assert_eq!(rewriter(None, "//example.com/x"), "//example.com/x");
+  }
+
+  /// Regression for #1175: `{@link [module].symbol}` in a JSDoc comment is
+  /// resolved by deno_doc into a registry URL before the rewriter sees it.
+  /// Those must not be sent to the repository, which is what turned them into
+  /// 404s.
+  #[test]
+  fn url_rewriter_leaves_registry_links_alone() {
+    for rewriter in [
+      get_url_rewriter(
+        String::from("/@foo/bar/1.2.3"),
+        Some(GithubRepository {
+          id: 0,
+          owner: "foo".to_string(),
+          name: "bar".to_string(),
+          updated_at: Default::default(),
+          created_at: Default::default(),
+        }),
+        true,
+      ),
+      // and with no repository linked, where the package base is the fallback
+      get_url_rewriter(String::from("/@foo/bar/1.2.3"), None, true),
+    ] {
+      // a link into this package's own docs
+      assert_eq!(
+        rewriter(None, "/@foo/bar/doc/sub/~/someSymbol"),
+        "/@foo/bar/doc/sub/~/someSymbol"
+      );
+      // and into another package's
+      assert_eq!(
+        rewriter(None, "/@std/assert@1.0.2/doc/~/assertEquals"),
+        "/@std/assert@1.0.2/doc/~/assertEquals"
+      );
+
+      // a genuine repository path is still rewritten
+      assert_ne!(rewriter(None, "/LICENSE"), "/LICENSE");
+    }
   }
 }


### PR DESCRIPTION
Closes #1175.

### What's actually broken

The issue reports two things. Checking the reported package today, only one of them is still real:

**Already fixed — the `is.isAny` names and their 404s.** On `@core/unknownutil@4.4.0-pre.0` the namespace members now render under their aliased names (`is.Any`, not `is.isAny`) and resolve. I walked every symbol link on that page: **83 links, 82 return 200.**

**Still broken — the one remaining link, and it's a different cause.** The 83rd is:

```
https://github.com/jsr-core/unknownutil/blob/HEAD/@core/unknownutil/doc/is/unknown/~/isUnknown
```

which comes from this JSDoc in `is/any.ts`:

```ts
/** Use {@linkcode [is/unknown].isUnknown|isUnknown} to assume that a value is `unknown`. */
```

deno_doc resolves `{@link [module].symbol}` into a registry URL — `/@core/unknownutil/doc/is/unknown/~/isUnknown` — before the markdown renderer runs. Then `get_url_rewriter` sees a root-relative URL and sends it to the repository, because of the rule added in #768 to make README links like `/LICENSE` resolve against the repo. A working link becomes a 404.

So it's a jsr-side bug, not a deno_doc one, and it has nothing to do with the re-re-export pattern in the title — any `{@link [module].symbol}` in a package with a linked repository hits it.

### Fix

Leave `/@scope/...` paths alone. That prefix is unambiguously a registry URL on jsr, so it's right whether deno_doc emitted it or the author wrote it, and it covers cross-package links (`/@std/assert@1.0.2/doc/~/assertEquals`) too. Repository-relative links keep their #768 behaviour.

### Verified end-to-end

Published a package reproducing the pattern (aliased namespace + `{@linkcode [is/unknown].isUnknown|isUnknown}`) to a local instance **with a GitHub repository linked**, which is the case that breaks, and rendered the same page on each side:

| | link emitted |
| --- | --- |
| before | `https://github.com/sweep-core/link175/blob/HEAD/@sweep/link175@1.0.0/doc/is/unknown/~/isUnknown` → 404 |
| after | `/@sweep/link175@1.0.0/doc/is/unknown/~/isUnknown` → correct page |

<img width="1404" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/jsr-1175/1175-jsdoc-link.jpg">

Following it lands where it should:

<img width="1404" src="https://raw.githubusercontent.com/crowlKats/jsr/docs-gen-sweep-assets/jsr-1175/1175-jsdoc-link-target.jpg">

A regression test covers both the linked-repository and no-repository cases, and asserts `/LICENSE` is still rewritten.

### One caveat

The rule keys off the `/@` prefix, so a README link to a genuine repository path that starts with `@` (say a top-level `@types/` directory) would no longer reach the repo. That seems clearly the better trade: `/@scope/name` reads as a registry link to almost every author, and cross-package doc links are far more common than repo paths beginning with `@`.
