### PR TITLE
feat(tickets): let staff open a ticket addressed to a user

### DIFF
--- a/api/.sqlx/query-12a9310c1545b8bf4c9656df981403e6a69b8d4af7b8d08fd90227a3e438b35b.json
+++ b/api/.sqlx/query-12a9310c1545b8bf4c9656df981403e6a69b8d4af7b8d08fd90227a3e438b35b.json
@@ -20,7 +20,8 @@
                 "scope_quota_increase",
                 "scope_claim",
                 "package_report",
-                "other"
+                "other",
+                "staff_outreach"
               ]
             }
           }

--- a/api/.sqlx/query-2d7b84a6ce0ac4b0d1b9912463155a59524620f5504355232490a66d412d190e.json
+++ b/api/.sqlx/query-2d7b84a6ce0ac4b0d1b9912463155a59524620f5504355232490a66d412d190e.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tickets (kind, creator, subject, meta, status)\n          VALUES ('staff_outreach', $1, $2, $3, 'waiting_on_user')\n          RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2d7b84a6ce0ac4b0d1b9912463155a59524620f5504355232490a66d412d190e"
+}

--- a/api/.sqlx/query-c80f65a0a17b45a42580398f6f3b0cf6f2364a1e991c5e0a5b6d6bab4f90a52c.json
+++ b/api/.sqlx/query-c80f65a0a17b45a42580398f6f3b0cf6f2364a1e991c5e0a5b6d6bab4f90a52c.json
@@ -25,7 +25,8 @@
                 "scope_quota_increase",
                 "scope_claim",
                 "package_report",
-                "other"
+                "other",
+                "staff_outreach"
               ]
             }
           }

--- a/api/.sqlx/query-ce1ed670ec26b083bab86ff3f873a88e576df31929dc614347753c5f6d0d2d9c.json
+++ b/api/.sqlx/query-ce1ed670ec26b083bab86ff3f873a88e576df31929dc614347753c5f6d0d2d9c.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO ticket_messages (ticket_id, author, direction, message, email_message_id)\n          VALUES ($1, $2, 'outbound', $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ce1ed670ec26b083bab86ff3f873a88e576df31929dc614347753c5f6d0d2d9c"
+}

--- a/api/migrations/20260903000000_ticket_staff_outreach.sql
+++ b/api/migrations/20260903000000_ticket_staff_outreach.sql
@@ -1,0 +1,5 @@
+-- Staff can open a ticket on a user's behalf to start a conversation with them.
+-- The ticket is owned by the user it is addressed to, so it shows up alongside
+-- their own tickets and their replies count as inbound; the first message is
+-- outbound, written by the staff member who opened it.
+ALTER TYPE ticket_kind ADD VALUE 'staff_outreach';

--- a/api/src/api/admin.rs
+++ b/api/src/api/admin.rs
@@ -14,11 +14,17 @@ use tracing::Span;
 use tracing::field;
 use tracing::instrument;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::analysis::PackageAnalysisData;
 use crate::analysis::analyze_package;
 use crate::db::*;
+use crate::emails;
+use crate::emails::EmailArgs;
+use crate::emails::EmailQueue;
+use crate::emails::EmailSender;
+use crate::emails::EmailThread;
 use crate::iam::ReqIamExt;
 use crate::ids::PackagePath;
 use crate::ids::ScopeDescription;
@@ -41,6 +47,10 @@ pub fn admin_router() -> Router<Body, ApiError> {
   Router::builder()
     .get("/users", util::auth(util::json(list_users)))
     .patch("/users/:user_id", util::auth(util::json(update_user)))
+    .post(
+      "/users/:user_id/tickets",
+      util::auth(util::json(create_outreach_ticket)),
+    )
     .get("/scopes", util::auth(util::json(list_scopes)))
     .post("/scopes", util::auth(util::json(assign_scope)))
     .patch("/scopes/:scope", util::auth(util::json(patch_scopes)))
@@ -124,6 +134,108 @@ pub async fn update_user(mut req: Request<Body>) -> ApiResult<ApiFullUser> {
       msg: "missing 'is_staff', 'is_blocked' or 'scope_limit' parameter".into(),
     })
   }
+}
+
+/// Opens a ticket addressed to a user, so that staff can start a conversation
+/// rather than only answer one. The user is notified by email when they have
+/// one; either way the ticket shows up in their account and unread badge, and
+/// replying works exactly as on a ticket they opened themselves.
+#[instrument(name = "POST /api/admin/users/:user_id/tickets", skip(req))]
+pub async fn create_outreach_ticket(
+  mut req: Request<Body>,
+) -> ApiResult<ApiTicket> {
+  let user_id = req.param_uuid("user_id")?;
+  Span::current().record("user_id", field::display(&user_id));
+  let ApiAdminNewOutreachTicketRequest {
+    subject,
+    message,
+    meta,
+  } = decode_json(&mut req).await?;
+  let db = req.data::<Database>().unwrap();
+
+  let iam = req.iam();
+  let staff = iam.check_admin_access()?;
+
+  let subject = subject.trim();
+  if subject.is_empty() {
+    return Err(ApiError::MalformedRequest {
+      msg: "'subject' must not be empty".into(),
+    });
+  }
+  if message.trim().is_empty() {
+    return Err(ApiError::TicketMessageEmpty);
+  }
+  let meta = meta.unwrap_or_else(|| serde_json::json!({}));
+  if !meta.is_object() {
+    return Err(ApiError::TicketMetaNotValid);
+  }
+
+  let user = db.get_user(user_id).await?.ok_or(ApiError::UserNotFound)?;
+
+  let email_sender = req.data::<Option<EmailSender>>().unwrap();
+  let registry_url = req.data::<RegistryUrl>().unwrap();
+
+  // Generated before the insert so the stored row and the header on the email
+  // announcing it agree, which is what makes the user's reply threadable. Only
+  // recorded when an email actually goes out: a user with no address on file
+  // gets the ticket on the web alone.
+  let email_message_id = match (&email_sender, &user.email) {
+    (Some(_), Some(_)) => {
+      Some(super::tickets::new_email_message_id(registry_url))
+    }
+    _ => None,
+  };
+
+  let (ticket, user, message) = db
+    .create_staff_outreach_ticket(
+      &staff.id,
+      user_id,
+      subject,
+      meta,
+      &message,
+      email_message_id.as_deref(),
+    )
+    .await?;
+
+  if let Some(email) = &user.email
+    && let Some(email_sender) = email_sender
+    && let Some(email_message_id) = &email_message_id
+  {
+    let email_args = EmailArgs::SupportTicketOutreach {
+      name: Cow::Borrowed(&user.name),
+      ticket_id: Cow::Owned(ticket.id.to_string()),
+      ticket_number: Cow::Borrowed(&ticket.ticket_number),
+      subject: Cow::Borrowed(subject),
+      content: Cow::Borrowed(&message.0.message),
+      registry_url: Cow::Borrowed(registry_url.0.as_str()),
+      registry_name: Cow::Borrowed(&email_sender.from_name),
+      support_email: Cow::Borrowed(&email_sender.from),
+    };
+    // Logged rather than returned: the ticket is already open, and failing the
+    // request would have staff open a second one. The sweeper re-drives
+    // anything left unsent.
+    if let Err(err) = emails::enqueue(
+      db,
+      email_sender,
+      req.data::<EmailQueue>().unwrap(),
+      email.clone(),
+      email_args,
+      Some(EmailThread {
+        message_id: email_message_id,
+        in_reply_to: None,
+        references: vec![],
+      }),
+    )
+    .await
+    {
+      tracing::error!("failed to queue email: {:?}", err);
+    }
+  }
+
+  Ok(ApiTicket::for_viewer(
+    (ticket, Some(user), vec![message]),
+    true,
+  ))
 }
 
 #[instrument(name = "GET /api/admin/scopes", skip(req))]
@@ -535,6 +647,131 @@ mod tests {
   use crate::util::test::TestSetup;
   use hyper::StatusCode;
   use serde_json::json;
+
+  #[tokio::test]
+  async fn create_outreach_ticket() {
+    use crate::api::ApiTicket;
+    use crate::api::ApiTicketActor;
+    use crate::api::ApiTicketMessage;
+    use crate::db::TicketKind;
+    use crate::db::TicketMessageDirection;
+    use crate::db::TicketStatus;
+
+    let mut t = TestSetup::new().await;
+    let staff_token = t.staff_user.token.clone();
+    let user_token = t.user1.token.clone();
+    let user_id = t.user1.user.id;
+    let path = format!("/api/admin/users/{user_id}/tickets");
+
+    // Not for regular users.
+    t.http()
+      .post(&path)
+      .token(Some(&user_token))
+      .body_json(json!({ "subject": "Hi", "message": "hello" }))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::FORBIDDEN, "actorNotAuthorized")
+      .await;
+
+    // An empty message opens nothing.
+    t.http()
+      .post(&path)
+      .token(Some(&staff_token))
+      .body_json(json!({ "subject": "Hi", "message": "  " }))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::BAD_REQUEST, "ticketMessageEmpty")
+      .await;
+
+    // Nor does one addressed to nobody.
+    t.http()
+      .post(format!("/api/admin/users/{}/tickets", uuid::Uuid::new_v4()))
+      .token(Some(&staff_token))
+      .body_json(json!({ "subject": "Hi", "message": "hello" }))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::NOT_FOUND, "userNotFound")
+      .await;
+
+    let ticket = t
+      .http()
+      .post(&path)
+      .token(Some(&staff_token))
+      .body_json(json!({
+        "subject": "About your scope",
+        "message": "hello from staff",
+        "meta": { "scope": "scope" },
+      }))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<ApiTicket>()
+      .await;
+
+    assert_eq!(ticket.kind, TicketKind::StaffOutreach);
+    assert_eq!(ticket.subject.as_deref(), Some("About your scope"));
+    assert_eq!(ticket.status, TicketStatus::WaitingOnUser);
+    assert_eq!(ticket.meta, json!({ "scope": "scope" }));
+    let ApiTicketActor::User { user: reporter } = &ticket.reporter else {
+      panic!("expected a user reporter, got {:?}", ticket.reporter);
+    };
+    assert_eq!(reporter.id, user_id);
+    assert_eq!(ticket.messages.len(), 1);
+    assert_eq!(ticket.messages[0].message, "hello from staff");
+    assert_eq!(
+      ticket.messages[0].direction,
+      TicketMessageDirection::Outbound
+    );
+    let ApiTicketActor::User { user: author } = &ticket.messages[0].author
+    else {
+      panic!(
+        "expected a user author, got {:?}",
+        ticket.messages[0].author
+      );
+    };
+    assert_eq!(author.id, t.staff_user.user.id);
+
+    // The contacted user can see it and reply, and their reply is inbound
+    // like on any ticket they opened themselves.
+    let message = t
+      .http()
+      .post(format!("/api/tickets/{}", ticket.id))
+      .token(Some(&user_token))
+      .body_json(json!({ "message": "hello back" }))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<ApiTicketMessage>()
+      .await;
+    assert_eq!(message.direction, TicketMessageDirection::Inbound);
+
+    let tickets = t
+      .http()
+      .get("/api/user/tickets")
+      .token(Some(&user_token))
+      .call()
+      .await
+      .unwrap()
+      .expect_ok::<Vec<ApiTicket>>()
+      .await;
+    assert_eq!(tickets.len(), 1);
+    assert_eq!(tickets[0].id, ticket.id);
+    assert_eq!(tickets[0].status, TicketStatus::WaitingOnSupport);
+
+    // Somebody else cannot.
+    let other_token = t.user2.token.clone();
+    t.http()
+      .get(format!("/api/tickets/{}", ticket.id))
+      .token(Some(&other_token))
+      .call()
+      .await
+      .unwrap()
+      .expect_err_code(StatusCode::NOT_FOUND, "ticketNotFound")
+      .await;
+  }
 
   #[tokio::test]
   async fn list_users() {

--- a/api/src/api/tickets.rs
+++ b/api/src/api/tickets.rs
@@ -116,7 +116,7 @@ fn thread_for<'a>(
 /// Generates a `Message-ID` for an email JSR is about to send. Recorded against
 /// the message it announces, so a reply pointing back at it can be threaded onto
 /// the right ticket.
-fn new_email_message_id(registry_url: &RegistryUrl) -> String {
+pub(super) fn new_email_message_id(registry_url: &RegistryUrl) -> String {
   let domain = registry_url.0.host_str().unwrap_or("jsr.io");
   format!("<{}@{}>", Uuid::new_v4(), domain)
 }

--- a/api/src/api/types.rs
+++ b/api/src/api/types.rs
@@ -1294,6 +1294,18 @@ pub struct ApiAdminUpdateTicketRequest {
   pub status: Option<TicketStatus>,
 }
 
+/// Opens a `staff_outreach` ticket addressed to a user.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiAdminNewOutreachTicketRequest {
+  pub subject: String,
+  pub message: String,
+  /// Structured context for what the conversation is about, such as the scope
+  /// or package it concerns. Shown on the ticket page.
+  #[serde(default)]
+  pub meta: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiAuditLog {

--- a/api/src/db/database.rs
+++ b/api/src/db/database.rs
@@ -4491,6 +4491,80 @@ gitlab_id: r.user_gitlab_id,
     Ok((ticket, user, message))
   }
 
+  /// Opens a ticket addressed to `user_id` on behalf of staff.
+  ///
+  /// The ticket belongs to the user being contacted, so it lists with their own
+  /// tickets and their replies are inbound like on any other. The opening
+  /// message is outbound from `staff_id`, and the ticket starts out waiting on
+  /// the user rather than in the open queue, since nobody is owed a reply by
+  /// support yet.
+  ///
+  /// `email_message_id` is the `Message-ID` the notification email will be
+  /// sent under, or `None` when no email goes out.
+  #[instrument(
+    name = "Database::create_staff_outreach_ticket",
+    skip(self, message),
+    err
+  )]
+  pub async fn create_staff_outreach_ticket(
+    &self,
+    staff_id: &Uuid,
+    user_id: Uuid,
+    subject: &str,
+    meta: serde_json::Value,
+    message: &str,
+    email_message_id: Option<&str>,
+  ) -> Result<(Ticket, User, FullTicketMessage)> {
+    let mut tx = self.pool.begin().await?;
+
+    let ticket_id = sqlx::query_scalar!(
+      r#"INSERT INTO tickets (kind, creator, subject, meta, status)
+          VALUES ('staff_outreach', $1, $2, $3, 'waiting_on_user')
+          RETURNING id"#,
+      user_id as _,
+      subject,
+      meta as _,
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+
+    sqlx::query!(
+      r#"INSERT INTO ticket_messages (ticket_id, author, direction, message, email_message_id)
+          VALUES ($1, $2, 'outbound', $3, $4)"#,
+      ticket_id as _,
+      staff_id as _,
+      message,
+      email_message_id,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    audit_log(
+      &mut tx,
+      staff_id,
+      true,
+      "create_staff_outreach_ticket",
+      json!({
+        "ticket_id": ticket_id,
+        "user_id": user_id,
+      }),
+    )
+    .await?;
+
+    let (ticket, user, mut messages) =
+      Self::load_full_ticket(&mut tx, ticket_id)
+        .await?
+        .expect("ticket was just inserted in this transaction");
+
+    tx.commit().await?;
+
+    // The whole message, author included: unlike a ticket somebody opens
+    // themselves, the author here is not the ticket's owner.
+    let message = messages.remove(0);
+    let user = user.expect("ticket was just created with a creator");
+    Ok((ticket, user, message))
+  }
+
   #[instrument(name = "Database::list_tickets", skip(self), err)]
   pub async fn list_tickets(
     &self,

--- a/api/src/emails/mod.rs
+++ b/api/src/emails/mod.rs
@@ -23,6 +23,8 @@ const SUPPORT_TICKET_MESSAGE_TXT: &str = "support_ticket_message.txt";
 const SUPPORT_TICKET_MESSAGE_HTML: &str = "support_ticket_message.html";
 const SUPPORT_TICKET_AUTO_REPLY_TXT: &str = "support_ticket_auto_reply.txt";
 const SUPPORT_TICKET_AUTO_REPLY_HTML: &str = "support_ticket_auto_reply.html";
+const SUPPORT_TICKET_OUTREACH_TXT: &str = "support_ticket_outreach.txt";
+const SUPPORT_TICKET_OUTREACH_HTML: &str = "support_ticket_outreach.html";
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
@@ -73,6 +75,19 @@ pub enum EmailArgs<'a> {
     registry_name: Cow<'a, str>,
     support_email: Cow<'a, str>,
   },
+  /// Sent to a user when staff open a ticket addressed to them. Unlike the
+  /// other ticket emails it is not a reply to anything, so it introduces the
+  /// conversation rather than announcing a new message on it.
+  SupportTicketOutreach {
+    name: Cow<'a, str>,
+    ticket_id: Cow<'a, str>,
+    ticket_number: Cow<'a, str>,
+    subject: Cow<'a, str>,
+    content: Cow<'a, str>,
+    registry_url: Cow<'a, str>,
+    registry_name: Cow<'a, str>,
+    support_email: Cow<'a, str>,
+  },
 }
 
 impl EmailArgs<'_> {
@@ -109,6 +124,13 @@ impl EmailArgs<'_> {
           .trim();
         format!("[{ticket_number}] Re: {subject}")
       }
+      EmailArgs::SupportTicketOutreach {
+        ticket_number,
+        subject,
+        ..
+      } => {
+        format!("[{ticket_number}] {}", subject.trim())
+      }
     }
   }
 
@@ -119,6 +141,7 @@ impl EmailArgs<'_> {
       EmailArgs::SupportTicketCreated { .. } => SUPPORT_TICKET_CREATED_TXT,
       EmailArgs::SupportTicketMessage { .. } => SUPPORT_TICKET_MESSAGE_TXT,
       EmailArgs::SupportTicketAutoReply { .. } => SUPPORT_TICKET_AUTO_REPLY_TXT,
+      EmailArgs::SupportTicketOutreach { .. } => SUPPORT_TICKET_OUTREACH_TXT,
     }
   }
 
@@ -131,6 +154,7 @@ impl EmailArgs<'_> {
       EmailArgs::SupportTicketAutoReply { .. } => {
         SUPPORT_TICKET_AUTO_REPLY_HTML
       }
+      EmailArgs::SupportTicketOutreach { .. } => SUPPORT_TICKET_OUTREACH_HTML,
     }
   }
 }
@@ -186,6 +210,14 @@ fn init_handlebars()
   t.register_template_string(
     SUPPORT_TICKET_AUTO_REPLY_HTML,
     include_str!("./templates/support_ticket_auto_reply.html.hbs"),
+  )?;
+  t.register_template_string(
+    SUPPORT_TICKET_OUTREACH_TXT,
+    include_str!("./templates/support_ticket_outreach.txt.hbs"),
+  )?;
+  t.register_template_string(
+    SUPPORT_TICKET_OUTREACH_HTML,
+    include_str!("./templates/support_ticket_outreach.html.hbs"),
   )?;
 
   t.set_strict_mode(true);

--- a/api/src/emails/templates/support_ticket_outreach.html.hbs
+++ b/api/src/emails/templates/support_ticket_outreach.html.hbs
@@ -1,0 +1,26 @@
+{{#*inline "html_inner"}}
+<h1 style="margin-top: 0; text-align: left; font-size: 24px; font-weight: 700; color: #333333">
+	Hey {{ name }},
+</h1>
+<p style="margin-top: 15px; font-size: 16px; line-height: 24px; color: #52525b">
+	The {{ registry_name }} team has opened a support ticket to get in touch with you about &ldquo;{{ subject }}&rdquo;.
+</p>
+
+<pre style="margin-bottom: 15px; font-family: 'Nunito Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 16px; line-height: 24px; color: #52525b; margin-left: 16px; padding-left: 6px; padding-top: 6px; padding-bottom: 6px; border-left: 1px solid #333339">
+	{{ content }}
+</pre>
+
+<p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
+	To view the ticket, you can go to
+	<a href="{{ registry_url }}ticket/{{ ticket_id }}" style="color: #2563eb">{{ registry_url }}ticket/{{ ticket_id }}</a>. You can reply to the ticket from there.
+</p>
+
+<p style="margin-bottom: 15px; font-size: 16px; line-height: 24px; color: #52525b">
+	You can reply to the ticket via the link above, or simply reply to this email. Your replies are added to the ticket automatically.
+</p>
+<p style="margin-bottom: 5px; margin-top: 8px; font-size: 16px; line-height: 24px; color: #52525b">
+	Cheers,
+	<br>{{ registry_name }}
+</p>
+{{/inline}}
+{{> base.html}}

--- a/api/src/emails/templates/support_ticket_outreach.txt.hbs
+++ b/api/src/emails/templates/support_ticket_outreach.txt.hbs
@@ -1,0 +1,15 @@
+{{#*inline "text_inner"}}
+Hey {{ name }},
+
+The {{ registry_name }} team has opened a support ticket to get in touch with you about "{{ subject }}":
+
+---
+{{content}}
+---
+
+To view the ticket, you can go to {{ registry_url }}ticket/{{ ticket_id }}. You can reply to the ticket from there, or simply reply to this email. Your replies are added to the ticket automatically.
+
+Cheers,
+{{ registry_name }}
+{{/inline}}
+{{> base.txt }}

--- a/crates/jsr_types/src/models.rs
+++ b/crates/jsr_types/src/models.rs
@@ -1106,6 +1106,9 @@ pub enum TicketKind {
   ScopeClaim,
   PackageReport,
   Other,
+  /// Opened by staff, addressed to a user. The ticket's creator is the user
+  /// being contacted, and its first message is outbound.
+  StaffOutreach,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/frontend/components/TicketTitle.tsx
+++ b/frontend/components/TicketTitle.tsx
@@ -35,6 +35,10 @@ export function TicketTitle(props: TicketTitleProps): JSX.Element {
     case "scope_claim":
       title = `Request for reserved scope '@${props.meta.scope}'`;
       break;
+    case "staff_outreach":
+      // Always opened with a subject; this is only reached if it was blank.
+      title = "Message from JSR staff";
+      break;
     case "package_report":
       title = `Report package '${props.meta.scope}/${props.meta.name}${
         props.meta.version ? `@${props.meta.version}` : ""

--- a/frontend/routes/admin/(_islands)/EditModal.tsx
+++ b/frontend/routes/admin/(_islands)/EditModal.tsx
@@ -37,11 +37,19 @@ type Field = SelectField | BooleanField | NumberField | TextField;
 const BASE_INPUT_STYLING = "w-full block px-2 py-1.5 input-container input";
 
 export function EditModal(
-  { style, fields, title, path }: {
+  { style, fields, title, path, method = "patch", label = "edit", redirect }: {
     path: APIPath;
     style: "primary" | "danger";
     title: string;
     fields: Field[];
+    /// `patch` sends only the fields that changed from their initial value and
+    /// reloads the page; `post` sends every field and creates something new.
+    method?: "patch" | "post";
+    /// Text on the button that opens the modal.
+    label?: string;
+    /// Where to go once a `post` succeeds, with `{id}` replaced by the id of
+    /// the object the API returned. Reloads the page when unset.
+    redirect?: string;
   },
 ) {
   const open = useSignal(false);
@@ -85,7 +93,7 @@ export function EditModal(
         onClick={() => open.value = !open.value}
         aria-expanded={open.value ? "true" : "false"}
       >
-        edit
+        {label}
       </button>
       <div
         class={`fixed top-0 right-0 w-screen h-screen bg-gray-300/40 dark:bg-jsr-gray-950/70 z-80 flex justify-center items-center overflow-hidden ${
@@ -112,7 +120,7 @@ export function EditModal(
             for (const field of fields) {
               const val = state.value[field.name];
 
-              if (field.value !== undefined) {
+              if (method === "patch" && field.value !== undefined) {
                 if (field.value !== val) {
                   data[field.name] = val;
                 }
@@ -128,8 +136,20 @@ export function EditModal(
 
             status.value = "submitting";
 
-            api.patch(path, data).then((res) => {
-              if (res.ok) {
+            const request = method === "post"
+              ? api.post<{ id: string }>(path, data)
+              : api.patch<{ id: string }>(path, data);
+            request.then((res) => {
+              if (!res.ok) {
+                status.value = "pending";
+                return;
+              }
+              if (redirect !== undefined) {
+                globalThis.location.href = redirect.replace(
+                  "{id}",
+                  res.data.id,
+                );
+              } else {
                 globalThis.location.reload();
               }
             });

--- a/frontend/routes/admin/users.tsx
+++ b/frontend/routes/admin/users.tsx
@@ -67,31 +67,55 @@ export default define.page<typeof handler>(function Users({ data, url }) {
               {twas(new Date(user.createdAt).getTime())}
             </TableData>
             <TableData align="right">
-              <EditModal
-                style="primary"
-                path={path`/admin/users/${user.id}`}
-                title={`Edit user '${user.name}'`}
-                fields={[
-                  {
-                    name: "scopeLimit",
-                    label: "scope limit",
-                    type: "number",
-                    value: user.scopeLimit,
-                  },
-                  {
-                    name: "isStaff",
-                    label: "is staff",
-                    type: "boolean",
-                    value: user.isStaff,
-                  },
-                  {
-                    name: "isBlocked",
-                    label: "is blocked",
-                    type: "boolean",
-                    value: user.isBlocked,
-                  },
-                ]}
-              />
+              <div class="flex gap-2 justify-end">
+                <EditModal
+                  style="primary"
+                  path={path`/admin/users/${user.id}/tickets`}
+                  title={`Contact '${user.name}'`}
+                  label="contact"
+                  method="post"
+                  redirect="/ticket/{id}"
+                  fields={[
+                    {
+                      name: "subject",
+                      label: "subject",
+                      type: "input",
+                      required: true,
+                    },
+                    {
+                      name: "message",
+                      label: "message",
+                      type: "textarea",
+                      required: true,
+                    },
+                  ]}
+                />
+                <EditModal
+                  style="primary"
+                  path={path`/admin/users/${user.id}`}
+                  title={`Edit user '${user.name}'`}
+                  fields={[
+                    {
+                      name: "scopeLimit",
+                      label: "scope limit",
+                      type: "number",
+                      value: user.scopeLimit,
+                    },
+                    {
+                      name: "isStaff",
+                      label: "is staff",
+                      type: "boolean",
+                      value: user.isStaff,
+                    },
+                    {
+                      name: "isBlocked",
+                      label: "is blocked",
+                      type: "boolean",
+                      value: user.isBlocked,
+                    },
+                  ]}
+                />
+              </div>
             </TableData>
           </TableRow>
         ))}

--- a/frontend/routes/ticket.tsx
+++ b/frontend/routes/ticket.tsx
@@ -292,6 +292,8 @@ function formatMeta(kind: TicketKind, meta: Record<string, string>) {
       return null;
     case "other":
       return null;
+    case "staff_outreach":
+      return null;
   }
 }
 

--- a/frontend/utils/api_types.ts
+++ b/frontend/utils/api_types.ts
@@ -349,7 +349,9 @@ export type TicketKind =
   | "scope_quota_increase"
   | "scope_claim"
   | "package_report"
-  | "other";
+  | "other"
+  /// Opened by staff, addressed to the user who appears as its reporter.
+  | "staff_outreach";
 
 export interface NewTicket {
   kind: TicketKind;


### PR DESCRIPTION
Staff could only ever answer tickets; there was no way to start a conversation with a user. This reuses the ticket system for that rather than adding a separate messaging feature.

## What changes

- **`POST /api/admin/users/:user_id/tickets`** (staff only) opens a ticket of the new kind `staff_outreach`, owned by the target user, with the staff member's message as its first, outbound message. Takes `subject`, `message` and an optional `meta` object. Writes an audit log entry.
- The ticket starts out **`waiting_on_user`** so it stays out of the open queue until the user replies. From then on it behaves like any ticket the user opened themselves: it lists in their account, their replies are inbound and flip the status to waiting on support, the unread badge counts it, and staff notes and canned replies work on it.
- A new **`support_ticket_outreach` email** introduces the conversation ("The JSR team has opened a support ticket to get in touch with you about …") instead of announcing a reply. Subject is `[TICKET-…] <subject>`. It is sent under a fresh Message-ID so a reply from the user's inbox threads back onto the ticket via the existing inbound webhook. Users with no email on file get the web ticket alone.
- **Admin UI**: a "contact" button on each row of the admin users table opens a subject/message form and lands on the new ticket. `EditModal` gains optional `method`, `label` and `redirect` props to support a create form; existing uses are unchanged.
- Migration adds the `staff_outreach` enum value only, so it is safe to run ahead of the API deploy.

## Not included

Contacting by bare email address (the reporter-email/claim-token ticket shape) was considered and deliberately left out; this targets accounts only.

## Testing

New test `api::admin::tests::create_outreach_ticket` covers: non-staff rejected, empty message and unknown user refused, resulting ticket kind/status/subject/meta/reporter/author, the contacted user replying (inbound, status flips), the ticket appearing in their list, and another user getting a 404. Full API suite passes; sqlx offline cache regenerated with `--all-targets`.
