### PR TITLE
ci: use a registry cache for the api docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,13 @@ jobs:
           file: api/Dockerfile
           push: true
           tags: ${{ env.API_IMAGE_ID_BASE }}:${{ github.sha }}
-          cache-from: type=gha,scope=docker-api
-          cache-to: type=gha,mode=max,scope=docker-api
+          # Use a registry cache (not type=gha): GHA caches are branch-scoped,
+          # and merge_group runs execute on transient refs, so a gha cache
+          # written there is never readable by later runs. A registry cache is
+          # shared across all refs. image-manifest/oci-mediatypes are required
+          # for Artifact Registry to accept the cache manifest.
+          cache-from: type=registry,ref=${{ env.API_IMAGE_ID_BASE }}:buildcache
+          cache-to: type=registry,ref=${{ env.API_IMAGE_ID_BASE }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Set api_image_id output
         id: api_image_id


### PR DESCRIPTION
The `docker-images` job takes ~12 minutes on every merge queue run because its Docker layer cache never hits: GHA caches are branch-scoped, and `merge_group` runs execute on transient `gh-readonly-queue/...` refs, so the cache written there is deleted along with the ref and is never readable by later runs. The only runs that could write a cache readable by everyone (pushes to `main`) skip the build entirely due to the image-reuse optimization — there are currently zero caches on `refs/heads/main`.

As a result every merge queue run pays ~7:20 compiling all dependencies from scratch, plus ~2:30 exporting a ~1.4GB GHA cache into a black hole. That garbage has also pushed the repo past the 10GB Actions cache quota (11GB currently), evicting the useful `rust-cache` entries for the `check`/`test` jobs.

This switches the build cache to a registry cache stored as a `:buildcache` tag next to the images in Artifact Registry, which is shared across all refs. `image-manifest=true,oci-mediatypes=true` is required for Artifact Registry to accept the cache manifest. No new permissions are needed — the job already pushes image tags to the same registry path.

Expected impact: after the first (still cold) run seeds the cache, `docker-images` should drop from ~12 min to ~3–4 min whenever `Cargo.lock`/`Cargo.toml` are unchanged, shortening the merge queue's critical path since `staging` waits on this job.