### PR TITLE
fix(ci): pass explicit value to deno bundle --sourcemap

### DIFF
--- a/lb/deno.json
+++ b/lb/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "dev": "wrangler dev",
-    "build": "mkdir -p dist && deno bundle --output=dist/main.js --sourcemap main.ts"
+    "build": "mkdir -p dist && deno bundle --output=dist/main.js --sourcemap=linked main.ts"
   },
   "lint": {
     "rules": {


### PR DESCRIPTION
The merge queue is currently failing on every PR (#1542, #1543) in the staging job: `terraform plan` errors because `lb/dist/main.js` does not exist.

Deno 2.9.6 (which CI picks up via `deno-version: 2.x`) changed the CLI parser so that bare `--sourcemap` now consumes the following positional argument as its value. In the lb build task, `--sourcemap main.ts` therefore swallows the entrypoint, and `deno bundle` silently reports "Bundled 0 modules" and exits 0 without writing any output. The failure only surfaces later at `terraform plan`.

This switches the build task to the explicit `--sourcemap=linked` form, which matches the previous implicit default and works on both 2.9.5 and 2.9.6 (verified locally with both binaries).

The parser regression itself (plus the missing value validation and `deno bundle` succeeding with zero entrypoints) will be reported/fixed upstream in Deno separately.