### PR TITLE
fix(api): resolve fast-check remapped specifiers in generated npm d.ts

### DIFF
--- a/api/src/npm/specifiers.rs
+++ b/api/src/npm/specifiers.rs
@@ -22,6 +22,9 @@ pub enum RewriteKind {
 #[derive(Clone, Copy)]
 pub struct SpecifierRewriter<'a> {
   pub base_specifier: &'a ModuleSpecifier,
+  /// The specifier of the module in the module graph whose specifiers are
+  /// being rewritten. Relative specifiers are resolved against this.
+  pub module_specifier: &'a ModuleSpecifier,
   pub source_rewrites: &'a HashMap<&'a ModuleSpecifier, ModuleSpecifier>,
   pub declaration_rewrites: &'a HashMap<&'a ModuleSpecifier, ModuleSpecifier>,
   pub dependencies: &'a IndexMap<String, Dependency>,
@@ -30,12 +33,29 @@ pub struct SpecifierRewriter<'a> {
 impl SpecifierRewriter<'_> {
   pub fn rewrite(&self, specifier: &str, kind: RewriteKind) -> Option<String> {
     let source_text_specifier = specifier;
-    let dep = self.dependencies.get(specifier)?;
 
-    let specifier = match kind {
-      RewriteKind::Source => dep.get_code(),
-      RewriteKind::Declaration => dep.get_type().or_else(|| dep.get_code()),
-    }?;
+    let resolved;
+    let specifier = if let Some(dep) = self.dependencies.get(specifier) {
+      match kind {
+        RewriteKind::Source => dep.get_code(),
+        RewriteKind::Declaration => dep.get_type().or_else(|| dep.get_code()),
+      }?
+    } else if matches!(kind, RewriteKind::Declaration)
+      && specifier.starts_with('.')
+    {
+      // The fast check transform in deno_graph rewrites relative import
+      // specifiers in the generated .d.ts to point at the resolved (types)
+      // dependency, so the specifier may not match a source text specifier
+      // in the dependency map anymore. For example, an import of `./a.js`
+      // where `./a.js` has an adjacent hand-written `./a.d.ts` is rewritten
+      // to `./a.d.ts`. Resolve such specifiers against the original module
+      // specifier so they can still be rewritten (the generated .d.ts is
+      // emitted to a different directory than the original module).
+      resolved = self.module_specifier.join(specifier).ok()?;
+      &resolved
+    } else {
+      return None;
+    };
 
     let rewrites = match kind {
       RewriteKind::Source => self.source_rewrites,

--- a/api/src/npm/tarball.rs
+++ b/api/src/npm/tarball.rs
@@ -188,6 +188,7 @@ pub async fn create_npm_tarball<'a>(
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
+          module_specifier: &js.specifier,
           source_rewrites: &source_rewrites,
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
@@ -209,6 +210,7 @@ pub async fn create_npm_tarball<'a>(
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
+          module_specifier: &js.specifier,
           source_rewrites: &source_rewrites,
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
@@ -227,6 +229,7 @@ pub async fn create_npm_tarball<'a>(
         let source_target = source_rewrites.get(&js.specifier).unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: source_target,
+          module_specifier: &js.specifier,
           source_rewrites: &source_rewrites,
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
@@ -246,6 +249,7 @@ pub async fn create_npm_tarball<'a>(
           .unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: &js.specifier,
+          module_specifier: &js.specifier,
           source_rewrites: &source_rewrites,
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
@@ -263,6 +267,7 @@ pub async fn create_npm_tarball<'a>(
         let source_target = source_rewrites.get(&js.specifier).unwrap();
         let specifier_rewriter = SpecifierRewriter {
           base_specifier: source_target,
+          module_specifier: &js.specifier,
           source_rewrites: &source_rewrites,
           declaration_rewrites: &declaration_rewrites,
           dependencies: &js.dependencies,
@@ -279,6 +284,7 @@ pub async fn create_npm_tarball<'a>(
             declaration_rewrites.get(&js.specifier).unwrap();
           let specifier_rewriter = SpecifierRewriter {
             base_specifier: declaration_target,
+            module_specifier: &js.specifier,
             source_rewrites: &source_rewrites,
             declaration_rewrites: &declaration_rewrites,
             dependencies: &js.dependencies,

--- a/api/testdata/specs/npm_tarballs/ts_importing_js_with_dts_types.txt
+++ b/api/testdata/specs/npm_tarballs/ts_importing_js_with_dts_types.txt
@@ -1,0 +1,88 @@
+# mod.ts
+import * as wasm from "./wasm/lib.js";
+
+export type Algorithm = wasm.Algorithm;
+
+export function defaultAlgorithm(): Algorithm {
+  return wasm.algorithm_default();
+}
+
+# wasm/lib.js
+// @ts-self-types="./lib.d.ts"
+export function algorithm_default() {
+  return "ed25519";
+}
+
+# wasm/lib.d.ts
+export type Algorithm = "ed25519" | "secp256k1";
+export function algorithm_default(): Algorithm;
+
+# jsr.json
+{
+  "name": "@scope/foo",
+  "version": "0.0.1",
+  "exports": "./mod.ts"
+}
+
+# output
+== /_dist/mod.d.ts ==
+import * as wasm from "../wasm/lib.js";
+export type Algorithm = wasm.Algorithm;
+export declare function defaultAlgorithm(): Algorithm;
+//# sourceMappingURL=mod.d.ts.map
+
+== /_dist/mod.d.ts.map ==
+{"version":3,"file":"mod.d.ts","sources":["../mod.ts"],"names":[],"mappings":"AAAA,YAAY,2BAA0B;AAEtC,YAAY,YAAY,KAAK;AAE7B,OAAO,iBAAS,oBAAoB"}
+
+== /jsr.json ==
+{
+  "name": "@scope/foo",
+  "version": "0.0.1",
+  "exports": "./mod.ts"
+}
+
+== /mod.js ==
+import * as wasm from "./wasm/lib.js";
+export function defaultAlgorithm() {
+  return wasm.algorithm_default();
+}
+//# sourceMappingURL=mod.js.map
+
+== /mod.js.map ==
+{"version":3,"file":"mod.js","sources":["./mod.ts"],"names":[],"mappings":"AAAA,YAAY,UAAU,gBAAgB;AAItC,OAAO,SAAS;EACd,OAAO,KAAK,iBAAiB;AAC/B"}
+
+== /mod.ts ==
+import * as wasm from "./wasm/lib.js";
+
+export type Algorithm = wasm.Algorithm;
+
+export function defaultAlgorithm(): Algorithm {
+  return wasm.algorithm_default();
+}
+
+== /package.json ==
+{
+  "name": "@jsr/scope__foo",
+  "version": "0.0.1",
+  "homepage": "http://jsr.test/@scope/foo",
+  "type": "module",
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "types": "./_dist/mod.d.ts",
+      "default": "./mod.js"
+    }
+  },
+  "_jsr_revision": 0
+}
+
+== /wasm/lib.d.ts ==
+export type Algorithm = "ed25519" | "secp256k1";
+export function algorithm_default(): Algorithm;
+
+== /wasm/lib.js ==
+// @ts-self-types="./lib.d.ts"
+export function algorithm_default() {
+  return "ed25519";
+}
+

--- a/api/testdata/specs/npm_tarballs/type_imports.txt
+++ b/api/testdata/specs/npm_tarballs/type_imports.txt
@@ -65,16 +65,16 @@ export declare function createAdd(): Add;
 
 # output
 == /_dist/main.d.ts ==
-export { type Add as Add2 } from "./foo.d.ts";
-export type { Add as Add3 } from "./foo.d.ts";
-export type * from "./foo.d.ts";
-export type * as Foo from "./foo.d.ts";
-import { Add } from "./foo.d.ts";
+export { type Add as Add2 } from "../foo.js";
+export type { Add as Add3 } from "../foo.js";
+export type * from "../foo.js";
+export type * as Foo from "../foo.js";
+import { Add } from "../foo.js";
 export declare function createAdd(): Add;
 //# sourceMappingURL=main.d.ts.map
 
 == /_dist/main.d.ts.map ==
-{"version":3,"file":"main.d.ts","sources":["../main.ts"],"names":[],"mappings":"AAAA,SAAS,KAAK,OAAO,IAAI,QAAQ,aAAW;AAC5C,cAAc,OAAO,IAAI,QAAQ,aAAW;AAC5C,mBAAmB,aAAW;AAC9B,YAAO,KAAU,GAAG,MAAM,aAAW;AACrC,SAAc,GAAG,QAAQ,aAAW;AAEpC,OAAO,iBAAS,aAAa"}
+{"version":3,"file":"main.d.ts","sources":["../main.ts"],"names":[],"mappings":"AAAA,SAAS,KAAK,OAAO,IAAI,oBAAmB;AAC5C,cAAc,OAAO,IAAI,oBAAmB;AAC5C,+BAA8B;AAC9B,YAAO,KAAU,GAAG,kBAAiB;AACrC,SAAc,GAAG,oBAAmB;AAEpC,OAAO,iBAAS,aAAa"}
 
 == /adder.d.ts ==
 export interface Adder {


### PR DESCRIPTION
Fixes #1018

deno_graph's fast check transform rewrites relative import specifiers in the generated .d.ts to the resolved, types-preferred dependency: an import of `./wasm/lib.js` where the JS file has an adjacent hand-written declaration file (via `@ts-self-types` or a types reference) becomes `./wasm/lib.d.ts` inside the dts program.

`SpecifierRewriter::rewrite` looked specifiers up by their source-text key in the module's dependency map. The remapped specifier (`./wasm/lib.d.ts`) is not a key there (the key is `./wasm/lib.js`), so the specifier was emitted verbatim into `_dist/**/*.d.ts` — where, relative to `_dist/`, the file doesn't exist, causing `TS2307: Cannot find module` when type checking with tsc (reproduced with `@iroha/core@0.0.13`).

This resolves unmatched relative specifiers in declaration rewrites against the original module specifier and continues through the existing rewrite pipeline (including the `.d.ts` → `.js` extension mapping so TypeScript probes for the hand-written declaration file). The generated `_dist/crypto/mod.d.ts` now emits a correct relative path pointing at the file that exists in the tarball.

The committed expectation in `type_imports.txt` had the same latent breakage (`_dist/main.d.ts` importing a nonexistent `_dist/foo.d.ts`) and is corrected by this change as well.

Verified end-to-end with tsc (`moduleResolution: nodenext`): the pre-fix layout fails with exactly the reported TS2307; the post-fix layout typechecks clean.