### PR TITLE
fix(api): let staff recompute a version's score meta to heal stale slow-types flags

### DIFF
--- a/api/.sqlx/query-fa5333f441b4533c8f1a2a68ffd68eca5a65f0bf664f22ef844219bf8d058631.json
+++ b/api/.sqlx/query-fa5333f441b4533c8f1a2a68ffd68eca5a65f0bf664f22ef844219bf8d058631.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE package_versions SET meta = $1\n      WHERE scope = $2 AND name = $3 AND version = $4",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa5333f441b4533c8f1a2a68ffd68eca5a65f0bf664f22ef844219bf8d058631"
+}

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -14,8 +14,13 @@ use tracing::Span;
 use tracing::field;
 use tracing::instrument;
 
+use std::collections::HashMap;
+
+use crate::analysis::PackageAnalysisData;
+use crate::analysis::analyze_package;
 use crate::db::*;
 use crate::iam::ReqIamExt;
+use crate::ids::PackagePath;
 use crate::ids::ScopeDescription;
 use crate::publish::publish_task;
 use crate::util;
@@ -40,6 +45,10 @@ pub fn admin_router() -> Router<Body, ApiError> {
     .post("/scopes", util::auth(util::json(assign_scope)))
     .patch("/scopes/:scope", util::auth(util::json(patch_scopes)))
     .get("/packages", util::auth(util::json(list_packages)))
+    .post(
+      "/packages/:scope/:package/:version/recompute_meta",
+      util::auth(util::json(recompute_package_version_meta)),
+    )
     .get(
       "/publishing_tasks",
       util::auth(util::json(list_publishing_tasks)),
@@ -232,6 +241,108 @@ pub async fn list_packages(
     items: packages.into_iter().map(|package| package.into()).collect(),
     total,
   })
+}
+
+/// Re-runs the package analysis for a published version and stores the
+/// freshly computed score meta, which is otherwise only computed at publish
+/// time. Docs, the npm tarball, and provenance are left untouched.
+#[instrument(
+  name = "POST /api/admin/packages/:scope/:package/:version/recompute_meta",
+  skip(req),
+  fields(scope, package, version)
+)]
+pub async fn recompute_package_version_meta(
+  req: Request<Body>,
+) -> ApiResult<ApiPackageScore> {
+  let iam = req.iam();
+  let staff = iam.check_admin_access()?;
+  let staff_id = staff.id;
+
+  let scope = req.param_scope()?;
+  let package = req.param_package()?;
+  let version = req.param_version()?;
+  Span::current().record("scope", field::display(&scope));
+  Span::current().record("package", field::display(&package));
+  Span::current().record("version", field::display(&version));
+
+  let db = req.data::<Database>().unwrap();
+  let buckets = req.data::<Buckets>().unwrap();
+  let registry_url = req.data::<RegistryUrl>().unwrap().0.clone();
+
+  let (pkg, _, _) = db
+    .get_package(&scope, &package)
+    .await?
+    .ok_or(ApiError::PackageNotFound)?;
+  let package_version = db
+    .get_package_version(&scope, &package, &version)
+    .await?
+    .ok_or(ApiError::PackageVersionNotFound)?;
+
+  let mut files = HashMap::new();
+  for file in db.list_package_files(&scope, &package, &version).await? {
+    let s3_path =
+      crate::s3_paths::file_path(&scope, &package, &version, &file.path);
+    let bytes = buckets
+      .modules_bucket
+      .download(s3_path.into())
+      .await?
+      .ok_or_else(|| {
+        tracing::error!(
+          "module file '{}' of @{}/{}@{} is missing from the modules bucket",
+          file.path,
+          scope,
+          package,
+          version
+        );
+        ApiError::InternalServerError
+      })?;
+    files.insert(file.path, bytes.to_vec());
+  }
+
+  // the config file path is only used in analysis error messages; the
+  // exports driving the analysis come from the database
+  let config_file = ["/jsr.json", "/jsr.jsonc", "/deno.json", "/deno.jsonc"]
+    .into_iter()
+    .map(|path| PackagePath::new(path.to_string()).unwrap())
+    .find(|path| files.contains_key(path))
+    .unwrap_or_else(|| PackagePath::new("/jsr.json".to_string()).unwrap());
+
+  let span = Span::current();
+  let analysis_scope = scope.clone();
+  let analysis_package = package.clone();
+  let analysis_version = version.clone();
+  let data = PackageAnalysisData {
+    exports: package_version.exports.clone(),
+    files,
+  };
+  let output = tokio::task::spawn_blocking(move || {
+    analyze_package(
+      span,
+      registry_url,
+      analysis_scope,
+      analysis_package,
+      analysis_version,
+      config_file,
+      data,
+    )
+  })
+  .await
+  .map_err(|join_error| {
+    tracing::error!("analysis task panicked: {join_error:?}");
+    ApiError::InternalServerError
+  })?
+  .map_err(|analysis_error| ApiError::PackageAnalysisFailed {
+    msg: analysis_error.to_string(),
+  })?;
+
+  let mut meta = output.meta;
+  // provenance is recorded post-publish and not derivable from the files
+  meta.has_provenance = package_version.meta.has_provenance;
+
+  db.update_package_version_meta(&staff_id, &scope, &package, &version, &meta)
+    .await?;
+
+  Ok(ApiPackageScore::from((&meta, &pkg)))
 }
 
 #[instrument(name = "GET /api/admin/publishing_tasks", skip(req))]
@@ -536,5 +647,128 @@ mod tests {
       .unwrap()
       .expect_err_code(StatusCode::CONFLICT, "scopeAlreadyExists")
       .await;
+  }
+
+  #[tokio::test]
+  async fn recompute_package_version_meta() {
+    use std::io::Write as _;
+
+    use bytes::Bytes;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    use crate::api::ApiPackageScore;
+    use crate::db::PublishingTaskStatus;
+    use crate::ids::PackageName;
+    use crate::ids::ScopeName;
+    use crate::ids::Version;
+
+    let mut t = TestSetup::new().await;
+
+    // a JS entrypoint typed via `/// <reference types>`, the layout from
+    // jsr-io/jsr#698
+    let mut tar_bytes = Vec::new();
+    let mut tar = tar::Builder::new(&mut tar_bytes);
+    let mut append = |path: &str, content: &[u8]| {
+      let mut header = tar::Header::new_gnu();
+      header.set_size(content.len() as u64);
+      header.set_mode(0o644);
+      header.set_cksum();
+      tar.append_data(&mut header, path, content).unwrap();
+    };
+    append(
+      "jsr.json",
+      br#"{ "name": "@scope/foo", "version": "1.2.3", "license": "MIT", "exports": "./mod.mjs" }"#,
+    );
+    append("README.md", b"# foo\n\n```ts\nadd(1, 2);\n```\n");
+    append(
+      "mod.mjs",
+      b"/// <reference types=\"./mod.d.ts\" />\n/** Adds two numbers. */\nexport function add(a, b) {\n  return a + b;\n}\n",
+    );
+    append(
+      "mod.d.ts",
+      b"/** A module. @module */\n\n/** Adds two numbers. */\nexport declare function add(a: number, b: number): number;\n",
+    );
+    tar.finish().unwrap();
+    drop(tar);
+    let mut gz_bytes = Vec::new();
+    let mut encoder = GzEncoder::new(&mut gz_bytes, Compression::default());
+    encoder.write_all(&tar_bytes).unwrap();
+    encoder.finish().unwrap();
+
+    let task =
+      crate::publish::tests::process_tarball_setup(&t, Bytes::from(gz_bytes))
+        .await;
+    assert_eq!(
+      task.status,
+      PublishingTaskStatus::Success,
+      "{:?}",
+      task.error
+    );
+
+    let scope = ScopeName::try_from("scope").unwrap();
+    let name = PackageName::try_from("foo").unwrap();
+    let version = Version::try_from("1.2.3").unwrap();
+
+    let fresh = t
+      .db()
+      .get_package_version(&scope, &name, &version)
+      .await
+      .unwrap()
+      .unwrap();
+    assert!(fresh.meta.all_fast_check);
+    assert!(fresh.meta.has_readme);
+
+    // simulate stale meta from an older analysis pipeline
+    let mut stale = fresh.meta.clone();
+    stale.all_fast_check = false;
+    stale.has_readme = false;
+    stale.has_provenance = true;
+    t.db()
+      .update_package_version_meta(
+        &t.staff_user.user.id,
+        &scope,
+        &name,
+        &version,
+        &stale,
+      )
+      .await
+      .unwrap();
+
+    let path = "/api/admin/packages/scope/foo/1.2.3/recompute_meta";
+
+    let user_token = t.user1.token.clone();
+    t.http()
+      .post(path)
+      .token(Some(&user_token))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::FORBIDDEN, "actorNotAuthorized")
+      .await;
+
+    let staff_token = t.staff_user.token.clone();
+    let score = t
+      .http()
+      .post(path)
+      .token(Some(&staff_token))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<ApiPackageScore>()
+      .await;
+    assert!(score.all_fast_check);
+    assert!(score.has_readme);
+    assert!(score.has_provenance);
+
+    let healed = t
+      .db()
+      .get_package_version(&scope, &name, &version)
+      .await
+      .unwrap()
+      .unwrap();
+    assert!(healed.meta.all_fast_check);
+    assert!(healed.meta.has_readme);
+    assert!(healed.meta.has_provenance);
   }
 }

--- a/api/src/api/errors.rs
+++ b/api/src/api/errors.rs
@@ -43,6 +43,11 @@ errors!(
     status: NOT_FOUND,
     "The requested package version was not found.",
   },
+  PackageAnalysisFailed {
+    status: BAD_REQUEST,
+    fields: { msg: String },
+    ({ msg }) => "Failed to re-analyze the package version: {msg}.",
+  },
   DiffNoIndex {
     status: NOT_FOUND,
     "Diffs do not have an index.",

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -577,6 +577,51 @@ impl Database {
     Ok(())
   }
 
+  /// Replaces the stored score metadata of a published version.
+  #[instrument(
+    name = "Database::update_package_version_meta",
+    skip(self, meta),
+    err
+  )]
+  pub async fn update_package_version_meta(
+    &self,
+    staff_id: &Uuid,
+    scope: &ScopeName,
+    name: &PackageName,
+    version: &Version,
+    meta: &PackageVersionMeta,
+  ) -> Result<()> {
+    let mut tx = self.pool.begin().await?;
+
+    audit_log(
+      &mut tx,
+      staff_id,
+      true,
+      "update_package_version_meta",
+      json!({
+        "scope": scope,
+        "name": name,
+        "version": version,
+      }),
+    )
+    .await?;
+
+    sqlx::query!(
+      r#"UPDATE package_versions SET meta = $1
+      WHERE scope = $2 AND name = $3 AND version = $4"#,
+      meta as _,
+      scope as _,
+      name as _,
+      version as _
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    Ok(())
+  }
+
   #[instrument(name = "Database::update_package_description", skip(self), err)]
   pub async fn update_package_description(
     &self,

--- a/frontend/routes/admin/(_islands)/RecomputeVersionMeta.tsx
+++ b/frontend/routes/admin/(_islands)/RecomputeVersionMeta.tsx
@@ -1,0 +1,102 @@
+// Copyright 2024 the JSR authors. All rights reserved. MIT license.
+import { useEffect, useId, useRef } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import TbLoader2 from "tb-icons/TbLoader2";
+import { api, path } from "../../../utils/api.ts";
+import { PackageScore } from "../../../utils/api_types.ts";
+
+export function RecomputeVersionMeta(
+  { scope, pkg }: { scope: string; pkg: string },
+) {
+  const open = useSignal(false);
+  const submitting = useSignal(false);
+  const version = useSignal("");
+  const result = useSignal<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const ref = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    function outsideClick(e: Event) {
+      if (
+        (ref.current && !ref.current.contains(e.target as Element)) &&
+        (buttonRef.current && !buttonRef.current.contains(e.target as Element))
+      ) {
+        open.value = false;
+      }
+    }
+    document.addEventListener("click", outsideClick);
+    return () => document.removeEventListener("click", outsideClick);
+  }, []);
+
+  const prefix = useId();
+
+  return (
+    <div class="select-none text-left">
+      <button
+        ref={buttonRef}
+        id={`${prefix}-recompute-modal`}
+        class="button-primary"
+        type="button"
+        onClick={() => open.value = !open.value}
+        aria-expanded={open.value ? "true" : "false"}
+      >
+        recompute
+      </button>
+      <div
+        class={`fixed top-0 right-0 w-screen h-screen bg-gray-300/40 dark:bg-jsr-gray-950/70 z-80 flex justify-center items-center overflow-hidden ${
+          open.value ? "opacity-100" : "opacity-0 pointer-events-none"
+        } transition`}
+        aria-labelledby={`${prefix}-recompute-modal`}
+        role="region"
+        style="--tw-shadow-color: rgba(156,163,175,0.2);"
+      >
+        <form
+          ref={ref}
+          class={`space-y-3 z-90 rounded border-1.5 border-current dark:border-cyan-700 bg-white dark:bg-jsr-gray-950 shadow min-w-96 max-w-[95vw] max-h-[95vh] px-6 py-4 ${
+            open.value ? "translate-y-0" : "translate-y-5"
+          } transition`}
+          style="--tw-shadow-color: rgba(156,163,175,0.2);"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submitting.value = true;
+            result.value = null;
+            api.post<PackageScore>(
+              path`/admin/packages/${scope}/${pkg}/${version.value}/recompute_meta`,
+              null,
+            ).then((res) => {
+              submitting.value = false;
+              result.value = res.ok
+                ? `done — recomputed score: ${res.data.total}%`
+                : `${res.code}: ${res.message}`;
+            });
+          }}
+        >
+          <h2 class="text-lg font-semibold text-primary">
+            Recompute meta of @{scope}/{pkg}
+          </h2>
+          <p class="text-sm text-secondary">
+            Re-runs the analysis on the stored module files of a version and
+            replaces its score meta.
+          </p>
+          <label class="block space-y-1.5 text-sm text-secondary">
+            version
+            <input
+              name="version"
+              required
+              class="w-full block px-2 py-1.5 input-container input"
+              value={version.value}
+              onChange={(event) => {
+                version.value = event.currentTarget.value;
+              }}
+            />
+          </label>
+          {result.value && <p class="text-sm">{result.value}</p>}
+          <button type="submit" class="button-primary" disabled={submitting}>
+            {submitting.value && <TbLoader2 class="animate-spin size-4" />}
+            recompute
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/routes/admin/packages.tsx
+++ b/frontend/routes/admin/packages.tsx
@@ -7,6 +7,7 @@ import { URLQuerySearch } from "./(_components)/URLQuerySearch.tsx";
 import { define } from "../../util.ts";
 import twas from "twas";
 import { AdminCopyButton } from "./(_islands)/AdminCopyButton.tsx";
+import { RecomputeVersionMeta } from "./(_islands)/RecomputeVersionMeta.tsx";
 
 export default define.page<typeof handler>(function Packages({ data, url }) {
   return (
@@ -33,6 +34,7 @@ export default define.page<typeof handler>(function Packages({ data, url }) {
             fieldName: "created_at",
             align: "right",
           },
+          { title: "", class: "w-0", align: "right" },
         ]}
         pagination={data}
         sortBy={data.sortBy}
@@ -95,6 +97,9 @@ export default define.page<typeof handler>(function Packages({ data, url }) {
               align="right"
             >
               {twas(new Date(pkg.createdAt).getTime())}
+            </TableData>
+            <TableData align="right">
+              <RecomputeVersionMeta scope={pkg.scope} pkg={pkg.name} />
             </TableData>
           </TableRow>
         ))}


### PR DESCRIPTION
Fixes #698

The "No slow types" score component (`allFastCheck`) is computed once at publish time and stored in `package_versions.meta` forever. Investigating the three packages reported on the issue showed the "false positives" are stale stored data, not a bug in current code:

- **@li/regexp-escape-polyfill@0.3.4** (published 2024-09): still stored as `allFastCheck: false` today. Re-running the *current* analysis on the exact published files yields `true` — its `.mjs` entrypoints are typed via `/// <reference types>` declaration files, a layout the analysis rejected until #992 (2025-02) and subsequent deno_graph upgrades. The stored meta was simply never recomputed.
- **@whiteand/cbor** (the original 2024 report): same class of problem at the time; its current version is healthy (`allFastCheck: true`, score 100), and current deno and the current server agree on the old layout too.
- **@rough/rough-elements@3.0.12** (2026-08 comment): *not* a false positive — both the server analysis and `deno publish --dry-run` on its published files report ~79 real slow-types problems (mixin super-class expressions etc.), and it was published with `--allow-slow-types` (`npx jsr publish --allow-slow-types` in its npm scripts). `deno lint --rules-tags=jsr` not flagging mixin super-class expressions is a deno CLI lint gap. Their 3.0.15 fixed the types and scores 100.

Since the analysis itself is already correct, this adds `POST /api/admin/packages/:scope/:package/:version/recompute_meta`: staff-only, re-downloads the version's module files from the modules bucket, re-runs `analyze_package`, and stores only the freshly computed score meta (audit-logged; `hasProvenance` is carried over since it's recorded post-publish and not derivable from the files; docs and the npm tarball are untouched). The admin panel's packages tab gets a "recompute" action that prompts for a version and calls the endpoint, showing the recomputed score.

After deploy, running it against `@li/regexp-escape-polyfill@0.3.4` (and any other pre-2025 version with this layout) heals the score.

Includes an integration test that publishes a #698-layout package, corrupts the stored meta to simulate the old pipeline, verifies non-staff get 403, and confirms the recompute heals `allFastCheck` while preserving provenance.