### PR TITLE
fix: render the package page for non-latest versions instead of redirecting

### DIFF
--- a/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
+++ b/frontend/routes/package/(_islands)/LocalSymbolSearch.tsx
@@ -14,11 +14,7 @@ import {
 import { Highlight, type Position } from "@orama/highlight";
 import { api, path } from "../../../utils/api.ts";
 import { useMacLike } from "../../../utils/os.ts";
-import type {
-  AllSymbolsCtx,
-  AllSymbolsItemCtx,
-  SectionContentNamespaceSectionCtx,
-} from "@deno/doc/html-types";
+import type { AllSymbolsCtx, AllSymbolsItemCtx } from "@deno/doc/html-types";
 import { renderToString } from "preact-render-to-string";
 import { AllSymbols } from "../../../components/doc/AllSymbols.tsx";
 
@@ -113,11 +109,8 @@ export function LocalSymbolSearch(
 
       for (const entrypoint of searchContent.value!.entrypoints) {
         for (const kindGroup of entrypoint.module_doc.sections.sections) {
-          for (
-            const symbol
-              of (kindGroup.content as SectionContentNamespaceSectionCtx)
-                .content
-          ) {
+          if (kindGroup.content.kind !== "namespace_section") continue;
+          for (const symbol of kindGroup.content.content) {
             searchItems.push({
               name: symbol.name,
               symbolName: symbol.name,
@@ -202,32 +195,34 @@ export function LocalSymbolSearch(
         .map((entrypoint) => {
           const filteredSections = entrypoint.module_doc.sections.sections
             .map((kindGroup) => {
-              const filteredContent =
-                (kindGroup.content as SectionContentNamespaceSectionCtx).content
-                  .map((symbol) => {
-                    const symbolMatches = hitNames.has(symbol.name);
-                    const matchingSubitems = symbol.subitems.filter((subitem) =>
-                      hitNames.has(subitem.title)
-                    );
+              const content = kindGroup.content;
+              if (content.kind !== "namespace_section") return null;
 
-                    if (!symbolMatches && matchingSubitems.length === 0) {
-                      return null;
-                    }
+              const filteredContent = content.content
+                .map((symbol) => {
+                  const symbolMatches = hitNames.has(symbol.name);
+                  const matchingSubitems = symbol.subitems.filter((subitem) =>
+                    hitNames.has(subitem.title)
+                  );
 
-                    return {
-                      ...symbol,
-                      subitems: symbolMatches
-                        ? symbol.subitems
-                        : matchingSubitems,
-                    };
-                  })
-                  .filter(Boolean);
+                  if (!symbolMatches && matchingSubitems.length === 0) {
+                    return null;
+                  }
+
+                  return {
+                    ...symbol,
+                    subitems: symbolMatches
+                      ? symbol.subitems
+                      : matchingSubitems,
+                  };
+                })
+                .filter(Boolean);
 
               if (filteredContent.length === 0) return null;
 
               return {
                 ...kindGroup,
-                content: { ...kindGroup.content, content: filteredContent },
+                content: { ...content, content: filteredContent },
               };
             })
             .filter(Boolean);

--- a/frontend/routes/package/index.tsx
+++ b/frontend/routes/package/index.tsx
@@ -42,6 +42,19 @@ export default define.page<typeof handler>(function PackagePage(
             showProvenanceBadge
           />
         )
+        : data.selectedVersion
+        ? (
+          <div class="mt-8 text-tertiary text-center">
+            Documentation is only available for the{" "}
+            <a
+              class="link"
+              href={`/@${data.package.scope}/${data.package.name}`}
+            >
+              latest version
+            </a>{" "}
+            of a package.
+          </div>
+        )
         : (
           <div class="mt-8 text-tertiary text-center">
             This package has not published{" "}

--- a/frontend/utils/data.ts
+++ b/frontend/utils/data.ts
@@ -127,14 +127,35 @@ export async function packageDataWithDocs(
       if (pkgDocsResp.code === "scopeNotFound") return null;
       if (pkgDocsResp.code === "packageNotFound") return null;
       if (pkgDocsResp.code === "docsOnlyForLatestVersion") {
-        // Docs are only served for the latest version; redirect to the
-        // canonical (versionless) docs URL for the latest version.
-        return new Response(null, {
-          status: 302,
-          headers: {
-            Location: `/@${scope}/${pkg}/doc${compileDocsRequestPath(docs)}`,
-          },
-        });
+        if ("entrypoint" in docs || "all_symbols" in docs) {
+          // Docs are only served for the latest version; redirect to the
+          // canonical (versionless) docs URL for the latest version.
+          return new Response(null, {
+            status: 302,
+            headers: {
+              Location: `/@${scope}/${pkg}/doc${compileDocsRequestPath(docs)}`,
+            },
+          });
+        }
+
+        // The package overview page of a non-latest version: render it
+        // without docs instead of redirecting away from the version.
+        const pkgVersionResp = await state.api.get<PackageVersionWithUser>(
+          path`/scopes/${scope}/packages/${pkg}/versions/${version!}`,
+        );
+        if (!pkgVersionResp.ok) {
+          if (pkgVersionResp.code === "packageVersionNotFound") return null;
+          if (pkgVersionResp.code === "scopeNotFound") return null;
+          if (pkgVersionResp.code === "packageNotFound") return null;
+          assertOk(pkgVersionResp);
+        }
+        return {
+          ...data,
+          kind: "content",
+          selectedVersion: pkgVersionResp.data,
+          selectedVersionIsLatestUnyanked: false,
+          docs: null,
+        };
       }
       if (pkgDocsResp.code === "entrypointOrSymbolNotFound") {
         // redirect to all symbols page if there is no default entrypoint


### PR DESCRIPTION
Since #1473, docs are only served for the latest version of a package. The package overview route also requests docs, so visiting `/@scope/pkg@version` for any non-latest version got `docsOnlyForLatestVersion` from the API and 302'd to `/@scope/pkg/doc/all_symbols` — making version pages unreachable from the Versions tab.

Now only the actual doc routes (entrypoint/symbol/all_symbols) redirect to the latest version's docs; the package overview page fetches the version's metadata and renders the header and nav for that version, with a note that documentation is only available for the latest version.

This also fixes the `TypeError: b.subitems is not iterable` crash in the local symbol search island reported in the issue: since #1518, module docs can contain an `example` section, but the island cast every section to `namespace_section` and iterated `symbol.subitems`. Sections other than `namespace_section` are now skipped when building the search index and when filtering results.

Fixes #1537